### PR TITLE
refactor: extract date grammar and journal-date resolution

### DIFF
--- a/src/calendar/date-input.test.ts
+++ b/src/calendar/date-input.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { parseDateExpression } from "./date-input";
+import { installTestCalendar } from "./testing";
+
+function parsed(input: string): string | null {
+  const result = parseDateExpression(input);
+  return result.isSome() ? result.value.toAnchor() : null;
+}
+
+describe("parseDateExpression", () => {
+  let teardown: () => void;
+
+  beforeEach(() => {
+    ({ teardown } = installTestCalendar());
+  });
+
+  afterEach(() => {
+    teardown();
+  });
+
+  it("parses an absolute anchor", () => {
+    expect(parsed("2026-08-18")).toBe("2026-08-18");
+  });
+
+  it("treats an empty string and today alike", () => {
+    expect(parsed("today")).toBe(parsed(""));
+    expect(parsed("today")).not.toBeNull();
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(parsed("  2026-08-18  ")).toBe("2026-08-18");
+  });
+
+  it("applies a positive relative shift", () => {
+    const base = parseDateExpression("today");
+    expect(parsed("+1w")).toBe(base.isSome() ? base.value.shift(1, "w").toAnchor() : null);
+  });
+
+  it("applies a negative relative shift", () => {
+    const base = parseDateExpression("today");
+    expect(parsed("-3d")).toBe(base.isSome() ? base.value.shift(-3, "d").toAnchor() : null);
+  });
+
+  it("returns none for an expression it cannot parse", () => {
+    expect(parsed("next tuesday")).toBeNull();
+    expect(parsed("2026-13-45")).toBeNull();
+  });
+});

--- a/src/calendar/date-input.ts
+++ b/src/calendar/date-input.ts
@@ -1,0 +1,22 @@
+import { Option } from "@/infrastructure/result";
+
+import { CalendarDate } from "./calendar-date";
+
+const RELATIVE_DATE = /^([+-])(\d+)([dwmqy])$/;
+
+/** "today" / "" / "+1w" / "-3d" / "YYYY-MM-DD". None when the expression is none of those. */
+export function parseDateExpression(raw: string): Option<CalendarDate> {
+  const value = raw.trim();
+  if (!value || value === "today") return Option.some(CalendarDate.today());
+
+  const relative = RELATIVE_DATE.exec(value);
+  if (relative) {
+    const sign = relative[1] === "-" ? -1 : 1;
+    const amount = sign * Number(relative[2]);
+    const unit = relative[3] as "d" | "w" | "m" | "q" | "y";
+    return Option.some(CalendarDate.today().shift(amount, unit));
+  }
+
+  const parsed = CalendarDate.parse(value);
+  return parsed.isErr() ? Option.none() : Option.some(parsed.value);
+}

--- a/src/calendar/index.ts
+++ b/src/calendar/index.ts
@@ -11,6 +11,7 @@ export { QuarterPeriod } from "./period-quarter";
 export { YearPeriod } from "./period-year";
 export { DecadePeriod } from "./period-decade";
 
+export { parseDateExpression } from "./date-input";
 export { advance, periodKinds, periodOfKind, window, type Period, type PeriodKind, type PeriodBase } from "./period";
 export { relativeDate, type RelativePeriod } from "./relative-date";
 export { type AnchorString } from "./types";

--- a/src/journals/flows/index.ts
+++ b/src/journals/flows/index.ts
@@ -1,3 +1,4 @@
+export { JournalDateResolver, type ApplicableJournal } from "./journal-date-resolver";
 export { OpenDateFlow } from "./open-date.flow";
 export { OpenJournalEntryFlow } from "./open-journal-entry.flow";
 export { journalFlowsModule } from "./module";

