### PR TITLE
Add a `home` code block to display links to today and this week journal entries

### DIFF
--- a/src/code-block-home/code-block-home-processor.ts
+++ b/src/code-block-home/code-block-home-processor.ts
@@ -1,0 +1,41 @@
+import { MarkdownPostProcessorContext, MarkdownRenderChild } from "obsidian";
+import { JournalManager } from "../journal-manager";
+import { CalendarJournal } from "../calendar-journal/calendar-journal";
+import { CodeBlockHome } from "./code-block-home";
+import { JournalFrontMatter } from "../contracts/config.types";
+
+export class CodeBlockHomeProcessor extends MarkdownRenderChild {
+  private journalData: JournalFrontMatter | null = null;
+
+  constructor(
+    private manager: JournalManager,
+    private readonly source: string,
+    private readonly el: HTMLElement,
+    private readonly ctx: MarkdownPostProcessorContext,
+  ) {
+    super(el);
+    this.init();
+  }
+
+  async init() {
+    this.journalData = await this.manager.getJournalData(this.ctx.sourcePath);
+    this.display();
+  }
+
+  async display() {
+    this.containerEl.empty();
+    const container = this.containerEl.createDiv();
+
+    let defaultJournal: CalendarJournal | undefined;
+    if (this.journalData?.id) {
+      const journal = this.manager.get(this.journalData.id);
+      if (journal instanceof CalendarJournal) {
+        defaultJournal = journal;
+      }
+    }
+
+    const block = new CodeBlockHome(container, this.manager, defaultJournal);
+    this.ctx.addChild(block);
+    block.display();
+  }
+}

--- a/src/code-block-home/code-block-home-processor.ts
+++ b/src/code-block-home/code-block-home-processor.ts
@@ -34,7 +34,26 @@ export class CodeBlockHomeProcessor extends MarkdownRenderChild {
       }
     }
 
-    const block = new CodeBlockHome(container, this.manager, defaultJournal);
+    // Parse source for configuration
+    const config = {
+      today: true, // Default to only showing today
+      week: false,
+    };
+
+    if (this.source) {
+      const lines = this.source.split("\n");
+      lines.forEach((line) => {
+        const [key, value] = line.split(":").map((s) => s.trim());
+        if (key === "today" || key === "day") {
+          config.today = value === "true";
+        } else if (key === "week") {
+          config.week = value === "true";
+        }
+      });
+    }
+
+    new CodeBlockHome(container, this.manager, defaultJournal, config);
+    const block = new CodeBlockHome(container, this.manager, defaultJournal, config);
     this.ctx.addChild(block);
     block.display();
   }

