### PR TITLE
feat(code-blocks): show neighboring periods in the timeline block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 - Clone a journal from settings: the copy carries the source's whole configuration, joins the same shelf, and gets its own copy of the source's commands. Notes are not copied.
 - A numbering variable can now be offset and rendered as an ordinal: `{{index+3}}` adds three to the rendered value, `{{index-1}}` subtracts one, and `{{index:o}}` renders it as an ordinal ("4th"). They combine as `{{index+3:o}}`, and both survive the round-trip out of a note name, so a journal named `Sprint {{index+3}}` still recognizes its own notes. This offset syntax now applies to any variable name, not only numbering ones, so a template that happened to contain a literal `+3` or `-1` after a variable name (for example `{{date+3}}`) will render differently from before.
 
+- A `calendar-timeline` code block in `week` or `month` mode can now show neighboring periods around the current one, using the new `before` and `after` options: `before: 1` with `after: 1` in week mode renders the previous, current and next week together.
+
 ### Bug Fixes
 
 - Navigation block rows — including the custom-interval list in a view — now render `{{note_name}}` and `{{title}}`. A row shows the name of the note it opens, or the name that note would get for a period whose note does not exist yet.

--- a/README.md
+++ b/README.md
@@ -303,6 +303,18 @@ Supports following settings:
 - `shelf` - limits the displayed notes to a specific shelf. Without it, the shelf holding the current journal is used.
 - `weeks` - where the week-number column appears. Supported values are - `default`, `left`, `right`, `none`. `default` follows the plugin's calendar setting.
 - `hiddenWeekdays` - hides the listed days of the week, where `0` is Sunday and `6` is Saturday, e.g. `[0, 6]` to drop weekends.
+- `before` - adds this many earlier periods above the current one. Applies to the `week` and `month` modes only.
+- `after` - adds this many later periods below the current one. Applies to the `week` and `month` modes only.
+
+To see the previous and next week alongside the current one:
+
+````markdown
+```calendar-timeline
+mode: week
+before: 1
+after: 1
+```
+````
 
 Sample week timeline
 

--- a/docs/manual-testing-checklist.md
+++ b/docs/manual-testing-checklist.md
@@ -604,6 +604,14 @@ preview.
 - [x] timeline **hiddenWeekdays** with an out-of-range entry → the valid entries
       still apply, the block does not error.
 - [x] **shelf** option → scopes the timeline to that shelf.
+- [ ] timeline **mode: week** with **before: 1** and **after: 1** → the previous,
+      current and next week render stacked in that order.
+- [ ] timeline **mode: month** with **before: 1** → the previous month renders
+      above the current one.
+- [ ] timeline **before/after** under **mode: quarter** or **mode: calendar** →
+      ignored, and the block does not report an unrecognized option.
+- [ ] timeline **before: -1** or a non-numeric **after** → treated as unset, the
+      block does not error.
 
 ### Reference help
 

--- a/messages/de.json
+++ b/messages/de.json
@@ -1946,6 +1946,8 @@
 	"journal_edit_code_block_timeline_option_shelf": "beschränkt die angezeigten Notizen auf ein bestimmtes Regal. Ohne diese Option wird das Regal des aktuellen Journals verwendet.",
 	"journal_edit_code_block_timeline_weeks": "steuert die Spalte mit den Wochennummern. Unterstützte Werte: default, left, right, none. Der Wert default folgt der Kalendereinstellung des Plugins.",
 	"journal_edit_code_block_timeline_hidden_weekdays": "blendet die aufgelisteten Wochentage aus (0 = Sonntag … 6 = Samstag), z. B. [0, 6], um Wochenenden auszulassen.",
+	"journal_edit_code_block_timeline_option_before": "fügt so viele frühere Zeiträume oberhalb des aktuellen hinzu. Gilt nur für die Modi week und month.",
+	"journal_edit_code_block_timeline_option_after": "fügt so viele spätere Zeiträume unterhalb des aktuellen hinzu. Gilt nur für die Modi week und month.",
 	"journal_edit_code_block_home_description": "Der Home-Block zeigt Links zu den aktuellen Notizen in deinen Journalen an.",
 	"journal_edit_code_block_home_default": "Standardmäßig sieht es so aus:",
 	"journal_edit_code_block_home_options_lead": "Unterstützte Optionen:",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1394,6 +1394,8 @@
   "journal_edit_code_block_timeline_option_shelf": "limits the displayed notes to a specific shelf. Without it, the shelf holding the current journal is used.",
   "journal_edit_code_block_timeline_weeks": "controls the week-number column. Supported values: default, left, right, none. The value default follows the plugin’s calendar setting.",
   "journal_edit_code_block_timeline_hidden_weekdays": "hides the listed days of the week (0 = Sunday … 6 = Saturday), e.g. [0, 6] to drop weekends.",