--- a/src/journals/flows/journal-date-resolver.test.ts
+++ b/src/journals/flows/journal-date-resolver.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { CalendarDate } from "@/calendar";
+import type { AnchorString } from "@/calendar";
+import { installTestCalendar } from "@/calendar/testing";
+import { Container } from "@/infrastructure/di";
+import { SuggestService, WorkspaceService } from "@/infrastructure/host";
+import type { VaultPath } from "@/infrastructure/host";
+
+import { CycleService } from "../cycle";
+import { JournalsIndex } from "../journals-index";
+import { JournalsRepository } from "../repository";
+import { fakeRepo, fixedJournal } from "../testing";
+import { TimelineService } from "../timeline";
+
+import { JournalDateResolver } from "./journal-date-resolver";
+
+function buildContainer(journals: Parameters<typeof fakeRepo>[0]): Container {
+  const c = new Container();
+  c.register(JournalsRepository).useValue(fakeRepo(journals));
+  c.register(JournalsIndex).useClass(JournalsIndex);
+  c.register(CycleService).useClass(CycleService);
+  c.register(TimelineService).useClass(TimelineService);
+  c.register(SuggestService).useValue({} as never);
+  c.register(WorkspaceService).useValue({} as never);
+  c.register(JournalDateResolver).useClass(JournalDateResolver);
+  return c;
+}
+
+const WEDNESDAY = "2026-08-19" as AnchorString;
+
+describe("JournalDateResolver.applicable", () => {
+  let teardown: () => void;
+
+  beforeEach(() => {
+    ({ teardown } = installTestCalendar({ dow: 0, doy: 6 }));
+  });
+
+  afterEach(() => {
+    teardown();
+  });
+
+  it("resolves each journal to the anchor of its own period", () => {
+    const c = buildContainer({
+      daily: fixedJournal("daily", { type: "day" }),
+      weekly: fixedJournal("weekly", { type: "week" }),
+    });
+
+    const applicable = c.resolve(JournalDateResolver).applicable(CalendarDate.fromAnchor(WEDNESDAY), undefined, false);
+
+    expect(applicable).toHaveLength(2);
+    expect(applicable.find((entry) => entry.name === "daily")?.anchor).toBe("2026-08-19");
+    expect(applicable.find((entry) => entry.name === "weekly")?.anchor).toBe("2026-08-16");
+  });
+
+  it("omits journals whose timeline does not contain the anchor", () => {
+    const c = buildContainer({
+      past: fixedJournal(
+        "past",
+        { type: "day" },
+        {
+          timeline: {
+            start: "2020-01-01" as AnchorString,
+            end: { kind: "date", date: "2020-12-31" as AnchorString },
+          },
+        },
+      ),
+      current: fixedJournal("current", { type: "day" }),
+    });
+
+    const applicable = c.resolve(JournalDateResolver).applicable(CalendarDate.fromAnchor(WEDNESDAY), undefined, false);
+
+    expect(applicable.map((entry) => entry.name)).toEqual(["current"]);
+  });
+
+  it("restricts to the named journals when given a list", () => {
+    const c = buildContainer({
+      a: fixedJournal("a", { type: "day" }),
+      b: fixedJournal("b", { type: "day" }),
+    });
+
+    const applicable = c.resolve(JournalDateResolver).applicable(CalendarDate.fromAnchor(WEDNESDAY), ["b"], false);
+
+    expect(applicable.map((entry) => entry.name)).toEqual(["b"]);
+  });
+
+  it("keeps only journals with an existing entry when existingOnly is set", () => {
+    const c = buildContainer({ daily: fixedJournal("daily", { type: "day" }) });
+    c.resolve(JournalsIndex).register({
+      journalName: "daily",
+      anchor: WEDNESDAY,
+      path: "Journal/2026-08-19.md" as VaultPath,
+    });
+    const resolver = c.resolve(JournalDateResolver);
+
+    expect(resolver.applicable(CalendarDate.fromAnchor(WEDNESDAY), undefined, true).map((entry) => entry.name)).toEqual(
+      ["daily"],
+    );
+    expect(resolver.applicable(CalendarDate.fromAnchor("2026-08-20" as AnchorString), undefined, true)).toHaveLength(0);
+  });
+});

