### PR TITLE
fix(e2e): repair the two remaining nightly-matrix failures

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,11 @@ on:
     # Nightly drift-detection across the OS + version matrix (07:00 UTC).
     - cron: "0 7 * * *"
   workflow_dispatch:
+    inputs:
+      full_matrix:
+        description: "Add the nightly version axis (floor + installer mismatch)"
+        type: boolean
+        default: true
 
 concurrency:
   group: e2e-${{ github.ref }}-${{ github.event_name }}
@@ -21,9 +26,11 @@ jobs:
         # PR + merge run latest/latest on every OS: the host differences that break this
         # plugin are platform-shaped (native vs DOM menus, path separators, popout focus)
         # and a Linux-only gate cannot see them. Nightly adds the version axis — the floor
-        # and the newest-app/oldest-installer mismatch (see docs/e2e-testing-strategy.md).
+        # and the newest-app/oldest-installer mismatch (see docs/e2e-testing-strategy.md),
+        # which a manual dispatch can ask for too — a floor-only failure is otherwise
+        # unverifiable until the next 07:00 UTC.
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        obsidian: ${{ (github.event_name == 'schedule') && fromJSON('["earliest/earliest", "latest/earliest", "latest/latest"]') || fromJSON('["latest/latest"]') }}
+        obsidian: ${{ (github.event_name == 'schedule' || inputs.full_matrix) && fromJSON('["earliest/earliest", "latest/earliest", "latest/latest"]') || fromJSON('["latest/latest"]') }}
 
     runs-on: ${{ matrix.os }}
     permissions:
@@ -36,7 +43,7 @@ jobs:
       # Named explicitly rather than falling back to the bare glob: `A && '' || B` yields B
       # in a GitHub expression, because the empty string is falsy — the old form silently
       # gave every run the same list, so quarantine had never run.
-      WDIO_SUITES: ${{ (github.event_name == 'schedule') && '--suite smoke --suite integration --suite migration --suite interop --suite journeys --suite quarantine' || '--suite smoke --suite integration --suite migration --suite interop --suite journeys' }}
+      WDIO_SUITES: ${{ (github.event_name == 'schedule' || inputs.full_matrix) && '--suite smoke --suite integration --suite migration --suite interop --suite journeys --suite quarantine' || '--suite smoke --suite integration --suite migration --suite interop --suite journeys' }}
 
     steps:
       - uses: actions/checkout@v7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,18 @@ on it.
 
 ### e2e traps and harness limits
 
+- `browser.executeObsidian` returns `undefined` as **null** — the WebDriver wire
+  serializes it. A poll predicate guarding only on `undefined` therefore receives
+  `null` and throws out of `waitUntil` instead of retrying, turning "not parsed
+  yet" into a hard failure on whichever combo happens to be slow. `waitForState`
+  guards both; anything hand-rolling a `waitUntil` must too.
+- Obsidian's own markup drifts across the supported range, so a selector can
+  encode a version floor tighter than `manifest.minAppVersion`. The settings
+  sidebar entry is the known case: `data-setting-id` and
+  `.vertical-tab-nav-item-title` are 1.12+, absent at the 1.8 floor. Reach
+  registry objects (`app.setting.pluginTabs`) rather than newer chrome. The
+  cached asars under `.obsidian-cache/obsidian-app/` settle such a question
+  directly — `npx asar extract` one and grep `app.js`.
 - Obsidian's editor zoom scales authored pixels (3px renders as 2.66667px).
   Assert widths through the rounding reader and colors via `getCSSProperty`
   parsed hex, from a custom hex fixture rather than a theme variable.

--- a/e2e/journeys/settings-first-journal.e2e.ts
+++ b/e2e/journeys/settings-first-journal.e2e.ts
@@ -2,7 +2,14 @@ import { $, browser, expect } from "@wdio/globals";
 
 import { m } from "../../src/i18n/paraglide/messages.js";
 import { waitForSettings } from "../support/plugin-data.js";
-import { clickIcon, openSettings, selectModalSelect, setModalText, submitModal } from "../support/settings.js";
+import {
+  clickIcon,
+  openSettings,
+  selectModalSelect,
+  setModalText,
+  settingsTabLabel,
+  submitModal,
+} from "../support/settings.js";
 
 // Slice B chunk 3 — first-journal-from-empty. e2e-empty has no journals (views auto-seed
 // the default calendar view at onload); the dashboard renders the empty state until the