+  "journal_edit_code_block_timeline_option_before": "adds this many earlier periods above the current one. Applies to the week and month modes only.",
+  "journal_edit_code_block_timeline_option_after": "adds this many later periods below the current one. Applies to the week and month modes only.",
   "journal_edit_code_block_home_description": "The home block displays links to the current notes in your journals.",
   "journal_edit_code_block_home_default": "By default it looks like this:",
   "journal_edit_code_block_home_options_lead": "Supported options:",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1936,6 +1936,8 @@
 	"journal_edit_code_block_timeline_option_shelf": "limita las notas mostradas a un estante específico. Sin esta opción, se usa el estante que contiene el diario actual.",
 	"journal_edit_code_block_timeline_weeks": "controla la columna del número de semana. Valores compatibles: default, left, right, none. El valor default sigue la configuración de calendario del complemento.",
 	"journal_edit_code_block_timeline_hidden_weekdays": "oculta los días de la semana indicados (0 = domingo … 6 = sábado), por ejemplo [0, 6] para omitir los fines de semana.",
+	"journal_edit_code_block_timeline_option_before": "añade esta cantidad de periodos anteriores encima del actual. Solo se aplica a los modos week y month.",
+	"journal_edit_code_block_timeline_option_after": "añade esta cantidad de periodos posteriores debajo del actual. Solo se aplica a los modos week y month.",
 	"journal_edit_code_block_home_description": "El bloque de inicio muestra enlaces a las notas actuales de tus diarios.",
 	"journal_edit_code_block_home_default": "Por defecto se ve así:",
 	"journal_edit_code_block_home_options_lead": "Opciones compatibles:",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1953,6 +1953,8 @@
 	"journal_edit_code_block_timeline_option_shelf": "limite les notes affichées à une étagère spécifique. Sans cette option, l’étagère contenant le journal actuel est utilisée.",
 	"journal_edit_code_block_timeline_weeks": "contrôle la colonne du numéro de semaine. Valeurs prises en charge : default, left, right, none. La valeur default suit le réglage de calendrier du plugin.",
 	"journal_edit_code_block_timeline_hidden_weekdays": "masque les jours de la semaine listés (0 = dimanche … 6 = samedi), par exemple [0, 6] pour supprimer les week-ends.",
+	"journal_edit_code_block_timeline_option_before": "ajoute autant de périodes précédentes au-dessus de la période actuelle. S’applique uniquement aux modes week et month.",
+	"journal_edit_code_block_timeline_option_after": "ajoute autant de périodes suivantes en dessous de la période actuelle. S’applique uniquement aux modes week et month.",
 	"journal_edit_code_block_home_description": "Le bloc d’accueil affiche des liens vers les notes actuelles de vos journaux.",
 	"journal_edit_code_block_home_default": "Par défaut, cela ressemble à ceci :",
 	"journal_edit_code_block_home_options_lead": "Options prises en charge :",

--- a/messages/it.json
+++ b/messages/it.json
@@ -1944,6 +1944,8 @@
 	"journal_edit_code_block_timeline_option_shelf": "limita le note visualizzate a uno scaffale specifico. Senza questa opzione viene usato lo scaffale che contiene il diario corrente.",
 	"journal_edit_code_block_timeline_weeks": "controlla la colonna del numero della settimana. Valori supportati: default, left, right, none. Il valore default segue l'impostazione del calendario del plugin.",
 	"journal_edit_code_block_timeline_hidden_weekdays": "nasconde i giorni della settimana elencati (0 = domenica … 6 = sabato), ad esempio [0, 6] per escludere i fine settimana.",
