### PR TITLE
test(e2e): cover the multi-journal pick, and run the PR gate on every OS

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,11 +18,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # PR + merge run a single fast combo (Linux, latest app on latest installer).
-        # Nightly widens to every OS and to the floor + the newest-app/oldest-installer
-        # mismatch, re-confirming latest/latest across platforms too (see
-        # docs/e2e-testing-strategy.md).
-        os: ${{ (github.event_name == 'schedule') && fromJSON('["ubuntu-latest", "windows-latest", "macos-latest"]') || fromJSON('["ubuntu-latest"]') }}
+        # PR + merge run latest/latest on every OS: the host differences that break this
+        # plugin are platform-shaped (native vs DOM menus, path separators, popout focus)
+        # and a Linux-only gate cannot see them. Nightly adds the version axis — the floor
+        # and the newest-app/oldest-installer mismatch (see docs/e2e-testing-strategy.md).
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         obsidian: ${{ (github.event_name == 'schedule') && fromJSON('["earliest/earliest", "latest/earliest", "latest/latest"]') || fromJSON('["latest/latest"]') }}
 
     runs-on: ${{ matrix.os }}
@@ -32,9 +32,11 @@ jobs:
       pull-requests: write
     env:
       OBSIDIAN_VERSIONS: ${{ matrix.obsidian }}
-      # PR + merge run the full set of stable suites. Nightly (empty -> bare glob)
-      # additionally picks up the non-blocking `quarantine` lane.
-      WDIO_SUITES: ${{ (github.event_name == 'schedule') && '' || '--suite smoke --suite integration --suite migration --suite interop --suite journeys' }}
+      # PR + merge run the stable suites; nightly adds the non-blocking `quarantine` lane.
+      # Named explicitly rather than falling back to the bare glob: `A && '' || B` yields B
+      # in a GitHub expression, because the empty string is falsy — the old form silently
+      # gave every run the same list, so quarantine had never run.
+      WDIO_SUITES: ${{ (github.event_name == 'schedule') && '--suite smoke --suite integration --suite migration --suite interop --suite journeys --suite quarantine' || '--suite smoke --suite integration --suite migration --suite interop --suite journeys' }}
 
     steps:
       - uses: actions/checkout@v7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,10 +108,12 @@ on it.
   on `menu-will-close` and delivers the pick over IPC an unbounded number of
   tasks later, so any "no pick by the time we hid" verdict fires on every pick.
   Obsidian defaults `nativeMenus` **on for macOS** (`null` config → `true`) and
-  off elsewhere, so this is invisible on Linux and Windows and untestable in
-  e2e. A menu whose result feeds a promise must call `setUseNativeMenu(false)`
-  — `WorkspaceService.pickFromMenu` does. Menus whose items only run side
-  effects (`openPathsMenu`) are order-independent and keep the host default.
+  off elsewhere, so this is invisible on Linux and Windows. A menu whose result
+  feeds a promise must call `setUseNativeMenu(false)` —
+  `WorkspaceService.pickFromMenu` does. Menus whose items only run side effects
+  (`openPathsMenu`) are order-independent and keep the host default. e2e pins the
+  DOM rendering suite-wide and reproduces the native one on demand; see the menu
+  section of [`docs/e2e-testing-strategy.md`](docs/e2e-testing-strategy.md).
 - `focusLeaf` calls `app.setting.close()`, and `setViewState({ active: true })`
   reaches it. `revealLeaf()` alone does not, so a leaf placed as a side effect
   of a settings interaction is placed then revealed, never activated.

