### PR TITLE
fix: keep a journal's kind when one of its settings fails to load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Opening a journal note now opens it in the window you are working in; previously, if the note was already open in another window, Obsidian jumped you over to that window.
 - Middle-clicking or Ctrl/Cmd-clicking to open a journal note in a new tab, split, or window now does so even when the note is already open somewhere; previously the request was ignored and the existing pane was focused instead.
 - Picking a journal from the menu that appears when several journals cover the clicked date now opens or creates that journal's note on macOS; previously the pick was silently discarded, so a date that more than one journal could answer for — the usual case in a calendar scoped to all journals — could not be opened at all. The menu still uses whichever style macOS is set to show.
+- A journal carrying one unreadable setting now keeps everything else it has — its period, folder, name template, templates and decorations — and only the unreadable setting falls back to its default. Previously the whole journal was replaced by a daily journal that kept nothing but its name, so an upgraded vault could end up with every journal writing days: clicking a date offered all of them at once, and the week, month, quarter and year cells stopped responding.
 
 ## [3.0.0] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Middle-clicking or Ctrl/Cmd-clicking to open a journal note in a new tab, split, or window now does so even when the note is already open somewhere; previously the request was ignored and the existing pane was focused instead.
 - Picking a journal from the menu that appears when several journals cover the clicked date now opens or creates that journal's note on macOS; previously the pick was silently discarded, so a date that more than one journal could answer for — the usual case in a calendar scoped to all journals — could not be opened at all. The menu still uses whichever style macOS is set to show.
 - A journal carrying one unreadable setting now keeps everything else it has — its period, folder, name template, templates and decorations — and only the unreadable setting falls back to its default. Previously the whole journal was replaced by a daily journal that kept nothing but its name, so an upgraded vault could end up with every journal writing days: clicking a date offered all of them at once, and the week, month, quarter and year cells stopped responding.
+- A decoration that matches on a note property no longer costs its journal its configuration when upgrading from an earlier version. Such conditions predate property value types and are now read as text conditions.
 
 ## [3.0.0] - 2026-08-14
 

--- a/src/journals/config.test.ts
+++ b/src/journals/config.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from "vitest";
 
 import type { AnchorString } from "@/calendar";
 
-import { journalConfigSchema, journalDefaultsFor, navBlockSchema } from "./config";
+import { journalConfigCollection, journalConfigSchema, journalDefaultsFor, navBlockSchema } from "./config";
 
 describe("journalDefaultsFor", () => {
   it("defaults nameTemplate to {{date}}", () => {
@@ -280,5 +280,29 @@ describe("navBlockSchema", () => {
       ],
     };
     expect(v.safeParse(navBlockSchema, value).success).toBe(false);
+  });
+});
+
+describe("journalConfigCollection default item", () => {
+  it("keeps the stored write type so a journal that fails validation stays its own kind", () => {
+    const item = journalConfigCollection.defaultItem("Journal weekly", { write: { type: "week" } });
+
+    expect(item.write).toEqual({ type: "week" });
+    expect(item.dateFormat).toBe("YYYY-[W]w");
+  });
+
+  it("keeps a stored custom write type with its interval", () => {
+    const item = journalConfigCollection.defaultItem("Sprints", {
+      write: { type: "custom", every: "week", duration: 2, anchorDate: "2024-01-01" },
+    });
+
+    expect(item.write).toEqual({ type: "custom", every: "week", duration: 2, anchorDate: "2024-01-01" });
+  });
+
+  it("falls back to day when the stored write type is unusable", () => {
+    const item = journalConfigCollection.defaultItem("Broken", { write: { type: "fortnight" } });
+
+    expect(item.write).toEqual({ type: "day" });
+    expect(item.name).toBe("Broken");
   });
 });

--- a/src/journals/config.ts
+++ b/src/journals/config.ts
@@ -352,6 +352,11 @@ export function journalDefaultsFor(write: JournalWrite, name = ""): JournalConfi
   };
 }
 