+	"journal_edit_code_block_timeline_option_before": "aggiunge questo numero di periodi precedenti sopra quello corrente. Si applica solo alle modalità week e month.",
+	"journal_edit_code_block_timeline_option_after": "aggiunge questo numero di periodi successivi sotto quello corrente. Si applica solo alle modalità week e month.",
 	"journal_edit_code_block_home_description": "Il blocco home mostra i collegamenti alle note correnti dei tuoi diari.",
 	"journal_edit_code_block_home_default": "Per impostazione predefinita si presenta così:",
 	"journal_edit_code_block_home_options_lead": "Opzioni supportate:",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1747,6 +1747,8 @@
 	"journal_edit_code_block_timeline_option_shelf": "表示するノートを特定の棚に限定します。指定しない場合は、現在のジャーナルが属する棚が使われます。",
 	"journal_edit_code_block_timeline_weeks": "週番号の列を制御します。サポートされている値: default、left、right、none。値 default はプラグインのカレンダー設定に従います。",
 	"journal_edit_code_block_timeline_hidden_weekdays": "リストされている曜日を非表示にします（0 = 日曜日 … 6 = 土曜日）。たとえば、[0, 6] は週末を非表示にします。",
+	"journal_edit_code_block_timeline_option_before": "現在の期間の上に、指定した数だけ前の期間を追加します。week と month モードでのみ有効です。",
+	"journal_edit_code_block_timeline_option_after": "現在の期間の下に、指定した数だけ後の期間を追加します。week と month モードでのみ有効です。",
 	"journal_edit_code_block_home_description": "ホームブロックには、各ジャーナルの現在のノートへのリンクが表示されます。",
 	"journal_edit_code_block_home_default": "デフォルトでは次のように表示されます:",
 	"journal_edit_code_block_home_options_lead": "サポートされているオプション:",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1936,6 +1936,8 @@
 	"journal_edit_code_block_timeline_option_shelf": "표시되는 노트를 특정 선반으로 제한합니다. 지정하지 않으면 현재 저널이 놓인 선반을 사용합니다.",
 	"journal_edit_code_block_timeline_weeks": "주 번호 열을 제어합니다. 지원되는 값: default, left, right, none. default는 플러그인의 달력 설정을 따릅니다.",
 	"journal_edit_code_block_timeline_hidden_weekdays": "나열한 요일(0 = 일요일 … 6 = 토요일)을 숨깁니다. 예를 들어 주말을 빼려면 [0, 6]을 씁니다.",
+	"journal_edit_code_block_timeline_option_before": "현재 기간 위에 지정한 수만큼 이전 기간을 추가합니다. week 및 month 모드에서만 적용됩니다.",
+	"journal_edit_code_block_timeline_option_after": "현재 기간 아래에 지정한 수만큼 이후 기간을 추가합니다. week 및 month 모드에서만 적용됩니다.",
 	"journal_edit_code_block_home_description": "홈 블록은 저널의 현재 노트로 연결되는 링크를 표시합니다.",
 	"journal_edit_code_block_home_default": "기본적으로는 다음과 같습니다:",
 	"journal_edit_code_block_home_options_lead": "지원되는 옵션:",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1944,6 +1944,8 @@
 	"journal_edit_code_block_timeline_option_shelf": "limita as notas exibidas a uma prateleira específica. Sem essa opção, é usada a prateleira que contém o diário atual.",
 	"journal_edit_code_block_timeline_weeks": "controla a coluna do número da semana. Valores suportados: default, left, right, none. O valor default segue a configuração de calendário do plugin.",
 	"journal_edit_code_block_timeline_hidden_weekdays": "oculta os dias da semana listados (0 = domingo … 6 = sábado), por exemplo, [0, 6] para excluir os fins de semana.",
+	"journal_edit_code_block_timeline_option_before": "adiciona esta quantidade de períodos anteriores acima do atual. Aplica-se apenas aos modos week e month.",
+	"journal_edit_code_block_timeline_option_after": "adiciona esta quantidade de períodos posteriores abaixo do atual. Aplica-se apenas aos modos week e month.",
 	"journal_edit_code_block_home_description": "O bloco inicial exibe links para as notas atuais nos seus diários.",
 	"journal_edit_code_block_home_default": "Por padrão, a aparência é esta:",
 	"journal_edit_code_block_home_options_lead": "Opções suportadas:",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -1995,6 +1995,8 @@
 	"journal_edit_code_block_timeline_option_shelf": "ограничивает отображаемые заметки определённой полкой. Без этого параметра используется полка, содержащая текущий журнал.",
 	"journal_edit_code_block_timeline_weeks": "управляет столбцом с номером недели. Поддерживаемые значения: default, left, right, none. Значение default следует настройке календаря в плагине.",
 	"journal_edit_code_block_timeline_hidden_weekdays": "скрывает перечисленные дни недели (0 = воскресенье … 6 = суббота), например, [0, 6] для удаления выходных.",