@@ -17,9 +24,7 @@ describe("first journal", () => {
   it("labels its settings sidebar entry with the translated tab title", async () => {
     await openSettings();
 
-    await expect($('.vertical-tab-nav-item[data-setting-id="journals"] .vertical-tab-nav-item-title')).toHaveText(
-      m.settings_tab_title(),
-    );
+    expect(await settingsTabLabel()).toBe(m.settings_tab_title());
   });
 
   it("creates the first journal from an empty vault and replaces the empty state", async () => {

--- a/e2e/support/settings.ts
+++ b/e2e/support/settings.ts
@@ -37,6 +37,19 @@ export async function openSettings(): Promise<void> {
   await $(DASHBOARD).waitForExist({ timeoutMsg: "settings dashboard did not mount" });
 }
 
+// The label Obsidian shows for the plugin's entry in the settings sidebar. Its markup moved
+// within the supported range: at the 1.8 floor `addSettingTab` puts the name straight on
+// `.vertical-tab-nav-item`, while 1.12+ nests it in a `.vertical-tab-nav-item-title` child and
+// adds the `data-setting-id` attribute. Selecting on either would pass only on newer builds, so
+// read the registered tab's own navEl — the element Obsidian caches at addSettingTab time. Its
+// icon and chevron children are SVG, so textContent is the name on both shapes.
+export function settingsTabLabel(): Promise<string | undefined> {
+  return browser.executeObsidian(({ app }, id) => {
+    const setting = (app as unknown as { setting: { pluginTabs: { id: string; navEl?: HTMLElement }[] } }).setting;
+    return setting.pluginTabs.find((tab) => tab.id === id)?.navEl?.textContent?.trim();
+  }, PLUGIN_ID);
+}
+
 // Whether the settings panel is still on screen — Obsidian closes it whenever a workspace leaf
 // takes focus, so actions triggered from a settings page have to be checked against it.
 export function isSettingsOpen(): Promise<boolean> {

--- a/e2e/support/wait.ts
+++ b/e2e/support/wait.ts
@@ -5,14 +5,18 @@ import { browser } from "@wdio/globals";
 // (metadataCache catch-up, debounced saveData, the live editor) converges on its
 // own clock, observable only by re-reading.
 export async function waitForState<T>(
-  read: () => Promise<T | undefined>,
+  read: () => Promise<T | undefined | null>,
   predicate: (value: T) => boolean,
   timeoutMsg: string,
 ): Promise<void> {
   await browser.waitUntil(
     async () => {
       const value = await read();
-      return value !== undefined && predicate(value);
+      // Null as well as undefined: a reader built on `executeObsidian` returns its value over
+      // the WebDriver wire, which serializes `undefined` to `null`. Testing only for `undefined`
+      // let the not-ready-yet read reach the predicate, so "no frontmatter parsed yet" threw
+      // out of waitUntil instead of polling again — the retry this primitive exists to provide.
+      return value !== undefined && value !== null && predicate(value);
     },
     { timeoutMsg },
   );


### PR DESCRIPTION
The nightly OS + version matrix has been red on every run since it was
introduced (2026-08-14). Three independent clusters caused it; #239/#240 landed
the fix for the macOS menu cluster while this branch was in flight, so what is
left here is the other two, both confirmed against the Obsidian bundle rather
than inferred.

### `Cannot read properties of null` — varying tests, `earliest` only

`browser.executeObsidian` returns `undefined` as **`null`** — the WebDriver wire
serializes it — so `waitForState`'s `value !== undefined` guard let a
not-yet-parsed read reach the predicate, which threw straight out of
`waitUntil`. That turned the retry this primitive exists to provide into a hard
failure on whichever combo happened to be slow, which is why the failing tests
varied run to run across auto-attach, delete-journal and week-preset.

The error is self-proving: it is only reachable if `null` passed a guard that
tests solely for `undefined`. A full local floor run goes from 12 occurrences to
0, and `settings-first-journal`, `auto-attach-index` and `week-preset` flip from
failing to passing.

### Settings tab label — all OSes, `earliest` only

`data-setting-id` and `.vertical-tab-nav-item-title` are both 1.12+. At the
1.8.7 floor `addSettingTab` puts the name straight on `.vertical-tab-nav-item`,
so the selector encoded a version floor tighter than `manifest.minAppVersion`.
Now reads the registered tab's own `navEl`, whose `textContent` is the name on
both shapes (the icon and chevron children are SVG). Confirmed by extracting the
cached 1.8.7 and 1.13.7 asars; verified against a real 1.8.7 boot.

### Also here

- `workflow_dispatch` can now add the version axis. It ran only on `schedule`,
  so a floor-only failure was unverifiable until the next 07:00 UTC — this
  branch needed exactly that. Both expression branches stay explicit strings,
  per the falsy-empty-string note added in #240.
- The two traps are recorded in `CLAUDE.md`. The menu trap is already covered by
  #239's entry, so nothing is restated here.

### Verification

Full 9-job matrix dispatched green on the pre-rebase revision (one flake in
`responsive layout`, which passed on re-run and is a font-metric threshold
unrelated to these changes). Re-verified after rebasing onto #239, including the
new `multi-journal-pick` spec driving both menu renderings.

### Not addressed

`delete-journal` and `nav-template` wedge the renderer on a *local headed* floor
run both with and without these changes, and never do so in CI. Left alone.