### PR TITLE
fix(host): open a note in the window the user is in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Bug Fixes
+
+- Opening a journal note now opens it in the window you are working in; previously, if the note was already open in another window, Obsidian jumped you over to that window.
+- Middle-clicking or Ctrl/Cmd-clicking to open a journal note in a new tab, split, or window now does so even when the note is already open somewhere; previously the request was ignored and the existing pane was focused instead.
+
 ## [3.0.0] - 2026-08-14
 
 ### Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,15 @@ on it.
 - `focusLeaf` calls `app.setting.close()`, and `setViewState({ active: true })`
   reaches it. `revealLeaf()` alone does not, so a leaf placed as a side effect
   of a settings interaction is placed then revealed, never activated.
+- `getLeavesOfType` is `iterateAllLeaves` underneath, so it spans **popout windows**
+  and sidebars. Any "is this note already open" reuse that then focuses the match
+  must be pinned to one window, or opening a note drags the user into whichever
+  window happens to hold it. The focused window is
+  `workspace.containerEl.win.activeWindow` — same value as the `activeWindow`
+  global but reachable through the injected `App`, where the global is not
+  fakeable and `workspace.activeLeaf` is deprecated. e2e can drive it:
+  `containerEl.win.focus()` moves `activeWindow` inside the WDIO harness, which
+  a leaf merely becoming active does not.
 - `app.metadataTypeManager` is undocumented and its shape changed at Obsidian
   1.9: property entries lost their `type` field in favor of `widget`, and
   `getPropertyInfo` now returns a fallback object instead of null, so it can no

--- a/docs/manual-testing-checklist.md
+++ b/docs/manual-testing-checklist.md
@@ -960,6 +960,21 @@ The same modifier map applies to every affordance below: **Ctrl/Cmd → new tab*
 - [x] **Period badge** (period-buttons item) → same modifier behavior.
 - [x] **Existing-notes navigation arrow** → same modifier behavior.
 
+### Entry already open
+
+`uri-open` covers this seam through the URI handler; walk it here for the
+affordances the harness cannot drive.
+
+Setup: pop a journal entry out into its own window (drag its tab out, or open it
+with **Open mode: new window**), then click back into the main window.
+
+- [ ] **Open that same entry** from a command, a calendar cell, or a `journal-nav`
+      row → it opens in the window you are in. Focus must not jump to the popout.
+- [ ] Repeat with the popout focused → the entry opens there, and no second pane
+      appears in the main window.
+- [ ] **Ctrl/Cmd+click** a cell whose note is already open in the current window →
+      a second pane appears; the existing pane is not merely focused.
+
 ### Context menus
 
 - [x] **Right-click a calendar cell with a note** → native file menu appears.

--- a/e2e/journeys/uri-open.e2e.ts
+++ b/e2e/journeys/uri-open.e2e.ts
@@ -5,7 +5,9 @@ import { openViaUri } from "../support/uri.js";
 import {
   closeAllLeaves,
   closePopoutWindows,
+  focusMainWindow,
   frontmatterOf,
+  mainWindowHoldsNote,
   markdownLeafCount,
   openNote,
   popoutWindowCount,
@@ -101,6 +103,40 @@ describe("open via uri", () => {
 
       // The popout would otherwise stay the active window and steal the next test's modals.
       await closePopoutWindows();
+    });
+  });
+
+  // Opening a note that is already open reuses its leaf. Obsidian's leaf lookup spans popout
+  // windows, so an unscoped reuse pulls the user into whichever window happens to hold the note,
+  // and it also swallows an explicit tab/split/window request. Neither is reachable in the unit
+  // suite: both need a real second window and a real workspace to open into.
+  describe("entry already open", () => {
+    it("opens the entry here when it is only open in a popout window", async () => {
+      await closeAllLeaves();
+      await openNote("baseline.md");
+      await openViaUri({ journal: "work", date: "2027-06-04", mode: "window" });
+      await waitForActiveNote("work/2027-06-04.md");
+      await focusMainWindow();
+
+      await openViaUri({ journal: "work", date: "2027-06-04" });
+      await waitForActiveNote("work/2027-06-04.md");
+
+      expect(await mainWindowHoldsNote("work/2027-06-04.md")).toBe(true);
+
+      await closePopoutWindows();
+    });
+
+    it("opens a second pane for an explicit tab mode when the entry is already open", async () => {
+      await closeAllLeaves();
+      await openViaUri({ journal: "work", date: "2027-06-05" });
+      await waitForActiveNote("work/2027-06-05.md");
+      const before = await markdownLeafCount();
+
+      await openViaUri({ journal: "work", date: "2027-06-05", mode: "tab" });
+
+      await browser.waitUntil(async () => (await markdownLeafCount()) === before + 1, {
+        timeoutMsg: "tab mode reused the leaf already holding the entry instead of adding one",
+      });
     });
   });
 

