### PR TITLE
fix(nav): resolve note_name and title in navigation block rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Bug Fixes
+
+- Navigation block rows — including the custom-interval list in a view — now render `{{note_name}}` and `{{title}}`. A row shows the name of the note it opens, or the name that note would get for a period whose note does not exist yet.
+- `{{current_date}}`, `{{time}}` and `{{current_time}}` now resolve in navigation block rows; the variable reference listed them, but they came out as literal text.
+
 ## [3.0.0] - 2026-08-14
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ These variables can be used in the note name template, the folder path, and the 
 - `{{start_date}}` - first day of week, month, quarter, year or interval depending on note type, formatting rules are the same as in `{{date}}`, as well as the calculations
 - `{{end_date}}` - last day of week, month, quarter, year or interval depending on note type, formatting rules are the same as in `{{date}}`, as well as the calculations
 - `{{index}}` - the journal's numbering variable, which is named `index` by default. A journal can define several numbering variables under its own names, each with its own frontmatter property; the name you give it there is the name you use here. Numbering is on by default for custom-interval journals and can be enabled for any journal type.
-- `{{note_name}}` / `{{title}}` - the rendered note name. Available in the folder path and in template content, but not in the note name template itself, since the name has to render first.
+- `{{note_name}}` / `{{title}}` - the note's name. Available in the folder path, in template content and in navigation block rows, but not in the note name template itself, since the name has to render first. In a navigation block row it is the name of the note the row opens; for a period whose note does not exist yet, the name that note would get.
 - `{{current_date}}` - the date the note is rendered on (not the reference period), formatted with `{{current_date:format}}`
 - `{{current_time}}` / `{{time}}` - the clock time at render, formatted with `{{time:HH:mm}}`
 - `{{relative_date}}` - "Yesterday", "Today", "Last Tuesday", "This month", "3 weeks ago", and so on. Available in navigation block rows.

--- a/e2e/fixtures/e2e-views/.obsidian/plugins/journals/data.json
+++ b/e2e/fixtures/e2e-views/.obsidian/plugins/journals/data.json
@@ -82,6 +82,17 @@
             "color": { "type": "theme", "name": "text-normal" },
             "background": { "type": "transparent" },
             "addDecorations": false
+          },
+          {
+            "template": "Note: {{note_name}}",
+            "fontSize": 1,
+            "bold": false,
+            "italic": false,
+            "link": "none",
+            "journal": "",
+            "color": { "type": "theme", "name": "text-normal" },
+            "background": { "type": "transparent" },
+            "addDecorations": false
           }
         ]
       }

