### PR TITLE
fix(calendar): re-anchor weekly notes when a week grid arrives from sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Bug Fixes
+
+- A week configuration arriving from sync now re-anchors weekly notes on the receiving device, the same way changing it on that device does; previously the calendar moved but the notes did not, so their cells read as empty and the open-this-week command could start a second note for the week.
+
 ## [3.0.0] - 2026-08-14
 
 ### Features

--- a/e2e/integration/sync-week-grid.e2e.ts
+++ b/e2e/integration/sync-week-grid.e2e.ts
@@ -1,0 +1,63 @@
+import { $, browser, expect } from "@wdio/globals";
+
+import { NAV_FENCE, NAV_NOT_CONNECTED, NAV_VIEW, openInReadingMode } from "../journeys/code-blocks.js";
+import { readRawSettings, writeRawSettings } from "../support/plugin-data.js";
+import { triggerExternalSettingsChange } from "../support/plugin.js";
+import { seedNote, waitForFrontmatter, waitForJournalFrontmatter } from "../support/vault.js";
+
+// The week grid has two write paths into the same calendar slice. The preset picker routes through
+// WeekPresetService.apply(), which snapshots week identity, writes the slice and re-anchors as one
+// unit — week-preset.e2e.ts covers it. A data.json arriving from Obsidian Sync takes the other
+// path: onExternalSettingsChange -> SettingsService.reload() -> #refresh mutates the reactive root,
+// CalendarSettingsBridge installs the new grid, and nothing re-anchors. The note keeps a stored
+// date that is no longer its week's first day, parseEntry rejects it as non-canonical, and it
+// drops out of JournalsIndex — the nav fence renders the not-connected fallback over a file that
+// is sitting right there.
+//
+// Same fixture, same note and same target grid as the picker spec, so the correct outcome is not
+// in question: 2026-06-01 (ISO) must become 2026-05-31 (Western) either way.
+
+const WESTERN_CALENDAR = { mode: "custom", dow: 0, doy: 6, global: false };
+
+async function syncWesternWeekGrid(): Promise<void> {
+  const raw = (await readRawSettings()) ?? "{}";
+  const settings = JSON.parse(raw) as Record<string, unknown>;
+  settings.calendar = WESTERN_CALENDAR;
+  await writeRawSettings(JSON.stringify(settings));
+  await triggerExternalSettingsChange();
+}
+
+describe("week grid arriving from settings sync", () => {
+  beforeEach(async () => {
+    await browser.reloadObsidian({ vault: "./e2e/fixtures/e2e-week-preset", plugins: ["journals"] });
+  });
+
+  it("re-anchors a connected weekly note onto the synced grid", async () => {
+    // vault.create refuses to write into a folder that doesn't exist on disk yet, and this
+    // fixture carries no note folders; seedNote creates "week/" first.
+    await seedNote("week/2026-W23.md", "");
+    await waitForJournalFrontmatter("week/2026-W23.md", { journal: "weekly", date: "2026-06-01" });
+
+    await syncWesternWeekGrid();
+
+    await waitForFrontmatter(
+      "week/2026-W23.md",
+      (frontmatter) => frontmatter["journal-date"] === "2026-05-31",
+      "weekly note was not re-anchored onto the week grid that arrived from sync",
+    );
+  });
+
+  it("keeps the note registered in the journal index after the synced change", async () => {
+    await seedNote("week/2026-W23.md", NAV_FENCE);
+    await waitForJournalFrontmatter("week/2026-W23.md", { journal: "weekly", date: "2026-06-01" });
+
+    await syncWesternWeekGrid();
+
+    await waitForJournalFrontmatter("week/2026-W23.md", { journal: "weekly", date: "2026-05-31" });
+    await openInReadingMode("week/2026-W23.md");
+    await $(NAV_VIEW).waitForExist({
+      timeoutMsg: "note dropped out of the journal index after the grid arrived from sync",
+    });
+    await expect($(NAV_NOT_CONNECTED)).not.toExist();
+  });
+});