--- a/docs/e2e-testing-strategy.md
+++ b/docs/e2e-testing-strategy.md
@@ -172,6 +172,24 @@ integration --suite migration --suite interop --suite journeys`), omitting
 - **Trigger via `executeCommandById` for A/C** (deterministic, outcome is the
   point); **trigger via real UI clicks for B** (the click path is the point).
 
+#### Menus render two ways
+
+Obsidian's `Menu` is a DOM node on Linux and Windows and an Electron/OS menu on
+macOS, where the `nativeMenus` config defaults on. The native rendering puts
+nothing in the document, so a `.menu-item-title` assertion cannot fail
+informatively — it reads as "menu did not open" whatever actually broke.
+
+`wdio.conf.mts` therefore pins the DOM rendering before every test, so a menu
+spec means the same thing on every OS. A spec that needs the _native_ path opts
+in with `e2e/support/native-menu.ts`, which flips the static and swaps Electron's
+`buildFromTemplate` for a capture — on any OS, so the macOS-only behavior is
+reproducible on the Linux PR gate. The capture also replays the ordering that
+makes the native menu different: it closes first and delivers the pick
+afterwards, the reverse of the DOM menu. Anything that resolves a promise on the
+pick and cancels on the close must be tested through it
+(`e2e/journeys/multi-journal-pick.e2e.ts` is the worked example, and issue #238
+is what it costs to skip).
+
 ### Waiting and flakiness budget
 
 e2e is a **PR + merge gate**, so flakiness discipline is defined up front:
@@ -271,13 +289,14 @@ Each entry is an `(appVersion, installerVersion)` pair (see Install and version
 modes). `appVersion: earliest` resolves the manifest's `minAppVersion`;
 `installerVersion: earliest` resolves to the **oldest installer still compatible
 with that app version** — so `latest/earliest` is always a real, bootable combo,
-never an impossible one. The PR/merge fast path runs one combo on Linux; nightly
-multiplies the version combos below by the OS matrix (Windows / macOS / Linux).
+never an impossible one. **OS is the PR axis, version is the nightly axis**: the
+host differences that break this plugin are platform-shaped (menu rendering, path
+separators, popout focus) and a single-OS gate cannot see them, so PR and merge
+run `latest/latest` on all three. Nightly multiplies that by the version combos.
 
 | Clock      | OS              | appVersion | installerVersion | Catches                                                                                                                               |
 | ---------- | --------------- | ---------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| PR + merge | Linux           | `latest`   | `latest`         | the common, modern case — fast merge signal                                                                                           |
-| Nightly    | Win/macOS/Linux | `latest`   | `latest`         | the modern case re-confirmed on every OS                                                                                              |
+| PR + merge | Win/macOS/Linux | `latest`   | `latest`         | the common, modern case, on every host — fast merge signal                                                                            |
 | Nightly    | Win/macOS/Linux | `earliest` | `earliest`       | a contract test, not a real user — proves the advertised `minAppVersion` floor isn't a lie                                            |
 | Nightly    | Win/macOS/Linux | `latest`   | `earliest`       | **the common real user**: Obsidian auto-updates the app but not the installer, so a long-time user runs today's JS on an old Electron |
 

--- a/docs/e2e-testing-strategy.md
+++ b/docs/e2e-testing-strategy.md
@@ -182,16 +182,23 @@ macOS, where the `nativeMenus` config defaults on. The native rendering puts
 nothing in the document, so a `.menu-item-title` assertion cannot fail
 informatively — it reads as "menu did not open" whatever actually broke.
 
-`wdio.conf.mts` therefore pins the DOM rendering before every test, so a menu
-spec means the same thing on every OS. A spec that needs the _native_ path opts
-in with `e2e/support/native-menu.ts`, which flips the static and swaps Electron's
-`buildFromTemplate` for a capture — on any OS, so the macOS-only behavior is
-reproducible on the Linux PR gate. The capture also replays the ordering that
-makes the native menu different: it closes first and delivers the pick
-afterwards, the reverse of the DOM menu. Anything that resolves a promise on the
-pick and cancels on the close must be tested through it
-(`e2e/journeys/multi-journal-pick.e2e.ts` is the worked example, and issue #238
-is what it costs to skip).
+`wdio.conf.mts` therefore pins the DOM rendering before every test, so an
+ordinary menu spec means the same thing on every OS and a macOS failure is a
+finding rather than an artifact.
+
+A spec that needs the _native_ path opts in with `e2e/support/native-menu.ts`,
+which flips Obsidian's static and swaps Electron's `buildFromTemplate` for a
+capture. That is not a simulation — it is the real native branch of
+`showAtPosition`, with only the OS popup replaced by something WebDriver can
+read. Because it works on any OS, macOS-only behavior is reproducible on the
+Linux PR gate.
+
+The capture also replays what makes the native menu different: it closes first
+and delivers the pick afterwards, the reverse of the DOM menu. **Anything whose
+result is a value — a promise the pick resolves and the close would cancel —
+must be tested under both orderings**, because the two disagree about what a
+close means. `e2e/journeys/multi-journal-pick.e2e.ts` is the worked example, one
+test per ordering; issue #238 is what it costs to cover only one.
 
 ### Waiting and flakiness budget
 

--- a/docs/e2e-testing-strategy.md
+++ b/docs/e2e-testing-strategy.md
@@ -126,8 +126,11 @@ Obsidian.
 
   **PR and merge-to-main** name every stable suite (`--suite smoke --suite
 integration --suite migration --suite interop --suite journeys`), omitting
-  `quarantine`. **Nightly** runs the bare glob — all suites, including
-  `quarantine` — across the OS + version matrix. Quarantining a flaky test = moving
+  `quarantine`. **Nightly** names those plus `--suite quarantine`, across the
+  version matrix. Both name their suites explicitly rather than letting nightly
+  fall through to the bare glob: `A && '' || B` yields `B` in a GitHub
+  expression, so the fall-through form silently gave every run the same list.
+  The bare glob remains a local-run convenience. Quarantining a flaky test = moving
   its file into the `quarantine` suite; it keeps running nightly and never blocks a
   merge — no separate mechanism needed.
 

--- a/e2e/fixtures/e2e-shelf-pick/.obsidian/plugins/journals/data.json
+++ b/e2e/fixtures/e2e-shelf-pick/.obsidian/plugins/journals/data.json
@@ -1,0 +1,56 @@
+{
+  "version": 4,
+  "journals": {
+    "work": {
+      "name": "work",
+      "write": { "type": "day" },
+      "folder": "work",
+      "timeline": { "start": "", "end": { "kind": "never" } },
+      "dateFormat": "YYYY-MM-DD",
+      "frontmatter": {
+        "dateField": "journal-date",
+        "startDateField": "journal-start-date",
+        "endDateField": "journal-end-date",
+        "addStartDate": false,
+        "addEndDate": false
+      },
+      "numbering": { "enabled": false, "anchorDate": "", "allowBefore": false, "sources": [] }
+    },
+    "personal": {
+      "name": "personal",
+      "write": { "type": "day" },
+      "folder": "personal",
+      "timeline": { "start": "", "end": { "kind": "never" } },
+      "dateFormat": "YYYY-MM-DD",
+      "frontmatter": {
+        "dateField": "journal-date",
+        "startDateField": "journal-start-date",
+        "endDateField": "journal-end-date",
+        "addStartDate": false,
+        "addEndDate": false
+      },
+      "numbering": { "enabled": false, "anchorDate": "", "allowBefore": false, "sources": [] }
+    }
+  },
+  "shelves": {
+    "office": { "name": "office", "journals": ["work"] },
+    "home": { "name": "home", "journals": ["personal"] }
+  },
+  "views": {
+    "d0cca100-0000-4000-8000-000000000001": {
+      "id": "d0cca100-0000-4000-8000-000000000001",
+      "name": "Calendar",
+      "icon": "calendar-days",
+      "defaultShelf": null,
+      "showInRibbon": true,
+      "leaf": "right",
+      "blocks": [
+        {
+          "id": "d0cca100-0000-4000-8000-000000000002",
+          "key": "month-calendar",
+          "config": { "before": 0, "after": 0, "hiddenWeekdays": [], "weeks": "left" }
+        }
+      ]
+    }
+  }
+}

--- a/e2e/journeys/multi-journal-pick.e2e.ts
+++ b/e2e/journeys/multi-journal-pick.e2e.ts
@@ -46,9 +46,13 @@ describe("multi-journal pick", () => {
 
     await calendar.cell(NATIVE_ANCHOR).click();
 
-    await browser.waitUntil(async () => (await nativeMenuLabels()).length > 0, {
-      timeoutMsg: "the journal pick menu did not reach Electron",
-    });
+    await browser.waitUntil(
+      async () => {
+        const captured = await nativeMenuLabels();
+        return captured.length > 0;
+      },
+      { timeoutMsg: "the journal pick menu did not reach Electron" },
+    );
     expect(await nativeMenuLabels()).toEqual([["work", "personal"]]);
 
     await pickNativeItem(0, 1);

--- a/e2e/journeys/multi-journal-pick.e2e.ts
+++ b/e2e/journeys/multi-journal-pick.e2e.ts
@@ -1,0 +1,65 @@
+import { $, browser, expect } from "@wdio/globals";
+
+import { forceNativeMenus, nativeMenuLabels, restoreMenus } from "../support/native-menu.js";
+import { closeAllLeaves, noteExists, waitForActiveNote, waitForJournalFrontmatter } from "../support/vault.js";
+
+import { dayAnchor } from "./decorations.js";
+import { calendar, openCalendarView } from "./view.js";
+
+// e2e-shelf-pick is issue #238's shape: two shelves, a day journal on each, and a calendar
+// scoped to all journals. Every day is then covered by two journals, so clicking one cannot
+// resolve to a single note and OpenDateFlow disambiguates through a menu at the pointer.
+//
+// That menu is the only one in the plugin whose *result* is a value — the picked name resolves
+// a promise, and the menu closing cancels it. Obsidian's native menu inverts those two: it
+// closes on Electron's "menu-will-close" and delivers the pick over IPC afterwards, so the pick
+// arrives after the cancel has already been decided and is discarded. Nothing is logged and no
+// note appears; on macOS, where `nativeMenus` defaults on, the calendar simply stopped creating
+// notes for any date more than one journal covered.
+//
+// forceNativeMenus() puts every OS on that footing (wdio.conf.mts otherwise pins the DOM
+// rendering suite-wide), so this holds the line everywhere rather than only on macOS. It runs
+// inside the test body, not a hook: the conf's per-test reset would undo a `before`.
+//
+// One test, not three — the assertions share a single open menu, and splitting them would let
+// the reset land between the click and the pick.
+const ANCHOR = dayAnchor(12);
+
+describe("multi-journal pick", () => {
+  before(async () => {
+    await browser.reloadObsidian({ vault: "./e2e/fixtures/e2e-shelf-pick", plugins: ["journals"] });
+    await openCalendarView();
+  });
+
+  after(async () => {
+    await restoreMenus();
+    await closeAllLeaves();
+  });
+
+  it("opens the journal picked from the disambiguation menu", async () => {
+    await forceNativeMenus();
+    expect(await noteExists(`personal/${ANCHOR}.md`)).toBe(false);
+
+    await calendar.cell(ANCHOR).click();
+
+    await $(".menu").waitForExist({
+      timeoutMsg: "the journal pick menu did not render in the document",
+    });
+    // A captured template means the menu went to Electron instead. Nothing can click it, and
+    // the pick it would eventually deliver lands after the flow has read the close as a cancel.
+    expect(await nativeMenuLabels()).toEqual([]);
+
+    const titles = await browser.execute(() =>
+      [...document.querySelectorAll(".menu-item-title")].map((el) => el.textContent ?? ""),
+    );
+    expect(titles).toEqual(["work", "personal"]);
+
+    // Pick the second entry: resolving the choice by name is what this proves, and a regression
+    // that silently took the first applicable journal would still pass on "work".
+    await $(".menu-item-title=personal").click();
+
+    await waitForActiveNote(`personal/${ANCHOR}.md`);
+    await waitForJournalFrontmatter(`personal/${ANCHOR}.md`, { journal: "personal", date: ANCHOR });
+    expect(await noteExists(`work/${ANCHOR}.md`)).toBe(false);
+  });
+});

--- a/e2e/support/errors.ts
+++ b/e2e/support/errors.ts
@@ -39,3 +39,17 @@ export class NoSpilloverDayError extends Error {
     this.name = "NoSpilloverDayError";
   }
 }
+
+export class NativeMenuUnavailableError extends Error {
+  constructor() {
+    super("electron.remote.Menu is unavailable, so native menus cannot be captured");
+    this.name = "NativeMenuUnavailableError";
+  }
+}
+
+export class NativeMenuItemMissingError extends Error {
+  constructor(menuIndex: number, itemIndex: number) {
+    super(`no clickable item at index ${String(itemIndex)} of captured native menu ${String(menuIndex)}`);
+    this.name = "NativeMenuItemMissingError";
+  }
+}

--- a/e2e/support/native-menu.ts
+++ b/e2e/support/native-menu.ts
@@ -1,0 +1,123 @@
+import { browser } from "@wdio/globals";
+
+import { NativeMenuItemMissingError, NativeMenuUnavailableError } from "./errors.js";
+
+// Obsidian's Menu has two renderings and only one of them is a DOM node. `nativeMenus`
+// defaults to on for macOS, and `showAtPosition` then hands the items to Electron:
+// `remote.Menu.buildFromTemplate(...)`, `M.on("menu-will-close", () => this.hide())`,
+// `M.popup(...)`. Nothing lands in the document, so every `.menu-item-title` assertion reads
+// as "menu did not open" — which is why the macOS lane failed wholesale rather than telling
+// anyone what broke.
+//
+// This module makes that path drivable, and drivable *anywhere*: it flips Obsidian's static
+// default so Linux and Windows take the native branch too, and swaps `buildFromTemplate` for
+// a capture, so the items arrive as data instead of an OS popup no WebDriver can click.
+//
+// The capture also preserves what makes the native menu different: Electron closes the menu
+// first and delivers the pick afterwards, the reverse of the DOM menu, which runs the item
+// callback and *then* hides. `pickNativeItem` replays that order, so a promise that resolves
+// on the pick and cancels on the close is exercised the way macOS exercises it.
+
+interface CapturedItem {
+  label?: string;
+  type?: string;
+  enabled?: boolean;
+  click?: (item: unknown, win: unknown, event: Record<string, unknown>) => void;
+}
+
+interface CapturedMenu {
+  template: CapturedItem[];
+  closers: (() => void)[];
+}
+
+interface Capture {
+  menus: CapturedMenu[];
+  original: unknown;
+  previousStatic: unknown;
+}
+
+interface RemoteMenu {
+  buildFromTemplate?: unknown;
+}
+
+interface CaptureWindow extends Window {
+  __journalsNativeMenuCapture?: Capture;
+  electron?: { remote?: { Menu?: RemoteMenu } };
+}
+
+// Flips every menu opened from here on to the native path and captures it instead of popping
+// it. Pair with `restoreMenus` in an `after` hook: the static is global, so a leaked override
+// would send Obsidian's own menus down the native path for the rest of the worker.
+export async function forceNativeMenus(): Promise<void> {
+  const installed = await browser.executeObsidian(({ obsidian }) => {
+    const win = window as CaptureWindow;
+    const MenuClass = (obsidian as unknown as { Menu: { useNativeMenu?: unknown } }).Menu;
+    const remoteMenu = win.electron?.remote?.Menu;
+    if (!remoteMenu) return false;
+
+    const capture: Capture = {
+      menus: [],
+      original: remoteMenu.buildFromTemplate,
+      previousStatic: MenuClass.useNativeMenu,
+    };
+    win.__journalsNativeMenuCapture = capture;
+
+    remoteMenu.buildFromTemplate = (template: CapturedItem[]) => {
+      const entry: CapturedMenu = { template, closers: [] };
+      capture.menus.push(entry);
+      return {
+        on: (event: string, callback: () => void) => {
+          if (event === "menu-will-close") entry.closers.push(callback);
+        },
+        popup() {
+          // The capture stands in for the OS popup, so there is nothing to show.
+        },
+      };
+    };
+    MenuClass.useNativeMenu = true;
+    return true;
+  });
+  if (!installed) throw new NativeMenuUnavailableError();
+}
+
+export async function restoreMenus(): Promise<void> {
+  await browser.executeObsidian(({ obsidian }) => {
+    const win = window as CaptureWindow;
+    const capture = win.__journalsNativeMenuCapture;
+    if (!capture) return;
+    const remoteMenu = win.electron?.remote?.Menu;
+    if (remoteMenu) remoteMenu.buildFromTemplate = capture.original;
+    (obsidian as unknown as { Menu: { useNativeMenu?: unknown } }).Menu.useNativeMenu = capture.previousStatic;
+    delete win.__journalsNativeMenuCapture;
+  });
+}
+
+// One label list per native menu opened since `forceNativeMenus`. Separators come through as
+// empty strings, so a test can still assert an item's position within its menu.
+export function nativeMenuLabels(): Promise<string[][]> {
+  return browser.execute(() => {
+    const capture = (window as CaptureWindow).__journalsNativeMenuCapture;
+    return (capture?.menus ?? []).map((menu) => menu.template.map((item) => item.label ?? ""));
+  });
+}
+
+// Picks an item the way Electron does: close first, then deliver the click a task later.
+// Anything deciding "no pick arrived by the time we closed" fails here exactly as on macOS.
+export async function pickNativeItem(menuIndex: number, itemIndex: number): Promise<void> {
+  const picked = await browser.execute(
+    (menuAt: number, itemAt: number) => {
+      const capture = (window as CaptureWindow).__journalsNativeMenuCapture;
+      const menu = capture?.menus[menuAt];
+      const click = menu?.template[itemAt]?.click;
+      if (!menu || !click) return false;
+      for (const close of menu.closers) close();
+      window.setTimeout(() => {
+        click(null, null, {});
+      }, 0);
+      return true;
+    },
+    menuIndex,
+    itemIndex,
+  );
+  if (!picked) throw new NativeMenuItemMissingError(menuIndex, itemIndex);
+}

--- a/wdio.conf.mts
+++ b/wdio.conf.mts
@@ -17,8 +17,8 @@ export const config: WebdriverIO.Config = {
   runner: "local",
   framework: "mocha",
 
-  // Suites are the grouping axis (see docs/e2e-testing-strategy.md). PR and merge
-  // runs name the stable suites; nightly runs the bare glob and so adds `quarantine`.
+  // Suites are the grouping axis (see docs/e2e-testing-strategy.md). Every CI run names
+  // its suites; nightly names `quarantine` too. The bare glob is a local-run convenience.
   specs: ["./e2e/**/*.e2e.ts"],
   suites: {
     smoke: ["./e2e/smoke/**/*.e2e.ts"],
@@ -68,6 +68,19 @@ export const config: WebdriverIO.Config = {
   mochaOpts: {
     ui: "bdd",
     timeout: 60_000,
+  },
+
+  // Obsidian renders menus two ways, and only one of them is a DOM node: `nativeMenus`
+  // defaults on for macOS, and the native path hands the items to Electron, leaving nothing
+  // for `.menu-item-title` to find. Left alone, every menu assertion in the suite passes on
+  // Linux and Windows and fails on macOS as "menu did not open" — a platform accident, not a
+  // finding. Pin the DOM rendering so menu specs mean the same thing on every OS; a spec that
+  // wants the native path opts into it explicitly with e2e/support/native-menu.ts, which
+  // reproduces it on all three. Re-applied per test because reloadObsidian resets the static.
+  beforeTest: async function () {
+    await browser.executeObsidian(({ obsidian }) => {
+      (obsidian as unknown as { Menu: { useNativeMenu: unknown } }).Menu.useNativeMenu = false;
+    });
   },
 
   // Headless CI failures are near-impossible to debug without a capture (see


### PR DESCRIPTION
Stacked on #239 (base is `fix/native-menu-pick-238`, so this diff is only the test/CI work). Covers the three follow-ups to that fix.

## Why nothing caught #238

Two independent reasons, both now addressed:

1. **No spec drove the pointer menu.** The two multi-journal picker specs (`uri-open`, `commands`) both wait on `"Search journals"` — the **SuggestModal** branch, which has no `pickAt` event and was never broken. `pickFromMenu` had zero coverage.
2. **A native menu is not in the DOM.** `nativeMenus` defaults on for macOS, so `showAtPosition` hands the items to Electron and `.menu-item-title` finds nothing. That is also why every nightly macOS job has failed since the lane was added — all four failures are menu lookups (`right-click did not open any context menu`, `shelf selector menu did not open`, …). The lane was reporting #238's mechanism as harness breakage.

## Can tests work with native menus? Yes

`e2e/support/native-menu.ts` flips Obsidian's static and swaps Electron's `buildFromTemplate` for a capture, so the native path becomes drivable **on any OS** — the macOS-only behavior is now reproducible on the Linux PR gate. Verified against a real menu: the shelf selector produced `[["All journals","core","extra",…]]` with no DOM node, and a replayed pick re-scoped the toolbar.

The capture preserves what makes the native menu different — it closes first and delivers the pick a task later, the reverse of the DOM menu — so `pickNativeItem` exercises a close/pick race exactly as macOS does.

`wdio.conf.mts` pins the DOM rendering before every test so ordinary menu specs mean the same thing on every host. Specs that want the native path opt in explicitly. That is what makes the macOS lane green *and* meaningful rather than green by avoidance.

## The regression spec

`e2e/journeys/multi-journal-pick.e2e.ts` on a new `e2e-shelf-pick` fixture — issue #238's exact shape: two shelves, a day journal on each, a calendar scoped to all journals. It forces the native rendering, then asserts the pick menu stayed in the DOM, that **no** native template was built, and that picking the **second** journal creates and opens that journal's note (a "first applicable journal wins" regression would still pass on the first).

Verified red without the fix:

```
Error: the journal pick menu did not render in the document
expect(received).toEqual(expected)
+   Array [ "work", "personal" ]     ← the menu went to Electron
```

## PR gate on every OS

`os` is no longer conditional: PR and merge run `latest/latest` on Linux, Windows and macOS. **OS is the PR axis, version is the nightly axis** — the host differences that break this plugin are platform-shaped, and a Linux-only gate cannot see them.

Also fixes a latent bug in the same file: `WDIO_SUITES` used `(event == 'schedule') && '' || '--suite …'`, and since `''` is falsy that always yields the right-hand side. Nightly has never run the `quarantine` lane it documents. Both branches now name their suites explicitly.

## Verification

Full e2e suite green locally on Linux (50 spec files: 32 journeys + 18 smoke/integration/migration/interop), plus `check:types`, `check:lint`, `check:i18n`. The macOS and Windows jobs on this PR are the real proof for the matrix change — they have never run on a PR before.