--- a/e2e/support/vault.ts
+++ b/e2e/support/vault.ts
@@ -110,6 +110,39 @@ export function popoutWindowCount(): Promise<number> {
   });
 }
 
+// Whether a markdown leaf in the main window holds this note. Opening a note that is already open
+// reuses whichever leaf has it, so the active *file* is the target either way — a leaf in the main
+// window holding it is what separates "opened in my window" from "focus jumped to the popout".
+export function mainWindowHoldsNote(path: string): Promise<boolean> {
+  return browser.executeObsidian(
+    ({ app }, notePath) =>
+      app.workspace.getLeavesOfType("markdown").some((leaf) => {
+        const view = leaf.view as { file?: { path: string } | null };
+        return leaf.getRoot() === app.workspace.rootSplit && view.file?.path === notePath;
+      }),
+    path,
+  );
+}
+
+// Puts the user back in the main window after a popout opened — the state a report of "it takes me
+// to a different window" starts from, since opening in a popout leaves that popout focused. Focus
+// has to reach the window itself: the plugin reads Obsidian's `activeWindow`, which only moves on a
+// real window focus, not on a leaf becoming active.
+export async function focusMainWindow(): Promise<void> {
+  await browser.executeObsidian(({ app }) => {
+    app.workspace.containerEl.win.focus();
+    const inMain = app.workspace.getLeavesOfType("markdown").find((leaf) => leaf.getRoot() === app.workspace.rootSplit);
+    if (inMain) app.workspace.setActiveLeaf(inMain, { focus: true });
+  });
+  await browser.waitUntil(
+    async () =>
+      browser.executeObsidian(
+        ({ app }) => app.workspace.containerEl.win.activeWindow === app.workspace.containerEl.win,
+      ),
+    { timeoutMsg: "main window never regained focus after the popout opened" },
+  );
+}
+
 // Detaches every leaf rooted outside the main window, which closes its popout. A test that opens a
 // popout must call this before finishing: an open popout stays the active window, so the next
 // test's modals render in the popout's document where the main-window selectors can't reach them.