--- a/src/journals/settings/module.ts
+++ b/src/journals/settings/module.ts
@@ -22,7 +22,9 @@ export const journalsSettingsModule: Module = {
     c.register(DashboardBlockToken).useValue(
       defineDashboardBlock({ key: "colliding-journals", component: CollidingJournalsBlock, order: 2 }),
     );
-    c.register(WeekPresetService).useClass(WeekPresetService);
+    // Eager: it subscribes to the settings reload seam, which fires whether or not anyone has
+    // opened the preset picker that resolves it through WeekPresetApplierToken.
+    c.register(WeekPresetService).useClass(WeekPresetService).eager();
     c.register(WeekPresetApplierToken).useFactory(() => inject(WeekPresetService));
   },
 };

--- a/src/journals/settings/week-preset-service.test.ts
+++ b/src/journals/settings/week-preset-service.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
 
 import { Calendar, WeekPeriod, calendarSlice } from "@/calendar";
 import { CalendarSettingsBridge } from "@/calendar/settings/bridge";
@@ -36,11 +37,11 @@ function weekly(patch: { addStartDate?: boolean; addEndDate?: boolean } = {}): R
   return { weekly: { ...config, frontmatter: { ...config.frontmatter, ...patch } } };
 }
 
-async function build(journals: Record<string, JournalConfig>) {
+async function build(journals: Record<string, JournalConfig>, initial: typeof ISO | typeof WESTERN = ISO) {
   const notes = new FakeNotesService();
   const settings = createSettingsService({
     slices: [calendarSlice],
-    raw: { version: 4, calendar: ISO },
+    raw: { version: 4, calendar: initial },
   });
   const c = settings.container;
   c.register(Calendar).useValue(testCalendar());
@@ -66,7 +67,20 @@ async function build(journals: Record<string, JournalConfig>) {
   // Resolving the bridge starts the watchEffect that applies the grid, exactly as autoLoad does.
   c.resolve(CalendarSettingsBridge);
 
-  return { container: c, notes, index: c.resolve(JournalsIndex), service: c.resolve(WeekPresetService) };
+  // Resolving the service starts its subscription to the settings reload seam, exactly as the
+  // eager registration does in the real container.
+  const service = c.resolve(WeekPresetService);
+
+  // Stands in for Obsidian Sync replacing data.json and the plugin's onExternalSettingsChange:
+  // the new raw lands on "disk", then reload() refreshes every slice from it. The re-anchor it
+  // triggers is fire-and-forget, so callers wait on the note itself.
+  async function syncCalendar(next: typeof ISO | typeof WESTERN): Promise<void> {
+    await settings.data.save({ version: 4, calendar: next });
+    await settings.service.reload();
+    await nextTick();
+  }
+
+  return { container: c, notes, index: c.resolve(JournalsIndex), service, syncCalendar };
 }
 
 function seedWeek(notes: FakeNotesService, index: JournalsIndex, path: string, date: string): void {
@@ -220,6 +234,61 @@ describe("WeekPresetService", () => {
     await service.apply(WESTERN);
 
     expect(notes.frontmatterOf("month/2026-06.md" as VaultPath)?.["journal-date"]).toBe("2026-06-01");
+  });
+
+  // A week grid can also arrive from Obsidian Sync, which never passes through apply(): reload()
+  // refreshes the calendar slice along with every other one. Without a re-anchor there, the note
+  // keeps a stored date that is no longer its week's first day, so the calendar reads "no note"
+  // over a file that is sitting right there.
+  describe("week grid arriving from an external settings reload", () => {
+    it("re-anchors a weekly note onto the synced grid", async () => {
+      const { notes, index, syncCalendar } = await build(weekly());
+      seedWeek(notes, index, "week/2026-W23.md", "2026-06-01");
+
+      await syncCalendar(WESTERN);
+
+      await vi.waitFor(() =>
+        expect(notes.frontmatterOf("week/2026-W23.md" as VaultPath)?.["journal-date"]).toBe("2026-05-31"),
+      );
+    });
+
+    // The re-anchor has to preserve which WEEK the note was, not which week now contains its old
+    // anchor. Going Western -> ISO the two answers differ by a full week for every anchor: the
+    // Western anchor is a Sunday, which ISO counts as the LAST day of the preceding week. Resolving
+    // by containment (anchorOf, as the v1 migration's canonicalization does) would silently shift a
+    // user's whole weekly archive back one week.
+    it("keeps the note's week identity rather than re-reading its old anchor under the new grid", async () => {
+      const { notes, index, syncCalendar } = await build(weekly(), WESTERN);
+      seedWeek(notes, index, "week/2025-W45.md", "2025-11-02");
+
+      await syncCalendar(ISO);
+
+      // 2025-10-27 is the containment answer — the ISO week holding the old Sunday anchor.
+      await vi.waitFor(() =>
+        expect(notes.frontmatterOf("week/2025-W45.md" as VaultPath)?.["journal-date"]).toBe("2025-11-03"),
+      );
+    });
+
+    it("recomputes the end date against the synced grid", async () => {
+      const { notes, index, syncCalendar } = await build(weekly({ addEndDate: true }));
+      seedWeek(notes, index, "week/2026-W23.md", "2026-06-01");
+
+      await syncCalendar(WESTERN);
+
+      await vi.waitFor(() =>
+        expect(notes.frontmatterOf("week/2026-W23.md" as VaultPath)?.["journal-end-date"]).toBe("2026-06-06"),
+      );
+    });
+
+    it("writes nothing when the reload does not move the grid", async () => {
+      const { notes, index, syncCalendar } = await build(weekly());
+      seedWeek(notes, index, "week/2026-W23.md", "2026-06-01");
+      const update = vi.spyOn(notes, "updateFrontmatter");
+
+      await syncCalendar(ISO);
+
+      expect(update).not.toHaveBeenCalled();
+    });
   });
 
   it("leaves a custom weekly interval's notes alone", async () => {

--- a/src/journals/settings/week-preset-service.ts
+++ b/src/journals/settings/week-preset-service.ts
@@ -7,7 +7,7 @@ import { inject } from "@/infrastructure/di";
 import { NoticeService } from "@/infrastructure/host";
 import type { VaultPath } from "@/infrastructure/host";
 import { attempt, type AsyncResult } from "@/infrastructure/result";
-import { SettingsService } from "@/settings";
+import { SettingsEventsToken, SettingsService } from "@/settings";
 
 import { CycleService } from "../cycle";
 import { JournalsIndex } from "../journals-index";
@@ -35,6 +35,31 @@ export class WeekPresetService implements WeekPresetApplier {
   readonly #cycle = inject(CycleService);
   readonly #connection = inject(NoteConnectionService);
   readonly #notices = inject(NoticeService);
+  readonly #settingsEvents = inject(SettingsEventsToken);
+  readonly #unsubscribes: (() => void)[] = [];
+  #pending: readonly WeekSnapshot[] | undefined;
+
+  // apply() is the picker's path and holds "move the grid" and "re-anchor the notes" together as
+  // one transaction. A data.json from Obsidian Sync reaches the same slice without passing through
+  // it — SettingsService.reload() refreshes every slice at once — so the invariant is re-established
+  // here, at the settings layer's own seam, rather than only at the UI entry point.
+  constructor() {
+    this.#unsubscribes.push(
+      // The snapshot has to be taken under the OLD grid: week identity is what survives the
+      // change, and once the incoming slice lands nothing can recover which week an anchor meant.
+      this.#settingsEvents.on("reloading", () => {
+        const snapshots = this.#snapshot();
+        this.#pending = snapshots.some(({ notes }) => notes.length > 0) ? snapshots : undefined;
+      }),
+      this.#settingsEvents.on("reloaded", () => {
+        const snapshots = this.#pending;
+        this.#pending = undefined;
+        // A reload that left the grid alone re-anchors every note onto the anchor it already
+        // has, which reanchorAll skips without writing — so no comparison is needed here.
+        if (snapshots) void this.#reanchor(snapshots);
+      }),
+    );
+  }
 
   // A stored end equal to the OLD grid's duration-derived default is period metadata the grid
   // change invalidates, not a manual extension — NoteConnectionService can't tell the two apart
@@ -94,5 +119,10 @@ export class WeekPresetService implements WeekPresetApplier {
     const snapshots = this.#snapshot();
     this.#settings.getSlice(calendarSlice).state = next;
     return this.#reanchor(snapshots);
+  }
+
+  [Symbol.dispose](): void {
+    for (const off of this.#unsubscribes) off();
+    this.#unsubscribes.length = 0;
   }
 }

--- a/src/settings/settings-service.ts
+++ b/src/settings/settings-service.ts
@@ -134,6 +134,7 @@ export class SettingsService {
         window.clearTimeout(this.#saveTimer);
         this.#saveTimer = undefined;
       }
+      this.#events.emit("reloading");
       this.#refresh(migrated);
       this.#stopWatch = watch(this.#root, () => this.#scheduleSave(), { deep: true });
       // Reactive consumers pick up #root mutations on their own, but event-driven

--- a/src/settings/tokens.ts
+++ b/src/settings/tokens.ts
@@ -5,6 +5,10 @@ import type { DashboardBlock, AnySubpage } from "./ui/schema";
 import type { Emitter } from "nanoevents";
 
 export interface SettingsEvents {
+  // Fired while the previous state is still live, so a listener whose data is only
+  // interpretable under it (the week grid, and every anchor written against it) can read
+  // what it needs before the incoming data.json overwrites the slices.
+  reloading: () => void;
   reloaded: () => void;
 }
 


### PR DESCRIPTION
Fixes #223.

The week grid has two write paths into the calendar slice. The preset picker routes through `WeekPresetService.apply()`, which snapshots week identity, writes the slice and re-anchors as one transaction. A `data.json` from Obsidian Sync reaches the same slice without passing through it — `SettingsService.reload()` refreshes every slice at once, `CalendarSettingsBridge` installs the new grid, and nothing re-anchors. The notes keep a stored date that is no longer their week's first day, so their calendar cells read as empty and `ensureNote` can start a second note for the week.

## The fix

`SettingsService.reload()` now emits a `reloading` event before `#refresh`, while the previous state is still live. `WeekPresetService` snapshots there — week identity is only interpretable under the old grid — and re-anchors off `reloaded`, reusing the same `#reanchor` the picker path uses. The invariant is now enforced at the settings seam rather than only at the UI entry point. Its registration became `.eager()` so the subscription exists whether or not anyone has opened the preset picker.

## Identity, not containment

The re-anchor preserves which week a note *was*, matching `apply()`. The issue suggested reusing `DataMigrationService.#canonicalizeWeekAnchor`, which resolves by containment (`anchorOf`). Those disagree on **57 of 57** anchors in the window I scanned when going Western → ISO, by a full week:

| stored (Western) | identity | containment |
| --- | --- | --- |
| `2025-11-02` W45 | `2025-11-03` W45 | `2025-10-27` **W44** |
| `2025-11-09` W46 | `2025-11-10` W46 | `2025-11-03` **W45** |

Containment is right where it lives today — a v1 `journal-start-date` is a date *within* the period — and wrong here, where the stored value already is an anchor. A unit test pins the two apart with the containment answer named in a comment, since it is the obvious thing to reach for.

Fuller correction of the issue's analysis, including two other details it got wrong, is in https://github.com/srg-kostyrko/obsidian-journal/issues/223#issuecomment-5292355985.

## Scope

Live-sync path only. The boot form — `data.json` already carrying the new grid at startup, from settings synced with the notes folder excluded, or a restored/hand-edited file — is **not** fixed here: no old grid ever exists in that process, so there is nothing to snapshot and week identity is not recoverable from the anchor alone. Worth its own issue.

## Verification

| | |
| --- | --- |
| New e2e `e2e/integration/sync-week-grid.e2e.ts` | red before the fix, 2 passing after |
| Full e2e suite | 46/46 spec files |
| `npm test` | 3525 passing (4 new) |
| `npm run check:types` | clean |
| `npm run check:lint` | clean (one pre-existing unrelated warning) |
| `npm run check:i18n` | no violations, 11 locales |