+	"journal_edit_code_block_timeline_option_before": "добавляет указанное количество предыдущих периодов над текущим. Применяется только к режимам week и month.",
+	"journal_edit_code_block_timeline_option_after": "добавляет указанное количество следующих периодов под текущим. Применяется только к режимам week и month.",
 	"journal_edit_code_block_home_description": "Блок home отображает ссылки на текущие заметки в ваших журналах.",
 	"journal_edit_code_block_home_default": "По умолчанию это выглядит так:",
 	"journal_edit_code_block_home_options_lead": "Поддерживаемые параметры:",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -1794,6 +1794,8 @@
 	"journal_edit_code_block_timeline_option_shelf": "обмежує відображувані нотатки певною полицею. Без цієї опції використовується полиця, що містить поточний журнал.",
 	"journal_edit_code_block_timeline_weeks": "керує стовпцем номера тижня. Підтримувані значення: default, left, right, none. Значення default відповідає налаштуванню календаря в плагіні.",
 	"journal_edit_code_block_timeline_hidden_weekdays": "приховує перелічені дні тижня (0 = неділя … 6 = субота), наприклад, [0, 6], щоб видалити вихідні.",
+	"journal_edit_code_block_timeline_option_before": "додає вказану кількість попередніх періодів над поточним. Застосовується лише до режимів week і month.",
+	"journal_edit_code_block_timeline_option_after": "додає вказану кількість наступних періодів під поточним. Застосовується лише до режимів week і month.",
 	"journal_edit_code_block_home_description": "У блоці «Головна» відображаються посилання на поточні нотатки у ваших журналах.",
 	"journal_edit_code_block_home_default": "За замовчуванням це виглядає так:",
 	"journal_edit_code_block_home_options_lead": "Підтримувані опції:",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1747,6 +1747,8 @@
 	"journal_edit_code_block_timeline_option_shelf": "将显示的笔记限制在特定书架上。不设置时，使用包含当前日记的书架。",
 	"journal_edit_code_block_timeline_weeks": "控制周数列。支持的值：default、left、right、none。值 default 跟随插件的日历设置。",
 	"journal_edit_code_block_timeline_hidden_weekdays": "隐藏列出的星期几（0 = 星期日 … 6 = 星期六），例如 [0, 6] 表示去掉周末。",
+	"journal_edit_code_block_timeline_option_before": "在当前时段上方添加指定数量的更早时段。仅适用于 week 和 month 模式。",
+	"journal_edit_code_block_timeline_option_after": "在当前时段下方添加指定数量的更晚时段。仅适用于 week 和 month 模式。",
 	"journal_edit_code_block_home_description": "主页块显示指向您日记中当前笔记的链接。",
 	"journal_edit_code_block_home_default": "默认情况下，它看起来像这样：",
 	"journal_edit_code_block_home_options_lead": "支持的选项：",