--- a/e2e/journeys/view-blocks.e2e.ts
+++ b/e2e/journeys/view-blocks.e2e.ts
@@ -15,6 +15,25 @@ import {
 // default Calendar view. The view-leaf mount is the real seam: a ribbon click renders
 // the configured blocks in an Obsidian leaf.
 
+const INTERVAL_ENTRY = `${CUSTOM_INTERVALS} .journal-view-custom-intervals__entry`;
+// The intervals the year window renders; which sprints those are depends on the run date.
+async function intervalAnchors(): Promise<string[]> {
+  await $(INTERVAL_ENTRY).waitForExist({ timeoutMsg: "no custom-interval entry rendered" });
+  return browser.execute(
+    (selector) => Array.from(document.querySelectorAll<HTMLElement>(selector), (el) => el.dataset.anchor ?? ""),
+    INTERVAL_ENTRY,
+  );
+}
+
+// The `Note: {{note_name}}` row is the last of the three the fixture configures.
+async function noteNameRow(anchor: string): Promise<string> {
+  return browser.execute((selector) => {
+    const entry = document.querySelector<HTMLElement>(selector);
+    const rows = entry ? [...entry.querySelectorAll<HTMLElement>(".nav-row")] : [];
+    return rows.at(-1)?.textContent?.trim() ?? "";
+  }, `${INTERVAL_ENTRY}[data-anchor="${anchor}"]`);
+}
+
 describe("blocks view", () => {
   before(async () => {
     await browser.reloadObsidian({ vault: "./e2e/fixtures/e2e-views", plugins: ["journals"] });
@@ -122,7 +141,7 @@ describe("blocks view", () => {
       // The sprint journal seeds no notes, so every rendered interval is un-created; its
       // "self" row must create-or-open rather than sit inert. Read a real entry's anchor
       // instead of assuming which sprint falls in the current year window.
-      const entry = $(`${CUSTOM_INTERVALS} .journal-view-custom-intervals__entry`);
+      const entry = $(INTERVAL_ENTRY);
       await entry.waitForExist({ timeoutMsg: "no custom-interval entry rendered" });
       const anchor = (await entry.getAttribute("data-anchor")) ?? "";
       const path = `sprint/${anchor}.md`;
@@ -131,6 +150,47 @@ describe("blocks view", () => {
 
       await waitForJournalFrontmatter(path, { journal: "sprint", date: anchor });
       expect(await activeNotePath()).toBe(path);
+    });
+  });
+
+  // The fixture gives the sprint journal a third interval row, `Note: {{note_name}}`. The nav
+  // row context bound no note name at all before the fix, so every interval in the list — the
+  // surface #219 reported — rendered the raw token.
+  describe("custom-intervals note names", () => {
+    before(async () => {
+      await browser.reloadObsidian({ vault: "./e2e/fixtures/e2e-views", plugins: ["journals"] });
+    });
+
+    it("names an interval with no note by what that note would be called", async () => {
+      await openBlocksView();
+
+      const anchors = await intervalAnchors();
+      const anchor = anchors.at(0) ?? "";
+      expect(anchor).not.toBe("");
+
+      // The journal keeps the default `{{date}}` name template under a YYYY-MM-DD date
+      // format, so an un-created interval's prospective note name is its own anchor.
+      await browser.waitUntil(async () => (await noteNameRow(anchor)) === `Note: ${anchor}`, {
+        timeoutMsg: `interval ${anchor} did not resolve note_name to its prospective note name`,
+      });
+    });
+
+    it("names an interval whose note was renamed by that note's own name", async () => {
+      await openBlocksView();
+
+      const anchors = await intervalAnchors();
+      const anchor = anchors.at(1) ?? "";
+      expect(anchor).not.toBe("");
+
+      // A name the journal's template can never render, so a pass can only mean the row read
+      // the connected note's own path rather than re-rendering the template.
+      const path = "sprint/Redesign kickoff.md";
+      await seedNote(path, `---\njournal: sprint\njournal-date: ${anchor}\n---\n`);
+      await waitForJournalFrontmatter(path, { journal: "sprint", date: anchor });
+
+      await browser.waitUntil(async () => (await noteNameRow(anchor)) === `Note: Redesign kickoff`, {
+        timeoutMsg: `interval ${anchor} did not follow the connected note's own name`,
+      });
     });
   });
 

--- a/messages/de.json
+++ b/messages/de.json
@@ -1973,7 +1973,7 @@
 	"journal_edit_variable_journal_link_description": "Wird im Inhalt einer Vorlagendatei zum Pfad der Notiz eines anderen Journals für das Datum dieser Notiz aufgelöst. Setze ihn selbst in einen Link oder eine Einbettung (zum Beispiel ![[ … ]]) und ergänze Datumsmodifikatoren wie +1w, um auf einen benachbarten Zeitraum zu verweisen.",
 	"journal_edit_variable_journal_name_description": "Der Name des Journals (hier: {name}).",
 	"journal_edit_variable_non_invertible_warning": "Wenn du das hier verwendest, kann das Journal das Datum nicht mehr aus dem Dateinamen ermitteln.",
-	"journal_edit_variable_note_name_description": "Der Name der zu erstellenden Notiz.",
+	"journal_edit_variable_note_name_description": "Der Name der Notiz für diesen Zeitraum.",
 	"journal_edit_variable_note_title_description": "Alias des Notiznamens, der die Variable des Kern-Plugins „Vorlagen“ unterstützt.",
 	"journal_edit_variable_numbering_description": "Die konfigurierte Nummerierungsvariable (siehe Abschnitt „Fortlaufende Nummern“).",
 	"journal_edit_variable_reference_intro": "Verfügbare Variablen. Das Datumsformat ist standardmäßig {dateFormat}, wenn kein eigenes Format angegeben ist.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1421,7 +1421,7 @@
   "journal_edit_variable_journal_link_description": "Inside a template file's content, resolves to the path of another journal's note for this note's date. Wrap it yourself in a link or embed (for example ![[ … ]]), and add date modifiers like +1w to point at a neighboring period.",
   "journal_edit_variable_journal_name_description": "The journal name (here: {name}).",
   "journal_edit_variable_non_invertible_warning": "Using this here prevents the journal from recovering the date from the filename.",
-  "journal_edit_variable_note_name_description": "The name of the note being created.",
+  "journal_edit_variable_note_name_description": "The name of the note for this period.",
   "journal_edit_variable_note_title_description": "Alias of the note name, supporting the core Templates plugin's variable.",
   "journal_edit_variable_numbering_description": "The configured numbering variable (see the Sequence section).",
   "journal_edit_variable_reference_intro": "Available variables. Date format defaults to {dateFormat} when no explicit format is given.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1963,7 +1963,7 @@
 	"journal_edit_variable_journal_link_description": "Dentro del contenido de un archivo de plantilla, se resuelve a la ruta de la nota de otro diario para la fecha de esta nota. Inclúyela en un enlace o incrustación (por ejemplo, ![[ … ]]) y agrega modificadores de fecha como +1w para apuntar a un período adyacente.",
 	"journal_edit_variable_journal_name_description": "El nombre del diario (aquí: {name}).",
 	"journal_edit_variable_non_invertible_warning": "Usar esto aquí impide que el diario recupere la fecha a partir del nombre del archivo.",
-	"journal_edit_variable_note_name_description": "El nombre de la nota que se está creando.",
+	"journal_edit_variable_note_name_description": "El nombre de la nota de este período.",
 	"journal_edit_variable_note_title_description": "Alias del nombre de la nota, compatible con la variable del complemento principal «Plantillas».",
 	"journal_edit_variable_numbering_description": "La variable de numeración configurada (consulta la sección Números secuenciales).",
 	"journal_edit_variable_reference_intro": "Variables disponibles. El formato de fecha predeterminado es {dateFormat} cuando no se proporciona un formato explícito.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1980,7 +1980,7 @@
 	"journal_edit_variable_journal_link_description": "Dans le contenu d’un fichier modèle, cette variable renvoie le chemin de la note d’un autre journal pour la date de cette note. Intégrez-la vous-même dans un lien ou une intégration (par exemple ![[ … ]]), et ajoutez des modificateurs de date comme +1w pour pointer vers une période voisine.",
 	"journal_edit_variable_journal_name_description": "Le nom du journal (ici : {name}).",
 	"journal_edit_variable_non_invertible_warning": "Son utilisation ici empêche le journal de récupérer la date à partir du nom du fichier.",
-	"journal_edit_variable_note_name_description": "Le nom de la note en cours de création.",
+	"journal_edit_variable_note_name_description": "Le nom de la note de cette période.",
 	"journal_edit_variable_note_title_description": "Alias du nom de la note, prenant en charge la variable du plugin principal « Modèles ».",
 	"journal_edit_variable_numbering_description": "La variable de numérotation configurée (voir la section Numéros séquentiels).",
 	"journal_edit_variable_reference_intro": "Variables disponibles. Le format de date par défaut est {dateFormat} lorsqu’aucun format explicite n’est spécifié.",

--- a/messages/it.json
+++ b/messages/it.json
@@ -1971,7 +1971,7 @@
 	"journal_edit_variable_journal_link_description": "All'interno del contenuto di un file modello, restituisce il percorso della nota di un altro diario per la data di questa nota. Inseriscilo tu stesso in un collegamento o in un embed (ad esempio ![[ … ]]) e aggiungi modificatori di data come +1w per puntare a un periodo adiacente.",
 	"journal_edit_variable_journal_name_description": "Il nome del diario (qui: {name}).",
 	"journal_edit_variable_non_invertible_warning": "Usarlo qui impedisce al diario di ricavare la data dal nome del file.",
-	"journal_edit_variable_note_name_description": "Il nome della nota che si sta creando.",
+	"journal_edit_variable_note_name_description": "Il nome della nota di questo periodo.",
 	"journal_edit_variable_note_title_description": "Alias del nome della nota, per supportare la variabile del plugin principale \"Modelli\".",
 	"journal_edit_variable_numbering_description": "La variabile di numerazione configurata (vedere la sezione Sequenza).",
 	"journal_edit_variable_reference_intro": "Variabili disponibili. Il formato della data predefinito è {dateFormat} quando non viene specificato alcun formato esplicito.",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1774,7 +1774,7 @@
 	"journal_edit_variable_journal_link_description": "テンプレートファイルの中では、このノートの日付に対応する別のジャーナルのノートのパスに解決されます。リンクや埋め込み（例: ![[ … ]]）で自分で囲み、+1w のような日付修飾子を付けると隣接する期間を指せます。",
 	"journal_edit_variable_journal_name_description": "ジャーナル名（ここでは {name}）。",
 	"journal_edit_variable_non_invertible_warning": "ここでこれを使用すると、ジャーナルがファイル名から日付を復元できなくなります。",
-	"journal_edit_variable_note_name_description": "作成されるノートの名前。",
+	"journal_edit_variable_note_name_description": "この期間のノートの名前。",
 	"journal_edit_variable_note_title_description": "ノート名のエイリアスで、コアプラグイン「テンプレート」の変数に対応します。",
 	"journal_edit_variable_numbering_description": "設定した番号付け変数（連番セクションを参照）。",
 	"journal_edit_variable_reference_intro": "使用できる変数。明示的な形式を指定しない場合、日付形式は{dateFormat}になります。",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1963,7 +1963,7 @@
 	"journal_edit_variable_journal_link_description": "템플릿 파일 안에서, 이 노트의 날짜에 해당하는 다른 저널 노트의 경로로 확정됩니다. 링크나 임베드(예: ![[ … ]])는 직접 감싸야 하며, +1w 같은 날짜 수정자를 붙이면 인접한 기간을 가리킬 수 있습니다.",
 	"journal_edit_variable_journal_name_description": "저널 이름입니다(여기서는 {name}).",
 	"journal_edit_variable_non_invertible_warning": "여기에 이 변수를 쓰면 저널이 파일 이름에서 날짜를 되찾지 못하게 됩니다.",
-	"journal_edit_variable_note_name_description": "만들어지는 노트의 이름입니다.",
+	"journal_edit_variable_note_name_description": "이 기간에 해당하는 노트의 이름입니다.",
 	"journal_edit_variable_note_title_description": "노트 이름의 별칭으로, 코어 템플릿(Templates) 플러그인의 변수를 지원합니다.",
 	"journal_edit_variable_numbering_description": "설정한 번호 매기기 변수입니다(순차 번호 섹션 참조).",
 	"journal_edit_variable_reference_intro": "사용할 수 있는 변수입니다. 형식을 따로 지정하지 않으면 날짜 형식은 {dateFormat}입니다.",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1971,7 +1971,7 @@
 	"journal_edit_variable_journal_link_description": "Dentro do conteúdo de um arquivo de modelo, o caminho aponta para a nota de outro diário na data desta nota. Você pode inserir o caminho em um link ou embuti-lo (por exemplo, ![[ … ]]) e adicionar modificadores de data como +1w para apontar para um período adjacente.",
 	"journal_edit_variable_journal_name_description": "O nome do diário (aqui: {name}).",
 	"journal_edit_variable_non_invertible_warning": "Usar isso aqui impede que o diário recupere a data a partir do nome do arquivo.",
-	"journal_edit_variable_note_name_description": "O nome da nota que está sendo criada.",
+	"journal_edit_variable_note_name_description": "O nome da nota deste período.",
 	"journal_edit_variable_note_title_description": "Alias do nome da nota, compatível com a variável do plugin principal Modelos.",
 	"journal_edit_variable_numbering_description": "A variável de numeração configurada (consulte a seção Sequência).",
 	"journal_edit_variable_reference_intro": "Variáveis disponíveis. O formato de data padrão é {dateFormat} quando nenhum formato explícito é fornecido.",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -2022,7 +2022,7 @@
 	"journal_edit_variable_journal_link_description": "Внутри содержимого файла шаблона указывается путь к заметке другого журнала для даты этой заметки. Вы можете самостоятельно обернуть его в ссылку или встроить (например, ![[ … ]]) и добавить модификаторы даты, такие как +1w, чтобы указать на соседний период.",
 	"journal_edit_variable_journal_name_description": "Название журнала (здесь: {name}).",
 	"journal_edit_variable_non_invertible_warning": "Использование этого здесь не позволит журналу восстановить дату из имени файла.",
-	"journal_edit_variable_note_name_description": "Название создаваемой заметки.",
+	"journal_edit_variable_note_name_description": "Название заметки за этот период.",
 	"journal_edit_variable_note_title_description": "Псевдоним названия заметки, поддерживающий переменную основного плагина «Шаблоны».",
 	"journal_edit_variable_numbering_description": "Настраиваемая переменная нумерации (см. раздел «Последовательность»).",
 	"journal_edit_variable_reference_intro": "Доступные переменные. Формат даты по умолчанию равен {dateFormat}, если явный формат не указан.",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -1821,7 +1821,7 @@
 	"journal_edit_variable_journal_link_description": "Усередині вмісту файлу шаблону переходить до шляху до нотатки іншого журналу для дати цієї нотатки. Оберніть її самостійно в посилання або вбудуйте (наприклад, ![[ … ]]) та додайте модифікатори дати, такі як +1w, щоб вказати на сусідній період.",
 	"journal_edit_variable_journal_name_description": "Назва журналу (тут: {name}).",
 	"journal_edit_variable_non_invertible_warning": "Використання цього тут запобігає відновленню дати з імені файлу журналом.",
-	"journal_edit_variable_note_name_description": "Ім’я нотатки, що створюється.",
+	"journal_edit_variable_note_name_description": "Назва нотатки за цей період.",
 	"journal_edit_variable_note_title_description": "Псевдонім імені нотатки, що підтримує змінну основного плагіна «Шаблони».",
 	"journal_edit_variable_numbering_description": "Налаштована змінна нумерації (див. розділ «Послідовність»).",
 	"journal_edit_variable_reference_intro": "Доступні змінні. Формат дати за замовчуванням має значення {dateFormat} якщо явний формат не вказано.",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1774,7 +1774,7 @@
 	"journal_edit_variable_journal_link_description": "在模板文件的内容中，它会解析为另一篇日记中与此笔记日期对应的笔记路径。请自行将其包装在链接或嵌入中（例如 ![[ … ]]），并添加类似 +1w 的日期修饰符以指向相邻周期。",
 	"journal_edit_variable_journal_name_description": "日记名称（此处：{name}）。",
 	"journal_edit_variable_non_invertible_warning": "在此处使用它会导致日记无法从文件名中还原日期。",
-	"journal_edit_variable_note_name_description": "正在创建的笔记的名称。",
+	"journal_edit_variable_note_name_description": "本周期笔记的名称。",
 	"journal_edit_variable_note_title_description": "笔记名称的别名，支持核心插件“模板”的变量。",
 	"journal_edit_variable_numbering_description": "配置的编号变量（参见“顺序编号”部分）。",
 	"journal_edit_variable_reference_intro": "可用变量。当未指定显式格式时，日期格式默认为{dateFormat}。",

--- a/src/code-blocks/nav/nav-row-context.test.ts
+++ b/src/code-blocks/nav/nav-row-context.test.ts
@@ -9,27 +9,43 @@ import { LoggerFactory, LoggerFactoryToken } from "@/infrastructure/logger";
 import { Option } from "@/infrastructure/result";
 import {
   CycleService,
+  FrontmatterService,
   JournalsIndex,
   JournalsRepository,
+  NotePathService,
   NumberingService,
   journalDefaultsFor,
   type JournalConfig,
   type JournalEntry,
 } from "@/journals";
 import { fakeRepo } from "@/journals/testing";
+import { TemplateEngine } from "@/templates";
 
 import { buildNavRowContext } from "./nav-row-context";
 
 installTestCalendar();
 
-function makeServices(journals: Record<string, JournalConfig>): { cycle: CycleService; numbering: NumberingService } {
+interface NavServices {
+  cycle: CycleService;
+  numbering: NumberingService;
+  notePath: NotePathService;
+}
+
+function makeServices(journals: Record<string, JournalConfig>): NavServices {
   const c = new Container();
   c.register(LoggerFactoryToken).useClass(LoggerFactory);
   c.register(JournalsRepository).useValue(fakeRepo(journals));
   c.register(JournalsIndex).useClass(JournalsIndex);
   c.register(CycleService).useClass(CycleService);
   c.register(NumberingService).useClass(NumberingService);
-  return { cycle: c.resolve(CycleService), numbering: c.resolve(NumberingService) };
+  c.register(FrontmatterService).useClass(FrontmatterService);
+  c.register(TemplateEngine).useClass(TemplateEngine);
+  c.register(NotePathService).useClass(NotePathService);
+  return {
+    cycle: c.resolve(CycleService),
+    numbering: c.resolve(NumberingService),
+    notePath: c.resolve(NotePathService),
+  };
 }
 
 const today = "2026-05-27" as AnchorString;
@@ -39,7 +55,7 @@ describe("buildNavRowContext", () => {
   beforeAll(() => initLocale("en"));
 
   const dailyConfig = journalDefaultsFor({ type: "day" }, "daily");
-  const { cycle, numbering } = makeServices({ daily: dailyConfig });
+  const { cycle, numbering, notePath } = makeServices({ daily: dailyConfig });
 
   it("exposes refDate as the `date` variable using the journal's dateFormat", () => {
     const context = buildNavRowContext({
@@ -48,6 +64,7 @@ describe("buildNavRowContext", () => {
       entry: Option.none(),
       cycle,
       numbering,
+      notePath,
       today,
     });
     const spec = context.get("date");
@@ -63,6 +80,7 @@ describe("buildNavRowContext", () => {
       entry: Option.none(),
       cycle,
       numbering,
+      notePath,
       today,
     });
     expect(context.get("journal_name")).toEqual({ kind: "string", value: "daily" });
@@ -75,6 +93,7 @@ describe("buildNavRowContext", () => {
       entry: Option.none(),
       cycle,
       numbering,
+      notePath,
       today,
     });
     expect(context.get("relative_date")).toEqual({ kind: "string", value: "Yesterday" });
@@ -97,6 +116,7 @@ describe("buildNavRowContext", () => {
         entry: Option.none(),
         cycle: custom.cycle,
         numbering: custom.numbering,
+        notePath: custom.notePath,
         today: customToday,
       }).get("relative_date");
     }
@@ -137,6 +157,7 @@ describe("buildNavRowContext", () => {
         entry: Option.none(),
         cycle: weekly.cycle,
         numbering: weekly.numbering,
+        notePath: weekly.notePath,
         today,
       });
     }
@@ -160,19 +181,84 @@ describe("buildNavRowContext", () => {
     });
   });
 
-  it("populates index from the entry numbers when present", () => {
-    const entry: JournalEntry = {
-      journalName: "daily",
-      anchor: refDate,
-      path: "Daily/2026-05-26.md" as VaultPath,
-      numbers: { index: 42 },
+  describe("note_name and title", () => {
+    const sprintConfig: JournalConfig = {
+      ...journalDefaultsFor(
+        { type: "custom", every: "week", duration: 2, anchorDate: "2024-01-01" as AnchorString },
+        "sprint",
+      ),
+      nameTemplate: "Sprint {{index}} ({{date:YYYY-MM-DD}})",
     };
+    const sprintServices = makeServices({ sprint: sprintConfig });
+    const sprintAnchor = "2024-01-15" as AnchorString;
+
+    function sprintContext(entry: Option<JournalEntry>): ReturnType<typeof buildNavRowContext> {
+      return buildNavRowContext({
+        journal: sprintConfig,
+        refDate: sprintAnchor,
+        entry,
+        cycle: sprintServices.cycle,
+        numbering: sprintServices.numbering,
+        notePath: sprintServices.notePath,
+        today,
+      });
+    }
+
+    it("renders the journal's note name when the note does not exist yet", () => {
+      const expected = { kind: "string", value: "Sprint 2 (2024-01-15)" };
+      const context = sprintContext(Option.none());
+      expect(context.get("note_name")).toEqual(expected);
+      expect(context.get("title")).toEqual(expected);
+    });
+
+    it("reads the existing note's own name so a renamed note is named as it is", () => {
+      const entry: JournalEntry = {
+        journalName: "sprint",
+        anchor: sprintAnchor,
+        path: "Sprints/Redesign kickoff.md" as VaultPath,
+      };
+      const expected = { kind: "string", value: "Redesign kickoff" };
+      const context = sprintContext(Option.some(entry));
+      expect(context.get("note_name")).toEqual(expected);
+      expect(context.get("title")).toEqual(expected);
+    });
+  });
+
+  it("exposes the render-time date and clock variables the variable reference lists", () => {
     const context = buildNavRowContext({
       journal: dailyConfig,
       refDate,
-      entry: Option.some(entry),
+      entry: Option.none(),
       cycle,
       numbering,
+      notePath,
+      today,
+    });
+    expect(context.get("current_date")?.kind).toBe("date");
+    expect(context.get("time")?.kind).toBe("clock");
+    expect(context.get("current_time")?.kind).toBe("clock");
+  });
+
+  it("prefers the entry's stored numbers over the computed ones", () => {
+    const customConfig = journalDefaultsFor(
+      { type: "custom", every: "week", duration: 2, anchorDate: "2024-01-01" as AnchorString },
+      "biweekly",
+    );
+    const custom = makeServices({ biweekly: customConfig });
+    const anchor = "2024-01-15" as AnchorString;
+    const entry: JournalEntry = {
+      journalName: "biweekly",
+      anchor,
+      path: "Biweekly/2024-01-15.md" as VaultPath,
+      numbers: { index: 42 },
+    };
+    const context = buildNavRowContext({
+      journal: customConfig,
+      refDate: anchor,
+      entry: Option.some(entry),
+      cycle: custom.cycle,
+      numbering: custom.numbering,
+      notePath: custom.notePath,
       today,
     });
     expect(context.get("index")).toEqual({ kind: "number", value: 42 });
@@ -185,6 +271,7 @@ describe("buildNavRowContext", () => {
       entry: Option.none(),
       cycle,
       numbering,
+      notePath,
       today,
     });
     expect(context.get("index")).toBeUndefined();
@@ -202,6 +289,7 @@ describe("buildNavRowContext", () => {
       entry: Option.none(),
       cycle: custom.cycle,
       numbering: custom.numbering,
+      notePath: custom.notePath,
       today,
     });
     expect(context.get("index")).toEqual({ kind: "number", value: 2 });

--- a/src/code-blocks/nav/nav-row-context.ts
+++ b/src/code-blocks/nav/nav-row-context.ts
@@ -2,9 +2,18 @@ import { match } from "ts-pattern";
 
 import { CalendarDate, relativeDate, type AnchorString, type PeriodKind } from "@/calendar";
 import { m } from "@/i18n";
-import { Option } from "@/infrastructure/result";
-import type { CycleService, JournalConfig, JournalEntry, NumberingService, JournalWrite } from "@/journals";
-import { TemplateContext } from "@/templates";
+import { basenameOf } from "@/infrastructure/host";
+import type { Option } from "@/infrastructure/result";
+import type {
+  CycleService,
+  JournalConfig,
+  JournalEntry,
+  JournalMetadata,
+  NotePathService,
+  NumberingService,
+  JournalWrite,
+} from "@/journals";
+import type { TemplateContext } from "@/templates";
 
 export interface NavRowContextInputs {
   readonly journal: JournalConfig;
@@ -12,6 +21,7 @@ export interface NavRowContextInputs {
   readonly entry: Option<JournalEntry>;
   readonly cycle: CycleService;
   readonly numbering: NumberingService;
+  readonly notePath: NotePathService;
   readonly today: AnchorString;
 }
 
@@ -44,34 +54,32 @@ function customRelativeDate(name: string, cycle: CycleService, refDate: AnchorSt
 }
 
 export function buildNavRowContext(inputs: NavRowContextInputs): TemplateContext {
-  const { journal, refDate, entry, cycle, numbering, today } = inputs;
-  const refCalendarDate = CalendarDate.fromAnchor(refDate);
-  const renderDate = cycle.representativeOf(journal.name, refDate).getOr(refCalendarDate);
-  const startDate = cycle.startOf(journal.name, refDate).getOr(refCalendarDate);
-  const endDate = cycle.endOf(journal.name, refDate).getOr(refCalendarDate);
+  const { journal, refDate, entry, cycle, numbering, notePath, today } = inputs;
   const periodKind = fixedPeriodKindFor(journal.write);
   const relative =
     periodKind === null
       ? customRelativeDate(journal.name, cycle, refDate, today)
       : relativeDate(periodKind, refDate, today);
 
-  let context = TemplateContext.empty()
-    .date("date", renderDate, journal.dateFormat)
-    .date("start_date", startDate, journal.dateFormat)
-    .date("end_date", endDate, journal.dateFormat)
-    .string("relative_date", relative)
-    .string("journal_name", journal.name);
-
   // A note's stored numbers are authoritative (manual extension/renumber); fall back to the
   // computed numbering so the row resolves the index even before the note exists.
   const numbers =
     entry.isSome() && entry.value.numbers
-      ? Option.some(entry.value.numbers)
-      : numbering.assignNumbers(journal.name, refDate);
-  if (numbers.isSome()) {
-    for (const [variable, value] of Object.entries(numbers.value)) {
-      if (typeof value === "number") context = context.number(variable, value);
-    }
-  }
-  return context;
+      ? entry.value.numbers
+      : numbering.assignNumbers(journal.name, refDate).getOrUndefined();
+  const metadata: JournalMetadata = { journalName: journal.name, anchor: refDate, ...(numbers && { numbers }) };
+
+  // A row names the note it opens, so an existing note is named as it actually is — renamed,
+  // or created under a name template the journal has since changed. Only a note that does not
+  // exist yet is named by rendering the template.
+  const noteName = entry.isSome() ? basenameOf(entry.value.path) : notePath.noteNameFor(journal, metadata);
+  const noteSpec = { kind: "string", value: noteName } as const;
+
+  // Sharing the note's own render context is what keeps a row's variables in step with the
+  // note's — the date trio, the numbering fallbacks and the render-time clock included.
+  return notePath
+    .contextFor(journal, metadata)
+    .string("relative_date", relative)
+    .withSpec("note_name", noteSpec)
+    .withSpec("title", noteSpec);
 }

--- a/src/code-blocks/nav/settings/ui/EditNavBlockRowModal.test.ts
+++ b/src/code-blocks/nav/settings/ui/EditNavBlockRowModal.test.ts
@@ -12,6 +12,8 @@ import { FakeModalService, provideModalApiOnApp } from "@/infrastructure/host/mo
 import {
   CycleService,
   JournalsIndex,
+  FrontmatterService,
+  NotePathService,
   NumberingService,
   JournalsRepository,
   JournalsViewModel,
@@ -49,6 +51,8 @@ function mountModal(options: {
   container.register(CycleService).useClass(CycleService);
   container.register(JournalsIndex).useClass(JournalsIndex);
   container.register(NumberingService).useClass(NumberingService);
+  container.register(FrontmatterService).useClass(FrontmatterService);
+  container.register(NotePathService).useClass(NotePathService);
   render(EditNavBlockRowModal, {
     props: { journalName: "daily", row: options.row },
     global: {

--- a/src/code-blocks/nav/settings/ui/EditNavBlockRowModal.vue
+++ b/src/code-blocks/nav/settings/ui/EditNavBlockRowModal.vue
@@ -12,6 +12,7 @@ import {
   CycleService,
   JournalsIndex,
   JournalsViewModel,
+  NotePathService,
   NumberingService,
   navBlockRowSchema,
   type JournalConfig,
@@ -41,6 +42,7 @@ const journalsVM = useService(JournalsViewModel);
 const engine = useService(TemplateEngine);
 const cycle = useService(CycleService);
 const numbering = useService(NumberingService);
+const notePath = useService(NotePathService);
 const index = useService(JournalsIndex);
 
 const config = computed<JournalConfig | undefined>(() => journalsVM.getJournal(props.journalName).getOrUndefined());
@@ -124,6 +126,7 @@ const resolved = computed(() => {
       entry: index.entryByAnchor(config.value.name, today),
       cycle,
       numbering,
+      notePath,
       today,
     }),
   );

--- a/src/code-blocks/nav/settings/ui/NavBlockRowsEditor.test.ts
+++ b/src/code-blocks/nav/settings/ui/NavBlockRowsEditor.test.ts
@@ -13,6 +13,8 @@ import { FakeNoticeService } from "@/infrastructure/host/testing";
 import {
   CycleService,
   JournalsIndex,
+  FrontmatterService,
+  NotePathService,
   NumberingService,
   JournalsRepository,
   JournalsViewModel,
@@ -59,6 +61,8 @@ function mount(rows: NavBlockRow[]) {
   container.register(CycleService).useClass(CycleService);
   container.register(JournalsIndex).useClass(JournalsIndex);
   container.register(NumberingService).useClass(NumberingService);
+  container.register(FrontmatterService).useClass(FrontmatterService);
+  container.register(NotePathService).useClass(NotePathService);
   container.register(WorkspaceService).useValue({} as WorkspaceService);
   render(NavBlockRowsEditor, {
     props: { journalName: "daily", field: "intervalBlock", title: TITLE, icon: "list" },

--- a/src/code-blocks/nav/settings/ui/NavBlockSection.test.ts
+++ b/src/code-blocks/nav/settings/ui/NavBlockSection.test.ts
@@ -13,6 +13,8 @@ import { FakeNoticeService } from "@/infrastructure/host/testing";
 import {
   CycleService,
   JournalsIndex,
+  FrontmatterService,
+  NotePathService,
   NumberingService,
   JournalsRepository,
   JournalsViewModel,
@@ -55,6 +57,8 @@ function mount(rows: NavBlockRow[]) {
   container.register(CycleService).useClass(CycleService);
   container.register(JournalsIndex).useClass(JournalsIndex);
   container.register(NumberingService).useClass(NumberingService);
+  container.register(FrontmatterService).useClass(FrontmatterService);
+  container.register(NotePathService).useClass(NotePathService);
   container.register(WorkspaceService).useValue({} as WorkspaceService);
   render(NavBlockSection, {
     props: { journalName: "daily" },

--- a/src/code-blocks/nav/ui/NavBlockRow.vue
+++ b/src/code-blocks/nav/ui/NavBlockRow.vue
@@ -24,6 +24,7 @@ import {
   CycleService,
   JournalsIndex,
   JournalsRepository,
+  NotePathService,
   NumberingService,
   OpenDateFlow,
   useIndexVersion,
@@ -53,6 +54,7 @@ const journals = useService(JournalsRepository);
 const index = useService(JournalsIndex);
 const cycle = useService(CycleService);
 const numbering = useService(NumberingService);
+const notePath = useService(NotePathService);
 const shelves = useService(ShelvesRepository);
 const engine = useService(TemplateEngine);
 const flows = useService(Flows);
@@ -97,6 +99,7 @@ const text = computed(() =>
       entry: entry.value,
       cycle,
       numbering,
+      notePath,
       today: today.value,
     }),
   ),

--- a/src/code-blocks/nav/ui/NavigationCodeBlock.test.ts
+++ b/src/code-blocks/nav/ui/NavigationCodeBlock.test.ts
@@ -32,6 +32,8 @@ import {
   CycleService,
   JournalsIndex,
   JournalsRepository,
+  FrontmatterService,
+  NotePathService,
   NumberingService,
   OpenDateFlow,
   TimelineService,
@@ -139,6 +141,8 @@ function buildHarness(journals: Record<string, JournalConfig>): Harness {
   container.register(CycleService).useClass(CycleService);
   container.register(TimelineService).useClass(TimelineService);
   container.register(NumberingService).useClass(NumberingService);
+  container.register(FrontmatterService).useClass(FrontmatterService);
+  container.register(NotePathService).useClass(NotePathService);
   const shelves = new FakeShelves();
   container.register(ShelvesRepository).useValue(shelves as unknown as ShelvesRepository);
   const workspace = new FakeWorkspace();
@@ -281,6 +285,32 @@ describe("NavigationCodeBlock columns", () => {
     expect(screen.queryByText("26")).toBeNull();
     expect(screen.queryByText("28")).toBeNull();
     expect(screen.getByText("27")).toBeTruthy();
+  });
+});
+
+describe("NavigationCodeBlock row templates", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-27T10:00:00Z"));
+  });
+
+  it("renders note_name as the connected note's own name, and as the prospective name where no note exists", () => {
+    const daily: JournalConfig = { ...journalDefaultsFor({ type: "day" }, "daily") };
+    daily.navBlock = { ...daily.navBlock, rows: [navRow({ template: "{{note_name}}" })] };
+    const h = buildHarness({ daily });
+    const entry: JournalEntry = {
+      journalName: "daily",
+      anchor: "2026-05-27" as AnchorString,
+      path: "Daily/Renamed day.md" as VaultPath,
+    };
+    h.index.byPath.set(entry.path, entry);
+    h.index.byAnchor.set("daily::2026-05-27", entry);
+    h.shelves.shelves = [{ name: "main", journals: ["daily"] }];
+    mount(h, entry.path);
+
+    expect(screen.getByText("Renamed day")).toBeTruthy();
+    expect(screen.getByText("2026-05-26")).toBeTruthy();
+    expect(screen.getByText("2026-05-28")).toBeTruthy();
   });
 });
 

--- a/src/infrastructure/host/index.ts
+++ b/src/infrastructure/host/index.ts
@@ -23,6 +23,7 @@ export { TemplaterService } from "./internal/templater-service";
 export { TemplatesService } from "./internal/templates-service";
 export { renderIcon } from "./internal/icons";
 export { defineOpenMode } from "./define-open-mode";
+export { basenameOf } from "./paths";
 export {
   defineModal,
   ModalCancelled,

--- a/src/infrastructure/host/paths.ts
+++ b/src/infrastructure/host/paths.ts
@@ -1,0 +1,7 @@
+import type { VaultPath } from "./types";
+
+/** The note's name as the user sees it — the last path segment without the `.md` extension. */
+export function basenameOf(path: VaultPath): string {
+  const filename = path.split("/").pop() ?? path;
+  return filename.replace(/\.md$/, "");
+}

--- a/src/journals/notes/note-creation.ts
+++ b/src/journals/notes/note-creation.ts
@@ -1,6 +1,6 @@
 import { inject } from "@/infrastructure/di";
 import { UserAborted } from "@/infrastructure/flows";
-import { NotesService } from "@/infrastructure/host";
+import { basenameOf, NotesService } from "@/infrastructure/host";
 import type {
   FrontmatterError,
   NoteCreateError,
@@ -48,11 +48,6 @@ export class NoteCreationService {
   readonly #modals = inject(ModalService);
   readonly #guard = inject(SelfWriteGuard);
 
-  #basename(path: VaultPath): string {
-    const filename = path.split("/").pop() ?? path;
-    return filename.replace(/\.md$/, "");
-  }
-
   ensureNote(
     name: string,
     metadata: JournalMetadata,
@@ -88,7 +83,7 @@ export class NoteCreationService {
       const config = this.#journals.get(name).getOrUndefined();
       if (!options?.skipConfirmation && config?.confirmCreation) {
         const confirmed = yield* this.#modals
-          .open(confirmCreationModal, { journalName: name, noteName: this.#basename(path) })
+          .open(confirmCreationModal, { journalName: name, noteName: basenameOf(path) })
           .mapErr(() => new UserAborted("confirm-creation") as NoteCreationError);
         if (!confirmed) return yield* new Err(new UserAborted("confirm-creation"));
       }
@@ -99,7 +94,7 @@ export class NoteCreationService {
         return yield* new Err(createResult.error as NoteCreationError);
       }
       const content = yield* this.#content
-        .renderFor(name, metadata, this.#basename(path), path)
+        .renderFor(name, metadata, basenameOf(path), path)
         .tapErr(() => this.#guard.release(path));
       if (content !== "") {
         yield* this.#notes.write(path, content).tapErr(() => this.#guard.release(path));
@@ -131,7 +126,7 @@ export class NoteCreationService {
       // first, then attach frontmatter last — matching ensureNote's order.
       const existing = yield* this.#notes.read(path);
       if (existing.trim() === "") {
-        const content = yield* this.#content.renderFor(name, metadata, this.#basename(path), path);
+        const content = yield* this.#content.renderFor(name, metadata, basenameOf(path), path);
         if (content !== "") yield* this.#notes.write(path, content);
       }
       yield* this.#notes.updateFrontmatter(path, mutator);

--- a/src/journals/notes/note-path.test.ts
+++ b/src/journals/notes/note-path.test.ts
@@ -172,6 +172,22 @@ describe("NotePathService.pathForDate", () => {
   });
 });
 
+describe("NotePathService.noteNameFor", () => {
+  it("renders the name template without the folder or the .md extension", () => {
+    const config = fixedJournal("daily", { type: "day" }, { folder: "Journals/{{date:YYYY}}" });
+    const c = buildContainer(fakeRepo({ daily: config }));
+    const meta: JournalMetadata = { journalName: "daily", anchor: anchor("2026-05-19") };
+    expect(c.resolve(NotePathService).noteNameFor(config, meta)).toBe("2026-05-19");
+  });
+
+  it("renders a numbering variable from the metadata's stored numbers", () => {
+    const config = customJournal("sprint", "week", 2, "2024-01-01", { nameTemplate: "Sprint {{index}}" });
+    const c = buildContainer(fakeRepo({ sprint: config }));
+    const meta: JournalMetadata = { journalName: "sprint", anchor: anchor("2024-01-15"), numbers: { index: 2 } };
+    expect(c.resolve(NotePathService).noteNameFor(config, meta)).toBe("Sprint 2");
+  });
+});
+
 describe("NotePathService.candidateFor", () => {
   it("inverts a {{date}}.md path into a metadata anchor", () => {
     const repo = fakeRepo({ daily: fixedJournal("daily", { type: "day" }) });

--- a/src/journals/notes/note-path.ts
+++ b/src/journals/notes/note-path.ts
@@ -145,6 +145,11 @@ export class NotePathService {
     return context;
   }
 
+  /** What this journal calls the note for a period, whether or not that note exists yet. */
+  noteNameFor(config: JournalConfig, metadata: JournalMetadata): string {
+    return this.#engine.renderString(config.nameTemplate, this.contextFor(config, metadata));
+  }
+
   bodyContextFor(config: JournalConfig, metadata: JournalMetadata, noteName: string): TemplateContext {
     return this.#withNoteName(this.contextFor(config, metadata), noteName);
   }

--- a/src/journals/settings/ui/VariableReferenceModal.test.ts
+++ b/src/journals/settings/ui/VariableReferenceModal.test.ts
@@ -85,7 +85,7 @@ describe("VariableReferenceModal — rules table", () => {
       expect(screen.queryByText("{{title}}")).toBeNull();
     });
 
-    it.each(["folder-path", "template-path"] as const)("renders note_name and title in %s", (context) => {
+    it.each(["folder-path", "template-path", "nav-row"] as const)("renders note_name and title in %s", (context) => {
       renderModal({ context });
       expect(screen.getByText("{{note_name}}")).toBeTruthy();
       expect(screen.getByText("{{title}}")).toBeTruthy();

--- a/src/journals/settings/ui/VariableReferenceModal.vue
+++ b/src/journals/settings/ui/VariableReferenceModal.vue
@@ -14,7 +14,7 @@ const showInvertibilityWarning = computed(() => NON_INVERTIBLE_CONTEXTS.has(prop
 const showNavRowVariables = computed(() => props.context === "nav-row");
 const showTemplateContentVariables = computed(() => props.context === "template-path");
 // note_name/title are bound after the filename renders, so the name template can't use them.
-const NOTE_NAME_CONTEXTS = new Set<VariableReferenceModalProps["context"]>(["folder-path", "template-path"]);
+const NOTE_NAME_CONTEXTS = new Set<VariableReferenceModalProps["context"]>(["folder-path", "template-path", "nav-row"]);
 const showNoteNameVariables = computed(() => NOTE_NAME_CONTEXTS.has(props.context));
 
 function handleModificationsClick(event: Event): void {


### PR DESCRIPTION
Fixes #219.

## The report

A custom journal's interval list in a calendar view rendered `{{note_name}}` / `{{title}}` as literal text, while `{{journal_name}}` and the dates resolved fine.

## Triage

`buildNavRowContext` built its own template context from scratch and bound only `date`, `start_date`, `end_date`, `relative_date`, `journal_name` and numbering. `note_name` / `title` were never bound, so they rendered as raw tokens — in the `journal-nav` code block and in the custom-interval list of a view.

Two things worth recording:

- **Not a v2 regression.** v2's `NavigationBlockRow.vue` bound the identical set. What v2 got wrong was the *listing*: its single `VariableReference.modal.vue` advertised `note_name` / `title` for every context, which is the "even though they are listed as supported" in the issue thread. v3's context-aware modal already excludes them for `nav-row`, so only the feature gap survived.
- **A second instance of the same defect, still advertised.** `VariableReferenceModal.vue` lists `current_date`, `time` and `current_time` unconditionally — including for `nav-row` — and `buildNavRowContext` bound none of them, so those came out as literal text too. Fixed here, same root cause.

## The fix

Rather than hand-binding the missing variables, the row context is now built on top of the note's own render context (`NotePathService.contextFor`) and adds `relative_date` plus the note name. A row therefore resolves exactly what the note it opens resolves, and there is one owner for what a journal's template variables mean.

- `NotePathService.noteNameFor(config, metadata)` — new; renders the journal's name template.
- An existing note is named from its own path, so a renamed note, or one created under a name template the journal has since changed, reads truthfully instead of showing a name that does not match the file the row opens. A period with no note falls back to rendering the template.
- `basenameOf` extracted to `src/infrastructure/host/paths.ts`; `NoteCreationService`'s private copy now uses it.
- The variable reference now lists `note_name` / `title` for `nav-row`, and `journal_edit_variable_note_name_description` is reworded off "the note being created" (wrong in a nav row) across all eleven locales.
- README and `CHANGELOG.md` updated.

## Tests

- `buildNavRowContext`: existing-note name, prospective name, and the render-time variables.
- `NotePathService.noteNameFor`: name template with and without a numbering variable.
- `NavigationCodeBlock`: mounts the real chain and asserts all three columns.
- e2e (`view-blocks.e2e.ts`, `e2e-views` fixture): the custom-interval list in a real view leaf, one test per branch. The renamed-note test pins a name the journal's template can never render, so it cannot pass if the existing-note branch is deleted.

Verified non-tautological: with the fix reverted and a fresh build, the two new e2e tests fail and every pre-existing one stays green; restored, all twelve pass. Unit suite, `check:types`, `check:lint` and `check:i18n` are clean.