### PR TITLE
Make rendering of interval-nav code block configurable

### DIFF
--- a/src/calendar-journal/calendar-journal.ts
+++ b/src/calendar-journal/calendar-journal.ts
@@ -1,5 +1,5 @@
 import { App, FrontMatterCache, Plugin, TFile } from "obsidian";
-import { CalendarConfig, CalendarGranularity, CalerndatFrontMatter } from "../contracts/config.types";
+import { CalendarConfig, CalendarGranularity, CalendarFrontMatter } from "../contracts/config.types";
 import { CalendarJournalSection } from "./calendar-journal-section";
 import {
   FRONTMATTER_DATE_FORMAT,
@@ -145,10 +145,10 @@ export class CalendarJournal implements Journal {
     await this.year.autoCreateNote();
   }
 
-  async findNextNote(data: CalerndatFrontMatter): Promise<string | null> {
+  async findNextNote(data: CalendarFrontMatter): Promise<string | null> {
     return this.index.findNextNote(this.calendar.date(data.end_date).add(1, "day").startOf("day"), data.granularity);
   }
-  async findPreviousNote(data: CalerndatFrontMatter): Promise<string | null> {
+  async findPreviousNote(data: CalendarFrontMatter): Promise<string | null> {
     return this.index.findPreviousNote(
       this.calendar.date(data.start_date).subtract(1, "day").endOf("day"),
       data.granularity,
@@ -161,12 +161,12 @@ export class CalendarJournal implements Journal {
     await this[section].open();
   }
 
-  async openPath(path: string, frontmatter: CalerndatFrontMatter): Promise<void> {
+  async openPath(path: string, frontmatter: CalendarFrontMatter): Promise<void> {
     const section = frontmatter.granularity;
     await this[section].openPath(path);
   }
 
-  parseFrontMatter(frontmatter: FrontMatterCache): CalerndatFrontMatter {
+  parseFrontMatter(frontmatter: FrontMatterCache): CalendarFrontMatter {
     return {
       type: "calendar",
       id: this.id,
@@ -176,7 +176,7 @@ export class CalendarJournal implements Journal {
     };
   }
 
-  indexNote(frontmatter: CalerndatFrontMatter, path: string): void {
+  indexNote(frontmatter: CalendarFrontMatter, path: string): void {
     const startDate = this.calendar.date(frontmatter.start_date, FRONTMATTER_DATE_FORMAT);
     const endDate = this.calendar.date(frontmatter.end_date, FRONTMATTER_DATE_FORMAT);
     this.index.add(startDate, endDate, { path, granularity: frontmatter.granularity });

--- a/src/code-block-interval/code-block-interval.ts
+++ b/src/code-block-interval/code-block-interval.ts
@@ -86,25 +86,16 @@ export class CodeBlockIntervalNav extends MarkdownRenderChild {
       });
     }
     wrapper.dataset.date = interval.startDate.format("YYYY-MM-DD");
-    const name = replaceTemplateVariables(journal.navNameTemplate || journal.nameTemplate, context);
+    const name = replaceTemplateVariables(journal.navNameTemplate, context);
     wrapper.createDiv({
       cls: "interval-name",
       text: name,
     });
-    const dates = wrapper.createDiv({
+    const dates = replaceTemplateVariables(journal.navDatesTemplate, context).replaceAll("|", "\n");
+
+    wrapper.createDiv({
       cls: "interval-dates",
-    });
-    dates.createDiv({
-      cls: "interval-start",
-      text: interval.startDate.format(journal.dateFormat),
-    });
-    dates.createSpan({
-      cls: "interval-separator",
-      text: " to ",
-    });
-    dates.createDiv({
-      cls: "interval-end",
-      text: interval.endDate.format(journal.dateFormat),
+      text: dates,
     });
   }
 }

--- a/src/code-block-interval/code-block-interval.ts
+++ b/src/code-block-interval/code-block-interval.ts
@@ -86,7 +86,7 @@ export class CodeBlockIntervalNav extends MarkdownRenderChild {
       });
     }
     wrapper.dataset.date = interval.startDate.format("YYYY-MM-DD");
-    const name = replaceTemplateVariables(journal.nameTemplate, context);
+    const name = replaceTemplateVariables(journal.navNameTemplate || journal.nameTemplate, context);
     wrapper.createDiv({
       cls: "interval-name",
       text: name,

--- a/src/code-block-interval/code-block-interval.ts
+++ b/src/code-block-interval/code-block-interval.ts
@@ -92,7 +92,6 @@ export class CodeBlockIntervalNav extends MarkdownRenderChild {
       text: name,
     });
     const dates = replaceTemplateVariables(journal.navDatesTemplate, context).replaceAll("|", "\n");
-
     wrapper.createDiv({
       cls: "interval-dates",
       text: dates,

--- a/src/config/config-defaults.ts
+++ b/src/config/config-defaults.ts
@@ -2,6 +2,7 @@ import { CalendarConfig, CalendarGranularity, IntervalConfig, PluginSettings } f
 
 export const DEFAULT_NAME_TEMPLATE_CALENDAR = "{{date}}";
 export const DEFAULT_NAME_TEMPLATE_INTERVAL = "{{journal_name}} {{index}}";
+export const DEFAULT_NAV_DATES_TEMPLATE_INTERVAL = "{{start_date}}|to|{{end_date}}";
 
 export const DEFAULT_DATE_FORMAT = "YYYY-MM-DD";
 export const DEFAULT_DATE_FORMATS_CALENDAR: Record<CalendarGranularity, string> = {
@@ -116,6 +117,7 @@ export const DEFAULT_CONFIG_INTERVAL: IntervalConfig = {
   openMode: "active",
   nameTemplate: "",
   navNameTemplate: "",
+  navDatesTemplate: "",
   dateFormat: "",
   folder: "",
   template: "",

--- a/src/config/config-defaults.ts
+++ b/src/config/config-defaults.ts
@@ -115,6 +115,7 @@ export const DEFAULT_CONFIG_INTERVAL: IntervalConfig = {
   openOnStartup: false,
   openMode: "active",
   nameTemplate: "",
+  navNameTemplate: "",
   dateFormat: "",
   folder: "",
   template: "",

--- a/src/contracts/config.types.ts
+++ b/src/contracts/config.types.ts
@@ -69,7 +69,7 @@ export interface IntervalConfig extends JournalCaseConfig {
 
 export type JournalConfig = CalendarConfig | IntervalConfig;
 
-export interface CalerndatFrontMatter {
+export interface CalendarFrontMatter {
   type: "calendar";
   id: string;
   start_date: string;
@@ -83,4 +83,4 @@ export interface IntervalFrontMatter {
   end_date: string;
   index: number;
 }
-export type JournalFrontMatter = CalerndatFrontMatter | IntervalFrontMatter;
+export type JournalFrontMatter = CalendarFrontMatter | IntervalFrontMatter;

--- a/src/contracts/config.types.ts
+++ b/src/contracts/config.types.ts
@@ -56,6 +56,7 @@ export interface IntervalConfig extends JournalCaseConfig {
   openMode: OpenMode;
   nameTemplate: string;
   navNameTemplate: string;
+  navDatesTemplate: string;
   dateFormat: string;
   folder: string;
   template: string;

--- a/src/contracts/config.types.ts
+++ b/src/contracts/config.types.ts
@@ -55,6 +55,7 @@ export interface IntervalConfig extends JournalCaseConfig {
   openOnStartup: boolean;
   openMode: OpenMode;
   nameTemplate: string;
+  navNameTemplate: string;
   dateFormat: string;
   folder: string;
   template: string;

--- a/src/interval-journal/interval-journal.ts
+++ b/src/interval-journal/interval-journal.ts
@@ -197,12 +197,12 @@ export class IntervalJournal implements Journal {
       await this.processFrontMatter(file, interval);
     } else {
       if (!(file instanceof TFile)) throw new Error("File is not a TFile");
-      await this.enshureFrontMatter(file, interval);
+      await this.ensureFrontMatter(file, interval);
     }
     return file;
   }
 
-  private async enshureFrontMatter(file: TFile, interval: Interval): Promise<void> {
+  private async ensureFrontMatter(file: TFile, interval: Interval): Promise<void> {
     const metadata = this.app.metadataCache.getFileCache(file);
     if (
       !metadata?.frontmatter?.[FRONTMATTER_ID_KEY] ||

--- a/src/interval-journal/interval-journal.ts
+++ b/src/interval-journal/interval-journal.ts
@@ -17,6 +17,7 @@ import { Interval, IntervalManager } from "./interval-manager";
 import {
   DEFAULT_DATE_FORMAT,
   DEFAULT_NAME_TEMPLATE_INTERVAL,
+  DEFAULT_NAV_DATES_TEMPLATE_INTERVAL,
   DEFAULT_RIBBON_ICONS_INTERVAL,
 } from "../config/config-defaults";
 import { delay } from "../utils/misc";
@@ -51,6 +52,10 @@ export class IntervalJournal implements Journal {
 
   get navNameTemplate(): string {
     return this.config.navNameTemplate || this.nameTemplate;
+  }
+
+  get navDatesTemplate(): string {
+    return this.config.navDatesTemplate || DEFAULT_NAV_DATES_TEMPLATE_INTERVAL;
   }
 
   get dateFormat(): string {

--- a/src/interval-journal/interval-journal.ts
+++ b/src/interval-journal/interval-journal.ts
@@ -49,6 +49,10 @@ export class IntervalJournal implements Journal {
     return this.config.nameTemplate || DEFAULT_NAME_TEMPLATE_INTERVAL;
   }
 
+  get navNameTemplate(): string {
+    return this.config.navNameTemplate || this.nameTemplate;
+  }
+
   get dateFormat(): string {
     return this.config.dateFormat || DEFAULT_DATE_FORMAT;
   }

--- a/src/settings/settings-interval-page.ts
+++ b/src/settings/settings-interval-page.ts
@@ -212,6 +212,21 @@ export class SettingsIntervalPage extends SettingsWidget {
           this.save();
         });
       });
+
+    const navNameTemplate = new Setting(containerEl).setName("Navigation name template").addText((text) => {
+      text
+        .setPlaceholder(this.config.nameTemplate || DEFAULT_NAME_TEMPLATE_INTERVAL)
+        .setValue(this.config.navNameTemplate)
+        .onChange((value) => {
+          this.config.navNameTemplate = value;
+          this.save();
+        });
+    });
+    navNameTemplate.descEl.createEl("span", {
+      text: "Template used to render the name in navigation code blocks.",
+    });
+    navNameTemplate.descEl.createEl("br");
+    this.createVariableReferenceHint(navNameTemplate.descEl);
   }
 
   createVariableReferenceHint(el: HTMLElement): void {

--- a/src/settings/settings-interval-page.ts
+++ b/src/settings/settings-interval-page.ts
@@ -9,6 +9,7 @@ import { IntervalCodeBlocksModal } from "./ui/interval-code-blocks";
 import {
   DEFAULT_DATE_FORMAT,
   DEFAULT_NAME_TEMPLATE_INTERVAL,
+  DEFAULT_NAV_DATES_TEMPLATE_INTERVAL,
   DEFAULT_RIBBON_ICONS_INTERVAL,
 } from "../config/config-defaults";
 import { TemplateSuggestion } from "./ui/template-suggestion";
@@ -227,6 +228,21 @@ export class SettingsIntervalPage extends SettingsWidget {
     });
     navNameTemplate.descEl.createEl("br");
     this.createVariableReferenceHint(navNameTemplate.descEl);
+
+    const navDatesTemplate = new Setting(containerEl).setName("Navigation dates template").addText((text) => {
+      text
+        .setPlaceholder(this.config.navDatesTemplate || DEFAULT_NAV_DATES_TEMPLATE_INTERVAL)
+        .setValue(this.config.navDatesTemplate)
+        .onChange((value) => {
+          this.config.navDatesTemplate = value;
+          this.save();
+        });
+    });
+    navDatesTemplate.descEl.createEl("span", {
+      text: "Template used to render the dates in navigation code blocks.",
+    });
+    navDatesTemplate.descEl.createEl("br");
+    this.createVariableReferenceHint(navDatesTemplate.descEl);
   }
 
   createVariableReferenceHint(el: HTMLElement): void {

--- a/src/settings/settings-interval-page.ts
+++ b/src/settings/settings-interval-page.ts
@@ -243,6 +243,9 @@ export class SettingsIntervalPage extends SettingsWidget {
     });
     navDatesTemplate.descEl.createEl("br");
     this.createVariableReferenceHint(navDatesTemplate.descEl);
+    navDatesTemplate.descEl.createEl("span", {
+      text: " You can also use the pipe symbol for line breaks.",
+    });
   }
 
   createVariableReferenceHint(el: HTMLElement): void {

--- a/styles.css
+++ b/styles.css
@@ -161,9 +161,7 @@
 }
 .interval-dates {
   font-size: 0.9em;
-}
-.interval-separator {
-  font-size: 0.9em;
+  white-space: pre-line;
 }
 
 .journal-date-picker-modal {


### PR DESCRIPTION
This PR implements the feature suggested in issue #7.

It adds two new settings which are the templates to be used when rendering the name and the dates (interval) in the interval-nav code block. The default settings are chosen so that it looks exactly like before. The advantage is that this is now customizable.

Example settings for an alternative customization:

Note name template: `{{date}} {{journal_name}} {{index}}`
Navigation name template: `{{journal_name}} {{index}}`
Navigation dates template: `{{start_date:D.M}} – {{end_date:D.M}}`

This makes the navigation bar much more compact than it would look without this PR.

Note that in the navigation dates template, line breaks can be added using the pipe symbol.