-export const journalConfigCollection = defineCollection("journals", journalConfigSchema, (id) =>
-  journalDefaultsFor({ type: "day" }, id),
+function storedWrite(raw: unknown): JournalWrite {
+  const parsed = v.safeParse(writeSchema, (raw as { write?: unknown } | null)?.write);
+  return parsed.success ? parsed.output : { type: "day" };
+}
+
+export const journalConfigCollection = defineCollection("journals", journalConfigSchema, (id, raw) =>
+  journalDefaultsFor(storedWrite(raw), id),
 );

--- a/src/settings/legacy/v3-to-v4.test.ts
+++ b/src/settings/legacy/v3-to-v4.test.ts
@@ -87,6 +87,48 @@ describe("v3ToV4Migration", () => {
     expect(journal).not.toHaveProperty("index");
   });
 
+  // v2 property conditions carried no valueType — the field arrived with the typed
+  // property conditions in v3, and without it the whole journal fails validation.
+  it("tags a v2 property decoration condition as a text condition", () => {
+    const data = monolithV3();
+    (data.journals as Record<string, { decorations: unknown[] }>)["My Journal Day"].decorations = [
+      {
+        mode: "and",
+        conditions: [{ type: "property", name: "mood", condition: "contains", value: "good" }],
+        styles: [{ type: "background", color: { type: "transparent" } }],
+      },
+    ];
+
+    const out = v3ToV4Migration.migrate(data);
+
+    const journal = Object.values(out.journals as Record<string, Record<string, unknown>>)[0];
+    const decorations = journal.decorations as { conditions: Record<string, unknown>[] }[];
+    expect(decorations[0].conditions[0]).toEqual({
+      type: "property",
+      name: "mood",
+      valueType: "text",
+      condition: "contains",
+      value: "good",
+    });
+  });
+
+  it("leaves a property condition that already declares its value type alone", () => {
+    const data = monolithV3();
+    (data.journals as Record<string, { decorations: unknown[] }>)["My Journal Day"].decorations = [
+      {
+        mode: "and",
+        conditions: [{ type: "property", name: "streak", valueType: "number", condition: "gt", value: 3 }],
+        styles: [{ type: "background", color: { type: "transparent" } }],
+      },
+    ];
+
+    const out = v3ToV4Migration.migrate(data);
+
+    const journal = Object.values(out.journals as Record<string, Record<string, unknown>>)[0];
+    const decorations = journal.decorations as { conditions: Record<string, unknown>[] }[];
+    expect(decorations[0].conditions[0]).toMatchObject({ valueType: "number", condition: "gt", value: 3 });
+  });
+
   it("keys each journal by its name so the repository resolves it", () => {
     const out = v3ToV4Migration.migrate(monolithV3());
     expect(Object.keys(out.journals as Record<string, unknown>)).toEqual(["My Journal Day"]);

--- a/src/settings/legacy/v3-to-v4.ts
+++ b/src/settings/legacy/v3-to-v4.ts
@@ -4,7 +4,13 @@ import type { Migration } from "@/settings";
 import type { View, ViewBlockInstance } from "@/views";
 import { DEFAULT_CALENDAR_VIEW_ID, defaultCalendarView } from "@/views/default-view";
 
-import type { OldJournalCommand, OldJournalSettings, OldPluginCommand, OldPluginSettings } from "./old-shapes";
+import type {
+  JournalDecorationCondition,
+  OldJournalCommand,
+  OldJournalSettings,
+  OldPluginCommand,
+  OldPluginSettings,
+} from "./old-shapes";
 
 type CommandTarget =
   | { kind: "all"; writeType: OldPluginCommand["writeType"] }
@@ -32,6 +38,21 @@ function mapMode(mode: "navigate" | "create" | "switch_date"): "navigate" | "cre
     .exhaustive();
 }
 
+// v2 property conditions predate v3's typed property conditions and carry no valueType.
+// Every v2 operator exists on the text condition, so tagging them text preserves the
+// decoration; leaving the field out fails the schema and costs the whole journal.
+function withPropertyValueType(condition: JournalDecorationCondition): unknown {
+  if (condition.type !== "property" || "valueType" in condition) return condition;
+  return { ...condition, valueType: "text" };
+}
+
+function reshapeDecorations(decorations: OldJournalSettings["decorations"] | undefined): unknown[] {
+  return (decorations ?? []).map((decoration) => ({
+    ...decoration,
+    conditions: decoration.conditions.map((condition) => withPropertyValueType(condition)),
+  }));
+}
+
 function reshapeJournal(old: OldJournalSettings): Record<string, unknown> {
   return {
     name: old.name,
@@ -42,7 +63,7 @@ function reshapeJournal(old: OldJournalSettings): Record<string, unknown> {
     dateFormat: old.dateFormat,
     folder: old.folder,
     templates: old.templates,
-    decorations: old.decorations,
+    decorations: reshapeDecorations(old.decorations),
     navBlock: old.navBlock,
     timeline: { start: old.start, end: mapEnd(old.end) },
     numbering: {

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -13,7 +13,8 @@ export interface CollectionDefinition<TKey extends string, TItem extends AnySche
   readonly __brand: "collection";
   readonly key: TKey;
   readonly itemSchema: TItem;
-  readonly defaultItem: (id: string) => InferOutput<TItem>;
+  /** `raw` is the stored entry that failed validation, so a default can keep what still parses. */
+  readonly defaultItem: (id: string, raw?: unknown) => InferOutput<TItem>;
   readonly seed?: () => Record<string, InferOutput<TItem>>;
 }
 
@@ -31,7 +32,7 @@ export function defineSlice<TKey extends string, TSchema extends AnySchema>(
 export function defineCollection<TKey extends string, TItem extends AnySchema>(
   key: TKey,
   itemSchema: TItem,
-  defaultItem: (id: string) => InferOutput<TItem>,
+  defaultItem: (id: string, raw?: unknown) => InferOutput<TItem>,
   options?: { seed?: () => Record<string, InferOutput<TItem>> },
 ): CollectionDefinition<TKey, TItem> {
   return { __brand: "collection", key, itemSchema, defaultItem, seed: options?.seed };

--- a/src/settings/settings-service.test.ts
+++ b/src/settings/settings-service.test.ts
@@ -8,6 +8,7 @@ import { FakePluginData } from "@/infrastructure/host/testing";
 import { createLoggerTestingModule } from "@/infrastructure/logger/testing";
 import { AsyncResult } from "@/infrastructure/result";
 import { expectErr, expectOk } from "@/infrastructure/result/testing";
+import { journalConfigCollection } from "@/journals/config";
 
 import { SliceKeyConflictError, MigrationFailedError, UnregisteredSliceError } from "./errors";
 import { defineCollection, defineSlice, type Migration } from "./schema";
@@ -29,6 +30,37 @@ const calendarSlice = defineSlice("calendar", calendarSchema, { dow: 1, global: 
 
 const journalSchema = v.object({ name: v.string() });
 const journalCollection = defineCollection("journals", journalSchema, (id) => ({ name: id }));
+
+const petSchema = v.object({
+  name: v.pipe(v.string(), v.minLength(1)),
+  kind: v.picklist(["cat", "dog"]),
+  sound: v.pipe(v.string(), v.minLength(1)),
+  toys: v.optional(v.array(v.string()), []),
+});
+
+const sounds = { cat: "meow", dog: "woof" } as const;
+
+function storedKind(raw: unknown): "cat" | "dog" {
+  return (raw as { kind?: unknown } | null)?.kind === "dog" ? "dog" : "cat";
+}
+
+const petDefaults = (id: string, raw: unknown): v.InferOutput<typeof petSchema> => ({
+  name: id,
+  kind: storedKind(raw),
+  sound: sounds[storedKind(raw)],
+  toys: [],
+});
+
+const petCollection = defineCollection("pets", petSchema, petDefaults);
+
+const checkedPetCollection = defineCollection(
+  "pets",
+  v.pipe(
+    petSchema,
+    v.check((pet) => pet.name !== pet.sound, "name and sound must differ"),
+  ),
+  petDefaults,
+);
 
 function build(
   options: {
@@ -95,6 +127,113 @@ describe("SettingsService", () => {
       const { service } = build({ raw: { version: 4, calendar: { dow: "not-a-number" } } });
       await service.initialize();
       expect(service.getSlice(calendarSlice).state.dow).toBe(1);
+    });
+  });
+
+  describe("initialize — collection entry repair", () => {
+    it("keeps the fields that validate and repairs only the ones that do not", async () => {
+      const raw = { version: 4, pets: { Rex: { name: "Rex", kind: "dog", sound: "", toys: ["ball"] } } };
+      const { service } = build({ raw, collections: [petCollection] });
+
+      await service.initialize();
+
+      expect(service.recordOf(petCollection).Rex).toEqual({
+        name: "Rex",
+        kind: "dog",
+        sound: "woof",
+        toys: ["ball"],
+      });
+    });
+
+    it("derives the repaired value from the entry's own stored fields", async () => {
+      const raw = { version: 4, pets: { Rex: { name: "Rex", kind: "dog", sound: "" } } };
+      const { service } = build({ raw, collections: [petCollection] });
+
+      await service.initialize();
+
+      expect(service.recordOf(petCollection).Rex.sound).toBe("woof");
+    });
+
+    it("falls back to the whole default when the entry is not an object", async () => {
+      const { service } = build({ raw: { version: 4, pets: { Rex: "not an entry" } }, collections: [petCollection] });
+
+      await service.initialize();
+
+      expect(service.recordOf(petCollection).Rex).toEqual({ name: "Rex", kind: "cat", sound: "meow", toys: [] });
+    });
+
+    it("falls back to the whole default when the failure names no field", async () => {
+      const raw = { version: 4, pets: { Rex: { name: "woof", kind: "dog", sound: "woof", toys: ["ball"] } } };
+      const { service } = build({ raw, collections: [checkedPetCollection] });
+
+      await service.initialize();
+
+      expect(service.recordOf(checkedPetCollection).Rex).toEqual({
+        name: "Rex",
+        kind: "dog",
+        sound: "woof",
+        toys: [],
+      });
+    });
+  });
+
+  // A v2 vault whose journals cleared the date format loaded every journal as a *day*
+  // journal named after the original, so the calendar offered five daily journals on a
+  // day click and week, month, quarter and year went inert.
+  describe("initialize — a journal keeps its kind when one field fails", () => {
+    const weekly = {
+      name: "Journal weekly",
+      write: { type: "week" },
+      timeline: { start: "", end: { kind: "never" } },
+      dateFormat: "",
+      frontmatter: {
+        dateField: "journal-date",
+        startDateField: "journal-start-date",
+        endDateField: "journal-end-date",
+        addStartDate: true,
+        addEndDate: true,
+      },
+      numbering: { enabled: false, anchorDate: "", allowBefore: false, sources: [] },
+      nameTemplate: "{{date:YYYY-[W]ww}}",
+      folder: "02 - Journal/Weekly",
+      templates: ["99 - Meta/Templates/Weekly Note Template.md"],
+    };
+
+    it("stays a weekly journal", async () => {
+      const { service } = build({
+        raw: { version: 4, journals: { "Journal weekly": weekly } },
+        collections: [journalConfigCollection],
+      });
+
+      await service.initialize();
+
+      expect(service.recordOf(journalConfigCollection)["Journal weekly"].write).toEqual({ type: "week" });
+    });
+
+    it("repairs the date format from its own write type", async () => {
+      const { service } = build({
+        raw: { version: 4, journals: { "Journal weekly": weekly } },
+        collections: [journalConfigCollection],
+      });
+
+      await service.initialize();
+
+      expect(service.recordOf(journalConfigCollection)["Journal weekly"].dateFormat).toBe("YYYY-[W]w");
+    });
+
+    it("keeps the folder, name template and templates the user configured", async () => {
+      const { service } = build({
+        raw: { version: 4, journals: { "Journal weekly": weekly } },
+        collections: [journalConfigCollection],
+      });
+
+      await service.initialize();
+
+      expect(service.recordOf(journalConfigCollection)["Journal weekly"]).toMatchObject({
+        nameTemplate: "{{date:YYYY-[W]ww}}",
+        folder: "02 - Journal/Weekly",
+        templates: ["99 - Meta/Templates/Weekly Note Template.md"],
+      });
     });
   });
 

--- a/src/settings/settings-service.ts
+++ b/src/settings/settings-service.ts
@@ -203,15 +203,54 @@ function parseCollectionValue<TItem extends AnySchema>(
     const parsed = v.safeParse(definition.itemSchema, value);
     if (parsed.success) {
       out[id] = parsed.output;
-    } else {
-      out[id] = definition.defaultItem(id);
-      logger.warn("collection entry reset to defaults", {
-        sliceKey: `${definition.key}/${id}`,
-        issues: parsed.issues.map((issue) => issue.message),
-      });
+      continue;
     }
+
+    const issues = parsed.issues.map((issue) => issue.message);
+    const repaired = repairCollectionEntry(definition, id, value, parsed.issues);
+    if (repaired) {
+      out[id] = repaired.value;
+      logger.warn("collection entry fields reset to defaults", {
+        sliceKey: `${definition.key}/${id}`,
+        fields: repaired.fields,
+        issues,
+      });
+      continue;
+    }
+
+    out[id] = definition.defaultItem(id, value);
+    logger.warn("collection entry reset to defaults", { sliceKey: `${definition.key}/${id}`, issues });
   }
   return out;
+}
+
+// Resetting a whole entity because one field went bad silently discards everything the
+// user configured — and the next save writes that loss over their data. Substitute the
+// default only for the fields the issues name, so a broken date format costs a date
+// format rather than the journal's write type, folder and templates.
+function repairCollectionEntry<TItem extends AnySchema>(
+  definition: CollectionDefinition<string, TItem>,
+  id: string,
+  value: unknown,
+  issues: readonly BaseIssue<unknown>[],
+): { value: InferOutput<TItem>; fields: string[] } | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+
+  const fields = new Set<string>();
+  for (const issue of issues) {
+    // A root-level check reports no path, so there is no field to swap out.
+    const key = issue.path?.[0]?.key;
+    if (typeof key !== "string") return undefined;
+    fields.add(key);
+  }
+  if (fields.size === 0) return undefined;
+
+  const defaults = definition.defaultItem(id, value) as Record<string, unknown>;
+  const candidate: Record<string, unknown> = { ...(value as Record<string, unknown>) };
+  for (const field of fields) candidate[field] = defaults[field];
+
+  const parsed = v.safeParse(definition.itemSchema, candidate);
+  return parsed.success ? { value: parsed.output, fields: [...fields] } : undefined;
 }
 
 function parseSliceValue<TSchema extends AnySchema>(


### PR DESCRIPTION
Fixes #237.

## What happened

A stored collection entry that fails validation was replaced wholesale by the collection's default item — and for journals that default is a **day** journal keyed by the entry name:

```ts
// settings-service.ts
out[id] = definition.defaultItem(id);

// journals/config.ts
defineCollection("journals", journalConfigSchema, (id) => journalDefaultsFor({ type: "day" }, id));
```

So one unreadable field cost a journal everything but its name. A vault upgrading from v2 loaded five journals — `Journal daily`, `Journal weekly`, `Journal monthly`, `Journal quarterly`, `Journal yearly` — all as daily journals. Clicking a date offered all five at once, while the week, month, quarter and year cells went inert because no journal of those kinds was left in scope. The next save then wrote that loss over the original config, so the damage was not recoverable and reinstalling did nothing.

The reporter's `data.json` confirms it: every journal carries `write: {"type": "day"}`, `dateFormat: "YYYY-MM-DD"`, `numbering.sources: []` and the **day** nav block (`{{date:ddd}}`, `{{date:D}}`, …) — including the one named `Journal weekly`. `numbering.sources` is the tell: `reshapeJournal` always emits exactly one source, so those entries did not come out of the migration. Everything else in the file migrated correctly (v2 command slugs, the view's `defaultShelf`, their customized `appearance`), which rules out a migration failure.

## The fix

**`fix(settings)`** — substitute the default only for the top-level fields the validation issues name, then re-parse. Whole-entity reset survives as the last resort for two cases: the stored entry is not an object, and a root-level check that reports no path, so no field can be attributed. `defaultItem` gained an optional `raw` argument and `journalConfigCollection` uses it to derive its default from the stored `write` — a journal keeps its own kind, and with it the right date format and nav block. The two log lines now distinguish a field repair (naming the fields) from a full reset.

**`fix(migration)`** — v2 wrote property decoration conditions with no `valueType`; v3's typed property conditions require one, so a journal carrying such a decoration failed validation on upgrade. Every v2 operator exists on the text condition, so they are now tagged `text`.

## Verification

The regression test was written first and confirmed failing against the unfixed code. The same v2 weekly journal with a cleared date format produced:

```
write:        { type: "day" }     expected week
dateFormat:   "YYYY-MM-DD"        expected YYYY-[W]w
folder:       ""                  expected "02 - Journal/Weekly"
nameTemplate: "{{date}}"          expected "{{date:YYYY-[W]ww}}"
templates:    []                  expected the weekly template
```

That reproduces the reporter's file from a clean input. With the fix: 3707 unit tests pass (up from 3695), `check:types`, `check:lint` and `check:i18n` clean.

## Scope

This stops the reset. It does **not** repair a vault already hit by it — the original config was overwritten on the first save, so affected users have to restore the write type by hand.

Two related findings are deliberately left out of this branch:

- `pendingMigrations` — the payload of an *unfinished* v2 → v3 migration modal — is declared in `old-shapes.ts` and never read by any migration.
- A v1 user who never set a week date format had it resolved at use time as `YYYY-[W]ww`; v2 changed the default to `YYYY-[W]w`, and the migration carries that value forward, so notes named `2026-W05` stop resolving.

Field-level repair attributes issues by their **first** path segment only, so a nested failure resets the whole top-level field — a bad `numbering.sources[0].frontmatterKey` costs the entire `numbering` object. That keeps the merge shallow and predictable; worth knowing before someone reports a narrower loss.