--- a/scripts/check-i18n-glossary.mjs
+++ b/scripts/check-i18n-glossary.mjs
@@ -251,6 +251,8 @@ const LITERALS = [
   { key: "journal_edit_code_block_home_option_scale", contains: ["scale:"] },
   { key: "journal_edit_code_block_timeline_option_mode", contains: ["week", "month", "quarter", "calendar"] },
   { key: "journal_edit_code_block_timeline_weeks", contains: ["default", "left", "right", "none"] },
+  { key: "journal_edit_code_block_timeline_option_before", contains: ["week", "month"] },
+  { key: "journal_edit_code_block_timeline_option_after", contains: ["week", "month"] },
   { key: "code_blocks_home_empty", contains: ["show", "shelf"] },
   // The "Supported units" list under `<startOf=unit>` — each row IS the token the
   // user types. Nine of ten locales had translated them ("<startOf=Jahr>").

--- a/src/code-blocks/timeline/timeline-config.test.ts
+++ b/src/code-blocks/timeline/timeline-config.test.ts
@@ -71,6 +71,33 @@ describe("timelineBlockSchema", () => {
     expect(result.shelf).toBe("2024");
   });
 
+  describe.each(["before", "after"] as const)("%s padding", (key) => {
+    it("accepts a positive count", () => {
+      const result = v.parse(timelineBlockSchema, { [key]: 2 });
+      expect(result[key]).toBe(2);
+    });
+
+    it("accepts zero", () => {
+      const result = v.parse(timelineBlockSchema, { [key]: 0 });
+      expect(result[key]).toBe(0);
+    });
+
+    it("treats a negative count as unset", () => {
+      const result = v.parse(timelineBlockSchema, { [key]: -1 });
+      expect(result[key]).toBeUndefined();
+    });
+
+    it("treats a fractional count as unset", () => {
+      const result = v.parse(timelineBlockSchema, { [key]: 1.5 });
+      expect(result[key]).toBeUndefined();
+    });
+
+    it("treats a non-numeric count as unset", () => {
+      const result = v.parse(timelineBlockSchema, { [key]: "two" });
+      expect(result[key]).toBeUndefined();
+    });
+  });
+
   it("infers TimelineMode as the mode union", () => {
     expectTypeOf<TimelineMode>().toEqualTypeOf<"week" | "month" | "quarter" | "calendar">();
   });
@@ -81,6 +108,8 @@ describe("timelineBlockSchema", () => {
       shelf?: string | undefined;
       weeks?: "default" | "none" | "left" | "right" | undefined;
       hiddenWeekdays?: number[] | undefined;
+      before?: number | undefined;
+      after?: number | undefined;
     }>();
   });
 });

--- a/src/code-blocks/timeline/timeline-config.ts
+++ b/src/code-blocks/timeline/timeline-config.ts
@@ -26,6 +26,10 @@ function isWeekdayIndex(value: unknown): value is number {
   return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 && value <= 6;
 }
 
+function asPadding(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
 const timelineBlockEntries = {
   // Every key degrades rather than erroring: a typo in one option must not blank the whole
   // block into an error panel, which is the rule the home fence follows and mode already did.
@@ -40,6 +44,10 @@ const timelineBlockEntries = {
     v.optional(v.unknown()),
     v.transform((value) => (Array.isArray(value) ? value.filter(isWeekdayIndex) : undefined)),
   ),
+  // Padding applies to the week and month modes only — quarter and calendar never receive
+  // it, so a value set under them is inert rather than reported as an unrecognized key.
+  before: v.pipe(v.optional(v.unknown()), v.transform(asPadding)),
+  after: v.pipe(v.optional(v.unknown()), v.transform(asPadding)),
 };
 
 export const timelineBlockSchema = v.pipe(v.unknown(), v.transform(asRecord), v.object(timelineBlockEntries));

--- a/src/code-blocks/timeline/ui/TimelineCodeBlock.isolated.test.ts
+++ b/src/code-blocks/timeline/ui/TimelineCodeBlock.isolated.test.ts
@@ -47,6 +47,18 @@ function mount(h: NotesCalendarHarness, props: { path: VaultPath; config: Timeli
   });
 }
 
+function dailyHarness() {
+  const h = buildNotesCalendarHarness({ journals: { daily: fixedJournal("daily", { type: "day" }) } });
+  h.index.register({ journalName: "daily", anchor: HOST_ANCHOR, path: HOST_PATH });
+  return h;
+}
+
+function weekAnchors(container: Element): string[] {
+  return [...container.querySelectorAll<HTMLElement>('[data-testid="week-number-cell"]')].map(
+    (cell) => cell.dataset.anchor ?? "",
+  );
+}
+
 afterEach(() => {
   cleanup();
   vi.useRealTimers();
@@ -216,6 +228,52 @@ describe("TimelineCodeBlock", () => {
 
       const row = container.querySelector<HTMLElement>(".notes-week-view__row");
       expect(row?.dataset.weeks).toBe("right");
+    });
+  });
+
+  describe("period padding", () => {
+    it("renders only the host week when no padding is set", () => {
+      const { container } = mount(dailyHarness(), { path: HOST_PATH, config: { mode: "week" } });
+
+      expect(weekAnchors(container).length).toBe(1);
+    });
+
+    it("renders the padded weeks in order around the host week", () => {
+      const bare = mount(dailyHarness(), { path: HOST_PATH, config: { mode: "week" } });
+      const hostWeek = weekAnchors(bare.container).at(0);
+
+      const padded = mount(dailyHarness(), { path: HOST_PATH, config: { mode: "week", before: 1, after: 1 } });
+
+      const anchors = weekAnchors(padded.container);
+      expect(anchors.length).toBe(3);
+      expect(anchors.at(1)).toBe(hostWeek);
+      expect(anchors.toSorted()).toEqual(anchors);
+    });
+
+    it("pads only forward when before is absent", () => {
+      const { container } = mount(dailyHarness(), { path: HOST_PATH, config: { mode: "week", after: 2 } });
+
+      const anchors = weekAnchors(container);
+      expect(anchors.length).toBe(3);
+      expect(anchors.at(0)).toBe(weekAnchors(mount(dailyHarness(), { path: HOST_PATH, config: {} }).container).at(0));
+    });
+
+    it("renders a run of month grids when the month mode is padded", () => {
+      const { container } = mount(dailyHarness(), {
+        path: HOST_PATH,
+        config: { mode: "month", before: 1, after: 1 },
+      });
+
+      expect(container.querySelectorAll(".notes-month-view__grid").length).toBe(3);
+    });
+
+    it("ignores padding in quarter mode", () => {
+      const bare = mount(dailyHarness(), { path: HOST_PATH, config: { mode: "quarter" } });
+      const padded = mount(dailyHarness(), { path: HOST_PATH, config: { mode: "quarter", before: 1, after: 1 } });
+
+      expect(padded.container.querySelectorAll(".notes-month-view__grid").length).toBe(
+        bare.container.querySelectorAll(".notes-month-view__grid").length,
+      );
     });
   });
 