--- a/src/code-block-home/code-block-home.ts
+++ b/src/code-block-home/code-block-home.ts
@@ -36,9 +36,10 @@ export class CodeBlockHome extends MarkdownRenderChild {
     const journals = this.manager.getByType("calendar").filter((j) => j.config.day.enabled);
     if (journals.length === 0) return;
 
-    const todayLink = parent.createSpan({
-      cls: "journal-home-link journal-clickable today-link",
+    const todayLink = parent.createEl("a", {
+      cls: "journal-home-link today-link",
       text: "Today",
+      href: "#",
     });
 
     todayLink.dataset.date = this.manager.calendar.today().format("YYYY-MM-DD");
@@ -60,9 +61,10 @@ export class CodeBlockHome extends MarkdownRenderChild {
     const journals = this.manager.getByType("calendar").filter((j) => j.config.week.enabled);
     if (journals.length === 0) return;
 
-    const weekLink = parent.createSpan({
-      cls: "journal-home-link journal-clickable week-link",
+    const weekLink = parent.createEl("a", {
+      cls: "journal-home-link week-link",
       text: "This week",
+      href: "#",
     });
 
     weekLink.dataset.date = this.manager.calendar.today().format("YYYY-MM-DD");

--- a/src/code-block-home/code-block-home.ts
+++ b/src/code-block-home/code-block-home.ts
@@ -38,7 +38,7 @@ export class CodeBlockHome extends MarkdownRenderChild {
 
     const todayLink = parent.createSpan({
       cls: "journal-home-link journal-clickable today-link",
-      text: "Today's Note",
+      text: "Today",
     });
 
     todayLink.dataset.date = this.manager.calendar.today().format("YYYY-MM-DD");
@@ -62,7 +62,7 @@ export class CodeBlockHome extends MarkdownRenderChild {
 
     const weekLink = parent.createSpan({
       cls: "journal-home-link journal-clickable week-link",
-      text: "This Week's Note",
+      text: "This week",
     });
 
     weekLink.dataset.date = this.manager.calendar.today().format("YYYY-MM-DD");

--- a/src/code-block-home/code-block-home.ts
+++ b/src/code-block-home/code-block-home.ts
@@ -8,6 +8,7 @@ export class CodeBlockHome extends MarkdownRenderChild {
     containerEl: HTMLElement,
     protected manager: JournalManager,
     protected defaultJournal?: CalendarJournal,
+    protected config: { today: boolean; week: boolean } = { today: true, week: false },
   ) {
     super(containerEl);
   }
@@ -20,8 +21,15 @@ export class CodeBlockHome extends MarkdownRenderChild {
       cls: "journal-home-view",
     });
 
-    this.createTodayLink(view);
-    this.createWeekLink(view);
+    if (this.config.today) {
+      this.createTodayLink(view);
+    }
+    if (this.config.week) {
+      if (this.config.today) {
+        view.createSpan({ text: " • " });
+      }
+      this.createWeekLink(view);
+    }
   }
 
   private createTodayLink(parent: HTMLElement) {
@@ -33,9 +41,6 @@ export class CodeBlockHome extends MarkdownRenderChild {
       text: "Today's Note",
     });
 
-    parent.createSpan({
-      text: " • ",
-    });
     todayLink.dataset.date = this.manager.calendar.today().format("YYYY-MM-DD");
 
     parent.on("click", ".today-link", (_e, _target) => {

--- a/src/code-block-home/code-block-home.ts
+++ b/src/code-block-home/code-block-home.ts
@@ -1,0 +1,72 @@
+import { MarkdownRenderChild } from "obsidian";
+import { CalendarJournal } from "../calendar-journal/calendar-journal";
+import { JournalManager } from "../journal-manager";
+import { JournalSuggestModal } from "../ui/journal-suggest-modal";
+
+export class CodeBlockHome extends MarkdownRenderChild {
+  constructor(
+    containerEl: HTMLElement,
+    protected manager: JournalManager,
+    protected defaultJournal?: CalendarJournal,
+  ) {
+    super(containerEl);
+  }
+
+  display() {
+    const { containerEl } = this;
+    containerEl.empty();
+
+    const view = containerEl.createDiv({
+      cls: "journal-home-view",
+    });
+
+    this.createTodayLink(view);
+    this.createWeekLink(view);
+  }
+
+  private createTodayLink(parent: HTMLElement) {
+    const journals = this.manager.getByType("calendar").filter((j) => j.config.day.enabled);
+    if (journals.length === 0) return;
+
+    const todayLink = parent.createDiv({
+      cls: "journal-home-link journal-clickable today-link",
+      text: "Today's Note",
+    });
+    todayLink.dataset.date = this.manager.calendar.today().format("YYYY-MM-DD");
+
+    parent.on("click", ".today-link", (_e, _target) => {
+      if (this.defaultJournal?.config.day.enabled) {
+        this.defaultJournal.day.open();
+      } else if (journals.length === 1) {
+        (journals[0] as CalendarJournal).day.open();
+      } else {
+        new JournalSuggestModal(this.manager.app, journals, (journal) => {
+          (journal as CalendarJournal).day.open();
+        }).open();
+      }
+    });
+  }
+
+  private createWeekLink(parent: HTMLElement) {
+    const journals = this.manager.getByType("calendar").filter((j) => j.config.week.enabled);
+    if (journals.length === 0) return;
+
+    const weekLink = parent.createDiv({
+      cls: "journal-home-link journal-clickable week-link",
+      text: "This Week's Note",
+    });
+    weekLink.dataset.date = this.manager.calendar.today().format("YYYY-MM-DD");
+
+    parent.on("click", ".week-link", (_e, _target) => {
+      if (this.defaultJournal?.config.week.enabled) {
+        this.defaultJournal.week.open();
+      } else if (journals.length === 1) {
+        (journals[0] as CalendarJournal).week.open();
+      } else {
+        new JournalSuggestModal(this.manager.app, journals, (journal) => {
+          (journal as CalendarJournal).week.open();
+        }).open();
+      }
+    });
+  }
+}

--- a/src/code-block-home/code-block-home.ts
+++ b/src/code-block-home/code-block-home.ts
@@ -28,9 +28,13 @@ export class CodeBlockHome extends MarkdownRenderChild {
     const journals = this.manager.getByType("calendar").filter((j) => j.config.day.enabled);
     if (journals.length === 0) return;
 
-    const todayLink = parent.createDiv({
+    const todayLink = parent.createSpan({
       cls: "journal-home-link journal-clickable today-link",
       text: "Today's Note",
+    });
+
+    parent.createSpan({
+      text: " • ",
     });
     todayLink.dataset.date = this.manager.calendar.today().format("YYYY-MM-DD");
 
@@ -51,10 +55,11 @@ export class CodeBlockHome extends MarkdownRenderChild {
     const journals = this.manager.getByType("calendar").filter((j) => j.config.week.enabled);
     if (journals.length === 0) return;
 
-    const weekLink = parent.createDiv({
+    const weekLink = parent.createSpan({
       cls: "journal-home-link journal-clickable week-link",
       text: "This Week's Note",
     });
+
     weekLink.dataset.date = this.manager.calendar.today().format("YYYY-MM-DD");
 
     parent.on("click", ".week-link", (_e, _target) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { JournalSettingTab } from "./settings/journal-settings";
 import { JournalManager } from "./journal-manager";
 import { CodeBlockTimelineProcessor } from "./code-block-timeline/code-block-timeline-processor";
 import { JournalConfigManager } from "./config/journal-config-manager";
+import { CodeBlockHomeProcessor } from "./code-block-home/code-block-home-processor";
 import { CodeBlockNavProcessor } from "./code-block-nav/code-block-nav-processor";
 import { CodeBlockIntervalProcessor } from "./code-block-interval/code-block-interval-processor";
 import { CALENDAR_VIEW_TYPE } from "./constants";
@@ -38,6 +39,10 @@ export default class JournalPlugin extends Plugin {
 
     this.registerMarkdownCodeBlockProcessor("interval-nav", (source, el, ctx) => {
       const processor = new CodeBlockIntervalProcessor(this.manager, source, el, ctx);
+      ctx.addChild(processor);
+    });
+    this.registerMarkdownCodeBlockProcessor("home", (source, el, ctx) => {
+      const processor = new CodeBlockHomeProcessor(this.manager, source, el, ctx);
       ctx.addChild(processor);
     });
     this.app.workspace.onLayoutReady(async () => {


### PR DESCRIPTION
Hey Sergii, love your plugin, been using it since a couple month to replace the Obsidian core one and Periodic plugin. 

I use a Home note in Obsidian which I use to navigate more than sidebars (I have them collapsed by defaault).
I also had a "Today" and "This week" links on my home note to quickly access the corresponding notes. 
Since I replaced the old plugins with yours, I had lost the ability to create a direct link to these journal entries, so I added a code block that adds back these features.

The `home` code block provides quick navigation links to today's note and/or the current week's note. It's a simple way to add navigation shortcuts to any note in your vault.

### Usage

Basic usage showing just today's link:
````markdown
```home
```
````

Show both today and week links:
````markdown
```home
today: true
week: true
```
````

### Features

- Displays clickable "Today" and "This week" links based on configuration
- Automatically handles multiple journals by showing a selection modal when needed
- Uses the current note's journal context if available'

This way, I was able to add back the links into my home note, of course anyone can add the links on any page (they don't have to be connected to a journal) for quick access.