--- a/src/journals/flows/journal-date-resolver.ts
+++ b/src/journals/flows/journal-date-resolver.ts
@@ -1,0 +1,57 @@
+import type { AnchorString, CalendarDate } from "@/calendar";
+import { inject } from "@/infrastructure/di";
+import { SuggestService, WorkspaceService } from "@/infrastructure/host";
+
+import { CycleService } from "../cycle";
+import { JournalsIndex } from "../journals-index";
+import { journalPickerSuggest } from "../notes/journal-picker";
+import { JournalsRepository } from "../repository";
+import { TimelineService } from "../timeline";
+
+export interface ApplicableJournal {
+  readonly name: string;
+  readonly anchor: AnchorString;
+}
+
+export class JournalDateResolver {
+  readonly #journals = inject(JournalsRepository);
+  readonly #timeline = inject(TimelineService);
+  readonly #index = inject(JournalsIndex);
+  readonly #cycle = inject(CycleService);
+  readonly #suggests = inject(SuggestService);
+  readonly #workspace = inject(WorkspaceService);
+
+  // The date is wherever the caller pointed — a day cell, today, a nav row in a daily note —
+  // while each journal answers for the period of its own granularity containing it. Resolve
+  // per journal before any entry is read or written by it: a weekly journal handed a
+  // mid-week day would otherwise store that day as the entry's identity, which parseEntry
+  // rejects as non-canonical, and look up an existing entry under an anchor it never owns.
+  applicable(
+    date: CalendarDate,
+    journalNames: readonly string[] | undefined,
+    existingOnly: boolean,
+  ): ApplicableJournal[] {
+    const all = [...this.#journals.find().ids()];
+    const candidates = journalNames ? all.filter((name) => journalNames.includes(name)) : all;
+    return candidates.flatMap((name) => {
+      const resolved = this.#cycle.anchorOf(name, date);
+      if (resolved.isNone()) return [];
+      const anchor = resolved.value;
+      if (!this.#timeline.contains(name, anchor)) return [];
+      if (existingOnly && this.#index.entryByAnchor(name, anchor).isNone()) return [];
+      return [{ name, anchor }];
+    });
+  }
+
+  // Answers only "which name did the user choose"; mapping that back to a candidate — and
+  // deciding what an unknown name means — stays with the caller, which is what lets
+  // OpenDateFlow keep reporting NoApplicableJournals for it rather than an abort.
+  /** null means the user dismissed the picker. */
+  async pick(names: readonly string[], pickAt?: MouseEvent): Promise<string | null> {
+    const options = [...names];
+    const choice = pickAt
+      ? await this.#workspace.pickFromMenu(options, pickAt)
+      : await this.#suggests.open(journalPickerSuggest, options);
+    return choice.isErr() ? null : choice.value;
+  }
+}

--- a/src/journals/flows/module.ts
+++ b/src/journals/flows/module.ts
@@ -1,10 +1,12 @@
 import type { Module } from "@/infrastructure/di";
 
+import { JournalDateResolver } from "./journal-date-resolver";
 import { OpenDateFlow } from "./open-date.flow";
 import { OpenJournalEntryFlow } from "./open-journal-entry.flow";
 
 export const journalFlowsModule: Module = {
   register(c) {
+    c.register(JournalDateResolver).useClass(JournalDateResolver);
     c.register(OpenDateFlow).useClass(OpenDateFlow);
     c.register(OpenJournalEntryFlow).useClass(OpenJournalEntryFlow);
   },

--- a/src/journals/flows/open-date.flow.test.ts
+++ b/src/journals/flows/open-date.flow.test.ts
@@ -30,6 +30,7 @@ import { JournalsRepository } from "../repository";
 import { fakeRepo, fixedJournal } from "../testing";
 import { TimelineService } from "../timeline";
 
+import { JournalDateResolver } from "./journal-date-resolver";
 import { OpenDateFlow } from "./open-date.flow";
 import { OpenJournalEntryFlow } from "./open-journal-entry.flow";
 
@@ -57,6 +58,7 @@ function build(repo: JournalsRepository, suggests: FakeSuggestService) {
   c.register(SelfWriteGuard).useClass(SelfWriteGuard);
   c.register(NoteCreationService).useClass(NoteCreationService);
   c.register(OpenJournalEntryFlow).useClass(OpenJournalEntryFlow);
+  c.register(JournalDateResolver).useClass(JournalDateResolver);
   c.register(OpenDateFlow).useClass(OpenDateFlow);
   return { container: c, notes, workspace };
 }

--- a/src/journals/flows/open-date.flow.ts
+++ b/src/journals/flows/open-date.flow.ts
@@ -3,17 +3,12 @@ import type { AnchorString } from "@/calendar";
 import { inject } from "@/infrastructure/di";
 import { Flows, UserAborted } from "@/infrastructure/flows";
 import type { Flow } from "@/infrastructure/flows";
-import { SuggestService, WorkspaceService } from "@/infrastructure/host";
 import type { OpenMode, VaultPath, WorkspaceOpenError } from "@/infrastructure/host";
 import { AsyncResult } from "@/infrastructure/result";
 
-import { CycleService } from "../cycle";
-import { JournalsIndex } from "../journals-index";
 import { NoApplicableJournals } from "../notes/errors";
-import { journalPickerSuggest } from "../notes/journal-picker";
-import { JournalsRepository } from "../repository";
-import { TimelineService } from "../timeline";
 
+import { JournalDateResolver } from "./journal-date-resolver";
 import { OpenJournalEntryFlow } from "./open-journal-entry.flow";
 
 import type { NoteCreationError } from "../notes/note-creation";
@@ -36,32 +31,12 @@ export interface OpenDateResult {
 export type OpenDateError = NoApplicableJournals | NoteCreationError | WorkspaceOpenError | UserAborted;
 
 export class OpenDateFlow implements Flow<OpenDateParameters, OpenDateResult, OpenDateError> {
-  readonly #journals = inject(JournalsRepository);
-  readonly #timeline = inject(TimelineService);
-  readonly #index = inject(JournalsIndex);
-  readonly #cycle = inject(CycleService);
+  readonly #resolver = inject(JournalDateResolver);
   readonly #flows = inject(Flows);
-  readonly #suggests = inject(SuggestService);
-  readonly #workspace = inject(WorkspaceService);
 
   execute(p: OpenDateParameters): AsyncResult<OpenDateResult, OpenDateError> {
-    const all = [...this.#journals.find().ids()];
-    const { journalNames } = p;
-    const candidates = journalNames ? all.filter((n) => journalNames.includes(n)) : all;
     const date = CalendarDate.fromAnchor(p.anchor);
-    // The date is wherever the caller pointed — a day cell, today, a nav row in a daily note —
-    // while each journal answers for the period of its own granularity containing it. Resolve
-    // per journal before any entry is read or written by it: a weekly journal handed a
-    // mid-week day would otherwise store that day as the entry's identity, which parseEntry
-    // rejects as non-canonical, and look up an existing entry under an anchor it never owns.
-    const applicable = candidates.flatMap((name) => {
-      const resolved = this.#cycle.anchorOf(name, date);
-      if (resolved.isNone()) return [];
-      const anchor = resolved.value;
-      if (!this.#timeline.contains(name, anchor)) return [];
-      if (p.existingOnly && this.#index.entryByAnchor(name, anchor).isNone()) return [];
-      return [{ name, anchor }];
-    });
+    const applicable = this.#resolver.applicable(date, p.journalNames, p.existingOnly ?? false);
 
     if (applicable.length === 0) {
       return AsyncResult.err(new NoApplicableJournals(p.anchor, p.journalNames));
@@ -81,11 +56,9 @@ export class OpenDateFlow implements Flow<OpenDateParameters, OpenDateResult, Op
     const names = applicable.map((entry) => entry.name);
     return AsyncResult.fromPromise(
       (async (): Promise<OpenDateResult> => {
-        const choice = p.pickAt
-          ? await this.#workspace.pickFromMenu(names, p.pickAt)
-          : await this.#suggests.open(journalPickerSuggest, names);
-        if (choice.isErr()) throw new UserAborted("journal-picker");
-        const chosen = applicable.find((entry) => entry.name === choice.value);
+        const choice = await this.#resolver.pick(names, p.pickAt);
+        if (choice === null) throw new UserAborted("journal-picker");
+        const chosen = applicable.find((entry) => entry.name === choice);
         if (chosen === undefined) throw new NoApplicableJournals(p.anchor, p.journalNames);
         const dispatched = await this.#flows.invoke(OpenJournalEntryFlow, {
           journalName: chosen.name,

--- a/src/journals/uri/parse-request.ts
+++ b/src/journals/uri/parse-request.ts
@@ -1,4 +1,4 @@
-import { CalendarDate } from "@/calendar";
+import { parseDateExpression, type CalendarDate } from "@/calendar";
 import type { OpenMode } from "@/infrastructure/host";
 import { Err, Ok } from "@/infrastructure/result";
 import type { Result } from "@/infrastructure/result";
@@ -14,7 +14,6 @@ import type { UriError } from "./errors";
 
 const WRITE_TYPES = ["day", "week", "month", "quarter", "year"] as const;
 const OPEN_MODES = ["active", "tab", "split", "window"] as const;
-const RELATIVE_DATE = /^([+-])(\d+)([dwmqy])$/;
 
 export type JournalUriWriteType = (typeof WRITE_TYPES)[number];
 
@@ -54,19 +53,8 @@ function parseTarget(parameters: Record<string, string | undefined>): Result<Jou
 }
 
 function parseDate(raw: string | undefined): Result<CalendarDate, UriError> {
-  const value = raw?.trim();
-  if (!value || value === "today") return new Ok(CalendarDate.today());
-
-  const relative = RELATIVE_DATE.exec(value);
-  if (relative) {
-    const sign = relative[1] === "-" ? -1 : 1;
-    const amount = sign * Number(relative[2]);
-    const unit = relative[3] as "d" | "w" | "m" | "q" | "y";
-    return new Ok(CalendarDate.today().shift(amount, unit));
-  }
-
-  const parsed = CalendarDate.parse(value);
-  if (parsed.isErr()) return new Err(new InvalidUriDateError(value));
+  const parsed = parseDateExpression(raw ?? "");
+  if (parsed.isNone()) return new Err(new InvalidUriDateError((raw ?? "").trim()));
   return new Ok(parsed.value);
 }
 


### PR DESCRIPTION
Preparatory refactors for the plugin-facing API ([#78](https://github.com/srg-kostyrko/obsidian-journal/issues/78)). No user-visible change.

These land separately because `OpenDateFlow` has ~10 production call sites — the nav block, the home block, the timeline, `command-registry`, `use-notes-cell` (every calendar cell click), three toolbar items and the URI handler. That is the highest-regression change in the API work, and it deserves a small diff with the e2e suite pointed at it alone rather than being buried in one that also adds a public API, an npm package and a CI step.

## What changed

**`parseDateExpression` moves to `@/calendar`.** The `today` / `±N[dwmqy]` / `YYYY-MM-DD` grammar was private to the URI parser; the API needs the same vocabulary, and one home means both documents teach one thing. `parse-request.ts` now delegates to it.

**`JournalDateResolver` is extracted from `OpenDateFlow`.** The flow resolved candidates, picked when ambiguous, then delegated. The resolve-and-pick half is now its own DI service so a future caller can reuse it without the open.

`pick` deliberately takes names and returns a name rather than resolving the candidate itself: `OpenDateFlow` reports `NoApplicableJournals` when the suggest returns a name that is not among the candidates, and resolving inside `pick` would have collapsed that branch into `UserAborted`.

## Verification

- `npm test` — 3952 passed
- `npm run check:types`, `check:lint`, `check:i18n` — clean
- All **eleven** existing `open-date.flow.test.ts` cases pass with **no assertion edits**. That file builds its container by hand rather than through `journalFlowsModule`, so it needed two DI-wiring lines (import + `c.register`) — `git diff` on it is exactly those two insertions.

e2e is the real gate here, since it is the only thing that covers those ~10 call sites end to end.