--- a/src/code-blocks/timeline/ui/TimelineCodeBlock.vue
+++ b/src/code-blocks/timeline/ui/TimelineCodeBlock.vue
@@ -74,12 +74,16 @@ const weekPlacement = useResolvedWeekPlacement(() => config.weeks);
 </script>
 
 <template>
+  <!-- Only the week and month modes take padding; quarter and calendar never receive it,
+       so a `before`/`after` set under them is inert by construction. -->
   <TimelineWeek
     v-if="mode === 'week'"
     :ref-date="refDate"
     :shelf="shelf"
     :weeks="weekPlacement"
     :hidden-weekdays="config.hiddenWeekdays"
+    :before="config.before"
+    :after="config.after"
   />
   <TimelineMonth
     v-else-if="mode === 'month'"
@@ -87,6 +91,8 @@ const weekPlacement = useResolvedWeekPlacement(() => config.weeks);
     :shelf="shelf"
     :weeks="weekPlacement"
     :hidden-weekdays="config.hiddenWeekdays"
+    :before="config.before"
+    :after="config.after"
   />
   <TimelineQuarter
     v-else-if="mode === 'quarter'"

--- a/src/code-blocks/timeline/ui/TimelineMonth.vue
+++ b/src/code-blocks/timeline/ui/TimelineMonth.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { computed } from "vue";
-
-import { CalendarDate, MonthPeriod, type AnchorString } from "@/calendar";
+import type { AnchorString } from "@/calendar";
+import { usePeriodWindow } from "@/calendar/ui";
 import { NotesMonthView } from "@/notes-calendar";
 
 const props = defineProps<{
@@ -9,23 +8,40 @@ const props = defineProps<{
   shelf: string | null;
   weeks?: "none" | "left" | "right";
   hiddenWeekdays?: readonly number[];
+  before?: number;
+  after?: number;
 }>();
 
-const month = computed(() => MonthPeriod.containing(CalendarDate.fromAnchor(props.refDate)));
+const monthPeriods = usePeriodWindow(
+  "month",
+  () => props.refDate,
+  () => props.before ?? 0,
+  () => props.after ?? 0,
+);
 </script>
 
 <template>
   <div class="timeline-month">
     <!-- Adjacent-month days stay actionable: a leading/trailing day can open that day's
          note. Quarter/calendar modes blank them instead. -->
-    <NotesMonthView :shelf :month :weeks="weeks" :hidden-weekdays="hiddenWeekdays" outside-dates="active" />
+    <NotesMonthView
+      v-for="month of monthPeriods"
+      :key="month.start.toAnchor()"
+      :shelf
+      :month
+      :weeks="weeks"
+      :hidden-weekdays="hiddenWeekdays"
+      outside-dates="active"
+    />
   </div>
 </template>
 
 <style scoped>
 .timeline-month {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--size-4-2);
 }
 .timeline-month > * {
   width: 400px;

--- a/src/code-blocks/timeline/ui/TimelineWeek.vue
+++ b/src/code-blocks/timeline/ui/TimelineWeek.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { computed } from "vue";
-
-import { CalendarDate, WeekPeriod, type AnchorString } from "@/calendar";
+import type { AnchorString } from "@/calendar";
+import { usePeriodWindow } from "@/calendar/ui";
 import { NotesWeekView } from "@/notes-calendar";
 
 const props = defineProps<{
@@ -9,21 +8,37 @@ const props = defineProps<{
   shelf: string | null;
   weeks?: "none" | "left" | "right";
   hiddenWeekdays?: readonly number[];
+  before?: number;
+  after?: number;
 }>();
 
-const week = computed(() => WeekPeriod.containing(CalendarDate.fromAnchor(props.refDate)));
+const weekPeriods = usePeriodWindow(
+  "week",
+  () => props.refDate,
+  () => props.before ?? 0,
+  () => props.after ?? 0,
+);
 </script>
 
 <template>
   <div class="timeline-week">
-    <NotesWeekView :shelf :week :weeks="weeks" :hidden-weekdays="hiddenWeekdays" />
+    <NotesWeekView
+      v-for="week of weekPeriods"
+      :key="week.start.toAnchor()"
+      :shelf
+      :week
+      :weeks="weeks"
+      :hidden-weekdays="hiddenWeekdays"
+    />
   </div>
 </template>
 
 <style scoped>
 .timeline-week {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--size-4-2);
 }
 .timeline-week > * {
   width: 400px;

--- a/src/journals/settings/ui/CodeBlockReferenceModal.vue
+++ b/src/journals/settings/ui/CodeBlockReferenceModal.vue
@@ -46,6 +46,8 @@ const customHomeBody = `show:\n  - day\n  - month\nscale: 2\nseparator: " | "`;
         <li><code>shelf</code> — {{ m.journal_edit_code_block_timeline_option_shelf() }}</li>
         <li><code>weeks</code> — {{ m.journal_edit_code_block_timeline_weeks() }}</li>
         <li><code>hiddenWeekdays</code> — {{ m.journal_edit_code_block_timeline_hidden_weekdays() }}</li>
+        <li><code>before</code> — {{ m.journal_edit_code_block_timeline_option_before() }}</li>
+        <li><code>after</code> — {{ m.journal_edit_code_block_timeline_option_after() }}</li>
       </ul>
       <p>{{ m.journal_edit_code_block_timeline_mode_lead() }}</p>
       <CodeBlockSnippet name="calendar-timeline" body="mode: month" />


### PR DESCRIPTION
Closes #53.

The `calendar-timeline` code block rendered exactly one week or month around the host note's anchor. Two new options render a run of neighboring periods instead:

````markdown
```calendar-timeline
mode: week
before: 1
after: 1
```
````

→ the previous, current and next week, stacked in that order.

## Notes

- **Week and month modes only.** `usePeriodWindow` — the helper the journal view's own calendar blocks already use for this — is typed for `"week" | "month"`, and that matches what was promised on the issue in 2024. Quarter and calendar never receive the props, so a value set under them is inert by construction rather than by a runtime check.
- **Both keys degrade rather than error**, following the rule already stated in `timelineBlockEntries`: a negative, fractional or non-numeric value parses to unset instead of blanking the block into an error panel.
- **`weeks` was already taken** — it means week-*number placement* (`left`/`right`/`none`) — hence `before`/`after`, which also matches the view blocks' naming.
- **Zero-padding is byte-identical to before**: `periodOfKind("week", d)` is literally `WeekPeriod.containing(d)`, so an existing block with no padding renders exactly as it did.
- The view blocks' `before`/`after` are *required* integers while these are optional-with-degrade. That asymmetry is intentional — a persisted view config is written by a form, a fence is typed by hand.

## Verification

`compile:i18n` → `check:i18n` → `check:types` → `test` (3633 passing) → `check:lint` all clean; `build` succeeds.

New tests, written before the implementation:

- `timeline-config.test.ts` — both keys accept a count and degrade on negative, fractional and non-numeric input.
- `TimelineCodeBlock.isolated.test.ts` — padded weeks render in chronological order around the host week (asserted on the week cells' `data-anchor`, so it checks *which* weeks, not just how many), month mode renders a run of grids, and quarter mode is unchanged by padding.

Manual checklist entries added but not yet run — the four new `calendar-timeline` lines are left unchecked.