--- a/src/infrastructure/host/internal/testing.ts
+++ b/src/infrastructure/host/internal/testing.ts
@@ -47,6 +47,12 @@ class FakeDispatcher {
 export interface FakeWorkspaceState {
   activeFile: TFile | null;
   openPaths: Set<string>;
+  // Which window each open path's leaf sits in, and which window the user is currently in.
+  // Popout windows are what make workspace-wide leaf reuse steal focus, so leaf lookups that
+  // must stay window-local can only be exercised with both modelled.
+  openWindows: Map<string, string>;
+  activeWindow: string;
+  focusedPaths: string[];
   openCalls: { path: string; mode: PaneType | false }[];
   triggerCalls: { event: string; arguments_: unknown[] }[];
   detachedTypes: string[];
@@ -69,6 +75,12 @@ interface FakeLeaf {
   openFile(file: TFile): Promise<void>;
   setViewState(state: { type: string; active?: boolean }): Promise<void>;
   updateHeader(): void;
+}
+
+interface FakeMarkdownLeaf {
+  view: { file: TFile | null };
+  openFile(): Promise<undefined>;
+  getContainer(): { win: Window };
 }
 
 export interface FakeFileSystemEntry {
@@ -118,6 +130,8 @@ export interface FakeHost {
   ): { el: HTMLElement; ctx: MarkdownPostProcessorContext; child?: MarkdownRenderChild };
 }
 
+const MAIN_WINDOW = "main";
+
 function makeFile(path: string): TFile {
   const file = new TFile();
   file.path = path;
@@ -152,6 +166,9 @@ export function createFakeHost(): FakeHost {
   const workspaceState: FakeWorkspaceState = {
     activeFile: null,
     openPaths: new Set(),
+    openWindows: new Map(),
+    activeWindow: MAIN_WINDOW,
+    focusedPaths: [],
     openCalls: [],
     triggerCalls: [],
     detachedTypes: [],
@@ -172,6 +189,7 @@ export function createFakeHost(): FakeHost {
   const codeBlockProcessors = new Map<string, CodeBlockProcessor>();
   const registeredViews = new Map<string, FakeRegisteredView>();
   const viewLeavesByType = new Map<string, FakeLeaf[]>();
+  const windowObjects = new Map<string, Window>();
   const unloadCallbacks: (() => void)[] = [];
   const layoutReadyCallbacks: (() => void)[] = [];
 
@@ -334,11 +352,27 @@ export function createFakeHost(): FakeHost {
     },
   };
 
+  // Every window answers `activeWindow` the way Obsidian's does — with whichever window currently
+  // holds focus — so a service can reach the focused window from any window it already holds.
+  function windowFor(id: string): Window {
+    const existing = windowObjects.get(id);
+    if (existing) return existing;
+    const created = {
+      id,
+      get activeWindow(): Window {
+        return windowFor(workspaceState.activeWindow);
+      },
+    } as unknown as Window;
+    windowObjects.set(id, created);
+    return created;
+  }
+
   function makeLeaf(placement: "left" | "right" | "tab", openMode: PaneType | false = false) {
     let assignedType: string | null = null;
     const leaf = {
       async openFile(file: TFile): Promise<void> {
         workspaceState.openPaths.add(file.path);
+        workspaceState.openWindows.set(file.path, workspaceState.activeWindow);
         workspaceState.openCalls.push({ path: file.path, mode: openMode });
         workspaceState.activeFile = file;
       },
@@ -365,7 +399,7 @@ export function createFakeHost(): FakeHost {
     getActiveFile(): TFile | null {
       return workspaceState.activeFile;
     },
-    getLeavesOfType(type: string): FakeLeaf[] | { view: { file: TFile | null }; openFile: () => Promise<undefined> }[] {
+    getLeavesOfType(type: string): FakeLeaf[] | FakeMarkdownLeaf[] {
       // The tracked branch is keyed by registered journal view types (`journal-view:*`),
       // so it never collides with the note-path fallback used for `"markdown"` lookups.
       const tracked = viewLeavesByType.get(type);
@@ -373,10 +407,13 @@ export function createFakeHost(): FakeHost {
       return [...workspaceState.openPaths].map((path) => ({
         view: { file: fileObjects.get(path) ?? null },
         openFile: async () => undefined,
+        getContainer: () => ({ win: windowFor(workspaceState.openWindows.get(path) ?? MAIN_WINDOW) }),
       }));
     },
-    setActiveLeaf(): void {
-      /* no-op */
+    containerEl: { win: windowFor(MAIN_WINDOW) },
+    setActiveLeaf(leaf: FakeMarkdownLeaf): void {
+      const file = leaf.view.file;
+      if (file) workspaceState.focusedPaths.push(file.path);
     },
     getLeaf(mode: PaneType | false) {
       return makeLeaf("tab", mode);

--- a/src/infrastructure/host/internal/workspace-service.test.ts
+++ b/src/infrastructure/host/internal/workspace-service.test.ts
@@ -75,6 +75,40 @@ describe("WorkspaceService", () => {
       expect(host.workspace.openCalls.at(-1)?.mode).toBe("tab");
     });
 
+    it("focuses the existing leaf when the note is already open in this window", async () => {
+      const { service, host } = build();
+      host.putFile(path);
+      await service.openNote(path);
+
+      await service.openNote(path);
+
+      expect(host.workspace.focusedPaths).toEqual([path]);
+      expect(host.workspace.openCalls).toHaveLength(1);
+    });
+
+    it("opens a new leaf when the note is only open in another window", async () => {
+      const { service, host } = build();
+      host.putFile(path);
+      await service.openNote(path);
+      host.workspace.activeWindow = "popout";
+
+      await service.openNote(path);
+
+      expect(host.workspace.focusedPaths).toEqual([]);
+      expect(host.workspace.openCalls).toHaveLength(2);
+    });
+
+    it("opens a new pane for an explicit mode even when the note is already open here", async () => {
+      const { service, host } = build();
+      host.putFile(path);
+      await service.openNote(path);
+
+      await service.openNote(path, "tab");
+
+      expect(host.workspace.focusedPaths).toEqual([]);
+      expect(host.workspace.openCalls.at(-1)).toEqual({ path, mode: "tab" });
+    });
+
     it("returns WorkspaceOpenError when the path is unknown", async () => {
       const { service } = build();
       const result = await service.openNote(path);

--- a/src/infrastructure/host/internal/workspace-service.ts
+++ b/src/infrastructure/host/internal/workspace-service.ts
@@ -80,7 +80,9 @@ export class WorkspaceService {
   }
 
   async #open(path: VaultPath, mode: OpenMode): Promise<void> {
-    const existing = this.#findOpenLeaf(path);
+    // A tab/split/window request is the user asking for a new pane; only the default "active"
+    // mode may collapse onto a leaf that already holds the note.
+    const existing = mode === "active" ? this.#findOpenLeaf(path, this.#activeWindow()) : null;
     if (existing) {
       this.#app.workspace.setActiveLeaf(existing, { focus: true });
       return;
@@ -90,8 +92,17 @@ export class WorkspaceService {
     await this.#app.workspace.getLeaf(toPaneType(mode)).openFile(file, { active: true });
   }
 
-  #findOpenLeaf(path: VaultPath): WorkspaceLeaf | null {
+  // Obsidian tracks the focused window here, differing from the main window only while a popout
+  // holds focus. Read off containerEl rather than the `activeWindow` global so it stays injectable.
+  #activeWindow(): Window {
+    return this.#app.workspace.containerEl.win.activeWindow;
+  }
+
+  // getLeavesOfType spans popout windows, so reuse has to be pinned to one window or opening a
+  // note already open elsewhere drags the user's focus to that other window.
+  #findOpenLeaf(path: VaultPath, win?: Window): WorkspaceLeaf | null {
     for (const leaf of this.#app.workspace.getLeavesOfType("markdown")) {
+      if (win && leaf.getContainer().win !== win) continue;
       const file = this.#fileOf(leaf);
       if (file?.path === path) return leaf;
     }


### PR DESCRIPTION
Fixes #164.

## The bug

`WorkspaceService.#open` reused an already-open leaf by searching `getLeavesOfType("markdown")`, which is `iterateAllLeaves` underneath and therefore spans popout windows. Opening a note that was already open in another window called `setActiveLeaf(..., { focus: true })` on that leaf and dragged the user out of the window they were working in — the symptom in #164, reachable from every open path (commands, calendar cells, nav blocks, home block, toolbar items, the URI handler, startup open).

Not a v3 regression: `2.1.10:src/obsidian-notes-manager.ts:118` is line-for-line the same. The reuse itself was deliberate (`4db3c206`); only its scope was wrong.

## Second defect, same three lines

The reuse short-circuit ran ahead of `toPaneType(mode)`, so an explicit `tab` / `split` / `window` request — a Ctrl/Cmd-click, a middle-click, `mode=tab` on a URI — silently collapsed onto the open leaf instead of opening a pane. Only the default `"active"` mode may reuse now.

## The window signal

`workspace.containerEl.win.activeWindow` — Obsidian's "actively focused Window", read through the injected `App` rather than the `activeWindow` global so it stays fakeable. `workspace.activeLeaf.getContainer().win` also works but is deprecated API and lint flags it.

`isOpen` is left window-agnostic; it answers "open anywhere", not "open here".

## Tests

Unit (`workspace-service.test.ts`): cross-window open, explicit-mode open, and a same-window reuse guard. The fake workspace now models per-leaf windows, a focused window, and records `setActiveLeaf` calls.

e2e (`uri-open.e2e.ts`, "entry already open"): both defects driven through a real popout. Verified red against reverted production code — `mainWindowHoldsNote` false, tab mode added no leaf — and green after restoring it, with a rebuild on each side and no dev watcher running.

## Gates

`check:types`, `test` (3524), `check:lint` (only the pre-existing `plugin-setting-tab` warning), `check:i18n`, and the full e2e suite (45/45 spec files) all pass.