### PR TITLE
feat: plugin-facing API (#78)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,3 +22,6 @@ jobs:
       # so any change to the public surface shows up as a diff in the PR that caused it.
       - run: npm run build:api
       - run: git diff --exit-code packages/api/index.d.ts
+      # check:types proves this repo compiles; this proves the package we publish is
+      # usable from TypeScript, which is a different thing.
+      - run: npm run check:api

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,3 +18,7 @@ jobs:
       - run: npm run check:types
       - run: npm test
       - run: npm run check:lint
+      # The published API types are generated from src/api/public-api.ts and committed,
+      # so any change to the public surface shows up as a diff in the PR that caused it.
+      - run: npm run build:api
+      - run: git diff --exit-code packages/api/index.d.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 main.js
+packages/api/index.d.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- Other plugins can now integrate with Journals through a documented API at `app.plugins.plugins.journals.api`, with types published as [`obsidian-journals-api`](https://www.npmjs.com/package/obsidian-journals-api). It covers listing journals, finding the note for a date, creating and opening one, and subscribing to journal and note changes. Because a vault can hold several journals of the same kind, reads return every match and writes ask which one to use — the same picker you see clicking a calendar cell. See [`docs/plugin-api.md`](docs/plugin-api.md).
+
 ### Bug Fixes
 
 - A note whose name carries a date too coarse to tell the journal's periods apart — a year in front of sequential numbers, say — is now matched to its period by the whole name rather than by the date alone. Previously every note of the year attached to whichever period contained January 1st: a journal named `{{date:YYYY}}-C{{cycle}}-S{{sprint}}` collapsed its whole year onto one interval, and a monthly journal named `{{date:YYYY}}-M{{month}}` put all twelve months on January. Notes arriving from sync, added in bulk, or repaired by the vault check all landed on the wrong period. The date and the numbers now identify the period together, so numbering that repeats — twelve months, four quarters — is enough as long as the date says which year it repeats in.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ restate it.
 | [`docs/2026-07-13-ux-text-audit.md`](docs/2026-07-13-ux-text-audit.md) | user-facing copy style — sentence case, error grammar, en-US                                     |
 | [`docs/manual-testing-checklist.md`](docs/manual-testing-checklist.md) | the manual verification pass                                                                     |
 | [`docs/releasing.md`](docs/releasing.md)                               | how a version reaches the community store                                                        |
+| [`docs/plugin-api.md`](docs/plugin-api.md)                             | the plugin-facing API — its surface, stability policy, and the npm package                       |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md)                                   | setup, quality gates, commit and PR conventions                                                  |
 
 **If a rule belongs to one of those documents, it goes there, not here.** This

--- a/README.md
+++ b/README.md
@@ -546,6 +546,13 @@ Produces `Release4711Sprint1` through `Release4711Sprint6`, then rolls over to
 
 **Template Variables**: Special placeholders like `{{date}}` or `{{index}}` that the plugin replaces with actual values when creating notes.
 
+## For plugin developers
+
+Journals exposes an API other plugins can use to list journals, find the note for
+a date, create or open one, and subscribe to changes — see
+[`docs/plugin-api.md`](docs/plugin-api.md). Types are published as
+[`obsidian-journals-api`](https://www.npmjs.com/package/obsidian-journals-api).
+
 ## Contributing
 
 Contributions via bug reports, bug fixes, documentation, and general improvements are always welcome. For more major feature work, open an issue about the idea first so we can judge feasibility and how best to implement it.

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -34,6 +34,7 @@ words:
   - tfile
   - unapplies
   - unitless
+  - unmappable
   - unpadded
   - unrenderable
   - unshifted

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -105,15 +105,15 @@ failures, and the second usually means a stored reference went stale — see
 
 ## Dates
 
-`DateInput` accepts four forms:
+`DateInput` accepts:
 
-```ts
-"2026-08-18"; // recommended
-"today";
-"+1w" / "-3d"; // the same relative grammar the obsidian:// URI uses
-new Date();
-moment(); // anything with toDate()
-```
+| form                                                          | example          |
+| ------------------------------------------------------------- | ---------------- |
+| an ISO date string — **recommended**                          | `"2026-08-18"`   |
+| `"today"`                                                     | `"today"`        |
+| a relative shift, the same grammar the `obsidian://` URI uses | `"+1w"`, `"-3d"` |
+| a `Date`                                                      | `new Date()`     |
+| anything with `toDate()`, such as a moment                    | `moment()`       |
 
 > **Prefer the string form.** A `Date` is a timestamp, not a date. A user in
 > UTC+13 calling `notesFor(sel, new Date())` near midnight — or passing a `Date`

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -1,0 +1,297 @@
+# Plugin API
+
+For developers writing an Obsidian plugin that needs to read or create Journals
+notes. If you are looking for `obsidian://` deep links instead, see the URI
+section of [`README.md`](../README.md).
+
+## Getting the API
+
+```sh
+npm install obsidian-journals-api
+```
+
+The package ships the TypeScript surface and a locator. It contains no domain
+logic, so it cannot drift from the plugin.
+
+```ts
+import { getJournalsApi } from "obsidian-journals-api";
+
+const journals = getJournalsApi(this.app);
+if (!journals) return; // not installed, or not enabled
+```
+
+**Call it at the point of use, not at load.** There is no readiness event, and
+reloading the plugin replaces the object, so a cached reference goes stale. Every
+method is async and waits internally for whatever it needs — you never have to
+schedule around Journals' startup.
+
+## There is no "the" daily note
+
+This is the one assumption worth meeting first. Unlike Daily Notes or Periodic
+Notes, a vault can hold **several journals of the same write type** — a personal
+daily and a work daily, two weeklies on different shelves. So:
+
+- **Reads fan out.** `notesFor` returns an array: empty, one, or several.
+- **Writes resolve to one.** `ensureNote` and `openNote` produce a single note,
+  showing the journal picker when your selector matches more than one — exactly
+  as clicking a calendar cell does.
+
+## The surface
+
+```ts
+interface JournalsApi {
+  readonly apiVersion: number;
+
+  listJournals(selector?: JournalSelector): Promise<readonly JournalInfo[]>;
+  journalInfo(name: string): Promise<JournalInfo | null>;
+
+  notesFor(selector: JournalSelector, date: DateInput): Promise<readonly JournalNote[]>;
+  journalOf(file: TFile): Promise<ExistingJournalNote | null>;
+
+  ensureNote(selector: JournalSelector, date: DateInput, options?: EnsureNoteOptions): Promise<EnsureResult>;
+  openNote(selector: JournalSelector, date: DateInput, options?: OpenNoteOptions): Promise<EnsureResult>;
+
+  on<K extends keyof JournalsApiEvents>(event: K, handler: JournalsApiEvents[K]): () => void;
+}
+```
+
+```ts
+// Which journals exist, and what cadence do they write?
+const dailies = await journals.listJournals({ writeType: "day" });
+//  [{ name: "Work Daily", shelf: "Work", write: { type: "day" } }, …]
+
+// Does today's note exist, and where would it go?
+const [today] = await journals.notesFor("Work Daily", "today");
+//  { journal, date, displayDate, endDate, path, file }
+if (today?.file) await this.app.vault.process(today.file, (text) => `${text}\n- captured`);
+
+// Create it if it is not there. Idempotent.
+const { note, created } = await journals.ensureNote("Work Daily", "today");
+
+// Which journal does the open note belong to?
+const current = await journals.journalOf(this.app.workspace.getActiveFile());
+if (current) console.log(current.journal, current.date);
+
+// React to changes.
+const off = journals.on("noteAdded", ({ journal, date, path }) => {
+  /* … */
+});
+```
+
+## Selectors
+
+A `JournalSelector` picks which journals a call applies to. A bare string is
+shorthand for one journal by name; the object form ANDs its fields; an empty
+selector matches every journal.
+
+```ts
+"Work Daily"                          // that journal
+{ journal: "Work Daily" }             // the same thing
+{ writeType: "week" }                 // every weekly journal
+{ shelf: "Work" }                     // everything on the Work shelf
+{ shelf: "Work", writeType: "day" }   // both conditions
+{ shelf: null }                       // journals on no shelf
+{}                                    // every journal
+```
+
+`shelf` has three states: `undefined` does not filter, `null` means "on no
+shelf", and a string names one. The value you read back from
+`JournalInfo.shelf` can be passed straight back in.
+
+A selector matching nothing is `no-matching-journal`; a selector naming a
+journal that does not exist is `journal-not-found`. Those are different
+failures, and the second usually means a stored reference went stale — see
+[Renames](#renames).
+
+## Dates
+
+`DateInput` accepts four forms:
+
+```ts
+"2026-08-18"; // recommended
+"today";
+"+1w" / "-3d"; // the same relative grammar the obsidian:// URI uses
+new Date();
+moment(); // anything with toDate()
+```
+
+> **Prefer the string form.** A `Date` is a timestamp, not a date. A user in
+> UTC+13 calling `notesFor(sel, new Date())` near midnight — or passing a `Date`
+> parsed from an ISO string ending in `Z` — lands on the wrong day, and it
+> reproduces for their users and not for you. `moment().format("YYYY-MM-DD")` is
+> the safe conversion.
+
+The date you pass is **any day inside the period**; the `date` you get back is
+**the period's own date**. For a monthly journal:
+
+```ts
+const [note] = await journals.notesFor("Monthly", "2026-08-18");
+note.date; // "2026-08-01"
+```
+
+## `date` vs `displayDate`
+
+Every returned note carries three dates, all `"YYYY-MM-DD"`:
+
+| field         | meaning                                                                  |
+| ------------- | ------------------------------------------------------------------------ |
+| `date`        | the period's first day, and its identity — the note's own `journal-date` |
+| `displayDate` | the day the journal formats this period's dates from                     |
+| `endDate`     | the period's last day, **inclusive**                                     |
+
+They are equal for every period kind **except a week**. Under ISO, the week
+containing 1 January 2026 runs Mon 2025-12-29 → Sun 2026-01-04:
+
+```ts
+const [week] = await journals.notesFor("Weekly", "2026-01-01");
+week.date; // "2025-12-29"  ← calendar year 2025
+week.displayDate; // "2026-01-01"  ← week-year 2026; the note is named 2026-W01
+```
+
+**Format from `displayDate`; correlate and store on `date`.** Formatting `date`'s
+year would label that note 2025 while the note itself says 2026. You cannot
+compute `displayDate` yourself, because it depends on the vault's week
+configuration.
+
+`endDate` names a day, not an instant. A containment test needs
+`d >= note.date && d <= note.endDate` on date strings, not a timestamp compare.
+
+## Errors
+
+Failures reject with an error carrying a stable string `code`. Absence is not a
+failure — no note for a period is `file: null`.
+
+| code                  | meaning                                                                   |
+| --------------------- | ------------------------------------------------------------------------- |
+| `journal-not-found`   | no journal by that name — usually a stale stored reference                |
+| `no-matching-journal` | the selector matched no journal                                           |
+| `invalid-date`        | the `DateInput` could not be read                                         |
+| `unmappable-date`     | the journal's configuration cannot place that date in a period            |
+| `outside-timeline`    | the period falls outside the journal's timeline, and no note exists there |
+| `creation-failed`     | the note could not be created or written                                  |
+| `open-failed`         | the note could not be opened                                              |
+| `aborted`             | the user dismissed the confirmation prompt or the journal picker          |
+| `plugin-unloaded`     | Journals was unloaded while the call was in flight                        |
+
+```ts
+try {
+  await journals.ensureNote("Work Daily", "today");
+} catch (error) {
+  switch (error.code) {
+    case "aborted":
+      return; // the user said no
+    case "journal-not-found":
+      return this.forgetStoredJournal();
+    default:
+      console.error("Journals:", error.code, error.message);
+  }
+}
+```
+
+Two rules:
+
+- **Discriminate on `code`, never `instanceof`.** This package ships no error
+  constructor, so `instanceof` cannot work across the boundary.
+- **Always write a default branch.** The code union is deliberately open — new
+  codes are an additive change and will appear without an `apiVersion` bump.
+
+`message` is English developer text and is not translated; it is for your console,
+not your user.
+
+## Renames
+
+A journal's **name is its identity**. If you persist one in your own settings, a
+user renaming that journal leaves you holding a dangling reference — silently,
+since every lookup simply reports `journal-not-found`.
+
+Subscribe and migrate:
+
+```ts
+this.register(
+  journals.on("journalRenamed", ({ from, to }) => {
+    if (this.settings.journal !== from) return;
+    this.settings.journal = to;
+    void this.saveSettings();
+  }),
+);
+```
+
+`on` returns its unsubscribe function, so it hands straight to `this.register`.
+
+Available events: `journalCreated`, `journalRenamed`, `journalDeleted`,
+`noteAdded`, `noteRemoved`. Note events carry `path` rather than a `TFile`,
+because on removal the file is already gone.
+
+## `path` is for display, not for writing
+
+`JournalNote.path` tells you where a note is, or where it _would_ be created. It
+is safe to show a user. Writing there yourself is not the supported path.
+
+It usually works — Journals reverse-parses the path back to the journal and
+adopts the file. But it fails **silently** when the journal's name template is
+not invertible, when two journals resolve to the same path, when the date is
+outside the timeline, or when the note claims a journal that no longer exists.
+It is also asynchronous: write the file and call `notesFor` immediately and you
+will see `file: null`, because the index only picks it up once Obsidian re-parses
+the frontmatter.
+
+`ensureNote` does all of that deterministically and hands you the connected note.
+Use it.
+
+Also: a returned `path` is valid only as of the call. Changing a journal's name
+template or folder invalidates every path previously returned — do not cache them.
+
+`path` is `null` when Journals will not place a note there at all: outside the
+timeline, or a name template that renders to nothing.
+
+## Versioning
+
+`apiVersion` is an integer, bumped **only** on a breaking change. The package's
+major version tracks it, so `obsidian-journals-api@1.x` describes `apiVersion 1`.
+
+| additive — no bump                        | breaking — bumps `apiVersion`           |
+| ----------------------------------------- | --------------------------------------- |
+| a new method                              | removing or renaming anything           |
+| a new optional field on an options object | changing a returned shape               |
+| a new readonly field on a returned object | narrowing a parameter type              |
+| a new event name                          | changing an existing method's semantics |
+| **a new error code**                      |                                         |
+| widening a parameter union                |                                         |
+
+Within an `apiVersion`, only additive changes are made. There is no promise to
+keep serving version N−1 after a bump.
+
+Adding a method is additive for callers but breaks a test double written as
+`implements JournalsApi` — mock the methods you use rather than the whole
+interface.
+
+The plugin's own version is not exposed. Read
+`app.plugins.plugins.journals.manifest.version` if you need it for a bug report,
+and do not branch on it.
+
+## Coming from `obsidian-daily-notes-interface`
+
+That package reads the Daily Notes plugin's settings and reimplements its logic.
+This one talks to Journals directly, so the shapes differ — and the difference
+that matters is the one at the top of this page: **there is no "the" daily note.**
+Every row below returns or acts on a set, not a singleton.
+
+| `obsidian-daily-notes-interface`       | Journals                                    | note                                          |
+| -------------------------------------- | ------------------------------------------- | --------------------------------------------- |
+| `appHasDailyNotesPluginLoaded()`       | `getJournalsApi(app) !== null`              |                                               |
+| `getAllDailyNotes()`                   | `listJournals({ writeType: "day" })`        | returns **journals**, not notes               |
+| `getDailyNote(date, all)`              | `notesFor({ writeType: "day" }, date)`      | an **array** — empty, one, or several         |
+| `createDailyNote(date)`                | `ensureNote({ writeType: "day" }, date)`    | idempotent; shows the picker if several match |
+| `getDateFromFile(file, "day")`         | `journalOf(file)` → `.date`                 | also gives the journal and the period bounds  |
+| `getWeeklyNote` / `getMonthlyNote` / … | the same calls with a different `writeType` | one surface instead of six                    |
+
+Two behaviours with no equivalent, worth knowing before you port:
+
+- **Creation may prompt.** If the user set _Confirm creation_ on a journal,
+  `ensureNote` shows that prompt. Pass `{ confirm: false }` when you are
+  backfilling a range or running in the background, or you will produce one
+  dialog per note.
+- **Custom journals exist.** A journal can write every N days/weeks/months rather
+  than on a calendar boundary. They appear as `write.type === "custom"` with
+  `every` and `duration`, and they are reachable by name — no `writeType` maps
+  onto them.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -97,3 +97,32 @@ default, which stays at read.
 `checks.yml` does run on the tag push, but in a separate workflow that cannot
 stop the draft. And the beta path has not shipped anything since the 2.0.1
 series — treat the first v3 beta as untested machinery.
+
+## API package release
+
+`packages/api` (`obsidian-journals-api`) is published from your machine — no
+workflow, no `NPM_TOKEN`.
+
+**1. The plugin stable release completes first.** The published types describe a
+surface users must already have; publishing ahead of it hands integrators a
+compile-clean call against an API nobody is running.
+
+**2. Bump `packages/api/package.json`.** Major only when `apiVersion` moves in
+`src/api/public-api.ts`; minor for additions.
+
+**3. Publish.**
+
+```bash
+cd packages/api && npm publish --access public
+```
+
+`prepublishOnly` regenerates `index.d.ts` from `src/api/public-api.ts` and
+refuses to publish if the committed file disagrees with its source.
+
+**4. Record it in `CHANGELOG.md`** under the plugin version that shipped the
+surface.
+
+Publishing locally means the package carries **no npm provenance attestation**
+(`--provenance` needs CI's OIDC token, unlike the plugin's build artifacts), and
+that your npm 2FA prompt applies. Both are deliberate: the alternative is an
+automation token sitting in repository secrets.

--- a/e2e/integration/plugin-api.e2e.ts
+++ b/e2e/integration/plugin-api.e2e.ts
@@ -1,0 +1,99 @@
+import { browser, expect } from "@wdio/globals";
+
+import { waitForJournalFrontmatter } from "../support/vault.js";
+
+// The API is the one surface unit tests cannot prove: it is reached through Obsidian's
+// plugin registry, and the note it creates only becomes visible to `notesFor` once
+// metadataCache has re-parsed the frontmatter. The `e2e-daily` fixture commits exactly one
+// journal, named `daily`, whose notes live at `{{date}}.md`.
+describe("plugin API", () => {
+  before(async () => {
+    await browser.reloadObsidian({ vault: "./e2e/fixtures/e2e-daily", plugins: ["journals"] });
+  });
+
+  it("is reachable at the documented registry path", async () => {
+    const version = await browser.waitUntil(
+      async () => {
+        // executeObsidian serializes undefined as null over the wire, so guard both or a
+        // not-yet-assigned api throws out of waitUntil instead of retrying.
+        const value = await browser.executeObsidian(({ app }) => {
+          const plugins = (app as unknown as { plugins: { plugins: Record<string, { api?: { apiVersion: number } }> } })
+            .plugins.plugins;
+          return plugins.journals?.api?.apiVersion ?? null;
+        });
+        return value ?? false;
+      },
+      { timeout: 10_000, timeoutMsg: "app.plugins.plugins.journals.api never appeared" },
+    );
+
+    expect(version).toBe(1);
+  });
+
+  it("lists the fixture's journal", async () => {
+    const names = await browser.executeObsidian(async ({ app }) => {
+      const api = (app as unknown as { plugins: { plugins: Record<string, { api: unknown }> } }).plugins.plugins
+        .journals.api as {
+        listJournals(selector: { writeType: string }): Promise<{ name: string; write: { type: string } }[]>;
+      };
+      const journals = await api.listJournals({ writeType: "day" });
+      return journals.map((journal) => journal.name);
+    });
+
+    expect(names).toEqual(["daily"]);
+  });
+
+  it("creates a note through ensureNote and finds it again through notesFor", async () => {
+    const created = await browser.executeObsidian(async ({ app }) => {
+      const api = (app as unknown as { plugins: { plugins: Record<string, { api: unknown }> } }).plugins.plugins
+        .journals.api as {
+        ensureNote(
+          selector: string,
+          date: string,
+        ): Promise<{ created: boolean; note: { path: string; date: string; endDate: string } }>;
+      };
+      const result = await api.ensureNote("daily", "2024-03-07");
+      return { path: result.note.path, date: result.note.date, endDate: result.note.endDate, created: result.created };
+    });
+
+    expect(created.created).toBe(true);
+    expect(created.date).toBe("2024-03-07");
+    expect(created.endDate).toBe("2024-03-07");
+    expect(created.path).toBe("2024-03-07.md");
+
+    // The write is what makes it a journal note; the index only sees it once Obsidian
+    // re-parses the frontmatter, which is the gap this whole spec exists to cross.
+    await waitForJournalFrontmatter("2024-03-07.md", { journal: "daily", date: "2024-03-07" });
+
+    const found = await browser.waitUntil(
+      async () => {
+        const value = await browser.executeObsidian(async ({ app }) => {
+          const api = (app as unknown as { plugins: { plugins: Record<string, { api: unknown }> } }).plugins.plugins
+            .journals.api as {
+            notesFor(selector: string, date: string): Promise<{ path: string | null; file: unknown }[]>;
+          };
+          const [note] = await api.notesFor("daily", "2024-03-07");
+          return note?.file == null ? null : note.path;
+        });
+        return value ?? false;
+      },
+      { timeout: 10_000, timeoutMsg: "the created note never appeared in the index" },
+    );
+
+    expect(found).toBe("2024-03-07.md");
+  });
+
+  it("reports an unknown journal as journal-not-found", async () => {
+    const code = await browser.executeObsidian(async ({ app }) => {
+      const api = (app as unknown as { plugins: { plugins: Record<string, { api: unknown }> } }).plugins.plugins
+        .journals.api as { ensureNote(selector: string, date: string): Promise<unknown> };
+      try {
+        await api.ensureNote("no-such-journal", "2024-03-07");
+        return null;
+      } catch (error) {
+        return (error as { code?: string }).code ?? null;
+      }
+    });
+
+    expect(code).toBe("journal-not-found");
+  });
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -63,6 +63,7 @@ const noEagerMessage = {
 export default [
   {
     ignores: [
+      "packages/**",
       "**/build/**",
       "**/test-vault/**",
       "**/perf-vault/**",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -402,4 +402,24 @@ export default [
       "unicorn/filename-case": ["error", { case: "pascalCase", checkDirectories: false }],
     },
   },
+  {
+    // Copied verbatim into the published packages/api/index.d.ts, so it may reference
+    // nothing a consumer does not have. The moment someone imports a branded type here,
+    // the published types break at *their* typecheck, not ours.
+    files: ["src/api/public-api.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["*", "!obsidian"],
+              message:
+                'public-api.ts is copied verbatim into the published .d.ts. Only `import type { TFile } from "obsidian"` is allowed.',
+            },
+          ],
+        },
+      ],
+    },
+  },
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -44,6 +44,15 @@ const obsidianMomentImport = {
 
 const momentImportPaths = [bareMomentImport, obsidianMomentImport];
 
+// `NoteFileService` is the single place a raw `TFile` leaves the host layer, and it exists
+// only so the public API can hand integrators one. Every other consumer takes the domain
+// `Note` from `NotesService`; the exemption below is `src/api/` and the host itself.
+const noteFileServiceImport = {
+  group: ["**/host/internal/note-file-service"],
+  message:
+    "NoteFileService is the single TFile escape hatch and belongs to src/api only. Use NotesService and the domain `Note` instead.",
+};
+
 const noEagerMessage = {
   selector:
     "CallExpression[callee.object.name='m']:not(:function CallExpression):not(PropertyDefinition CallExpression)",
@@ -194,7 +203,7 @@ export default [
       // domain-meaningful check at every site it flags.
       "unicorn/prefer-simple-condition-first": "off",
 
-      "no-restricted-imports": ["error", { paths: momentImportPaths }],
+      "no-restricted-imports": ["error", { paths: momentImportPaths, patterns: [noteFileServiceImport] }],
       "no-restricted-syntax": ["error", noRawError, noStrayDefineModal],
 
       "@eslint-community/eslint-comments/no-use": ["error", { allow: [] }],
@@ -360,7 +369,7 @@ export default [
     rules: {
       // The calendar module IS the abstraction, so `import { moment } from "obsidian"` belongs
       // here and nowhere else. The bare-package ban still applies.
-      "no-restricted-imports": ["error", { paths: [bareMomentImport] }],
+      "no-restricted-imports": ["error", { paths: [bareMomentImport], patterns: [noteFileServiceImport] }],
     },
   },
   {
@@ -400,6 +409,14 @@ export default [
     files: ["src/**/*.vue"],
     rules: {
       "unicorn/filename-case": ["error", { case: "pascalCase", checkDirectories: false }],
+    },
+  },
+  {
+    // The two directories the TFile escape hatch is for: the API that returns one, and the
+    // host layer that owns it.
+    files: ["src/api/**/*.ts", "src/infrastructure/host/**/*.ts"],
+    rules: {
+      "no-restricted-imports": ["error", { paths: momentImportPaths }],
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "name": "obsidian-journal",
   "version": "3.1.0",
   "description": "Journal plugin for Obsidian (https://obsidian.md)",
+  "private": true,
   "main": "main.js",
   "scripts": {
     "dev": "vite build --watch",
     "build": "vite build",
+    "build:api": "node scripts/build-api-types.mjs",
     "compile:i18n": "paraglide-js compile --project ./project.inlang --outdir ./src/i18n/paraglide --output-structure locale-modules",
     "check:i18n": "node scripts/check-i18n-glossary.mjs",
     "version": "node version-bump.mjs && git add manifest.json manifest-beta.json versions.json CHANGELOG.md",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:api": "node scripts/build-api-types.mjs",
     "compile:i18n": "paraglide-js compile --project ./project.inlang --outdir ./src/i18n/paraglide --output-structure locale-modules",
     "check:i18n": "node scripts/check-i18n-glossary.mjs",
+    "check:api": "node scripts/check-api-package.mjs",
     "version": "node version-bump.mjs && git add manifest.json manifest-beta.json versions.json CHANGELOG.md",
     "check:lint": "eslint . --cache --cache-location node_modules/.cache/eslint/",
     "test": "vitest run",

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1,0 +1,43 @@
+# obsidian-journals-api
+
+Types and a locator for the [Journals](https://github.com/srg-kostyrko/obsidian-journal)
+Obsidian plugin's API. This package contains **no domain logic** — it describes the
+surface the plugin exposes and helps you find it.
+
+```sh
+npm install obsidian-journals-api
+```
+
+## Usage
+
+Call `getJournalsApi` at the point of use rather than caching it at load: there is no
+readiness event, and reloading the plugin replaces the object.
+
+```ts
+import { getJournalsApi } from "obsidian-journals-api";
+
+const journals = getJournalsApi(this.app);
+if (!journals) return; // Journals is not installed or not enabled
+
+// Journals allows several journals of the same kind, so reads fan out.
+const notes = await journals.notesFor({ writeType: "day" }, "today");
+
+// Writes resolve to exactly one note, asking the user when a selector is ambiguous.
+const { note, created } = await journals.ensureNote({ writeType: "day" }, "today");
+```
+
+## There is no "the" daily note
+
+Unlike Daily Notes or Periodic Notes, a vault can hold **several** journals of the same
+write type. `notesFor` therefore returns an array, and `ensureNote` shows the journal
+picker when more than one matches. Coming from `obsidian-daily-notes-interface`? See the
+migration table in the plugin's [`docs/plugin-api.md`](https://github.com/srg-kostyrko/obsidian-journal/blob/main/docs/plugin-api.md).
+
+## Versioning
+
+`api.apiVersion` is an integer, bumped only on a breaking change; this package's **major**
+tracks it, so `obsidian-journals-api@1.x` describes `apiVersion 1`. Additive changes —
+including **new error codes** — never move it, so always handle the default case when
+branching on `error.code`.
+
+Full reference: [`docs/plugin-api.md`](https://github.com/srg-kostyrko/obsidian-journal/blob/main/docs/plugin-api.md).

--- a/packages/api/index.d.ts
+++ b/packages/api/index.d.ts
@@ -1,0 +1,122 @@
+// Generated from src/api/public-api.ts by scripts/build-api-types.mjs.
+// Do not edit by hand — run `npm run build:api`.
+
+import type { TFile } from "obsidian";
+
+/** Anything with toDate() — notably a moment, which is what Obsidian hands out. */
+export interface DateLike {
+  toDate(): Date;
+}
+
+/** "YYYY-MM-DD", "today", a relative shift like "+1w" / "-3d", a Date, or a moment. */
+export type DateInput = Date | DateLike | string;
+
+export type JournalWriteType = "day" | "week" | "month" | "quarter" | "year" | "custom";
+
+/**
+ * Selects journals. A bare string is shorthand for { journal: name }.
+ * Fields are ANDed; an empty selector matches every journal.
+ */
+export type JournalSelector =
+  | string
+  | {
+      readonly journal?: string;
+      readonly writeType?: JournalWriteType;
+      /** undefined = any shelf; null = journals on no shelf; a name = that shelf. */
+      readonly shelf?: string | null;
+    };
+
+export type JournalWrite =
+  | { readonly type: "day" | "week" | "month" | "quarter" | "year" }
+  | {
+      readonly type: "custom";
+      readonly every: "day" | "week" | "month" | "quarter" | "year";
+      readonly duration: number;
+    };
+
+export interface JournalInfo {
+  readonly name: string;
+  readonly shelf: string | null;
+  readonly write: JournalWrite;
+}
+
+/** The journal's note for a period — on disk, or where it would go. */
+export interface JournalNote {
+  readonly journal: string;
+  /** "YYYY-MM-DD" — the period's first day, and its identity. The note's `journal-date`. */
+  readonly date: string;
+  /**
+   * "YYYY-MM-DD" — the day this period's dates are formatted from. Equals `date` for every
+   * period kind except a week: the ISO week containing 2026-01-01 has date 2025-12-29 but
+   * displayDate 2026-01-01, and is named 2026-W01. Format from this; correlate on `date`.
+   */
+  readonly displayDate: string;
+  /** "YYYY-MM-DD" — the period's last day, inclusive. The note's `journal-end-date`. */
+  readonly endDate: string;
+  /** Where the note is, or would be created. null = no note can be placed here. */
+  readonly path: string | null;
+  /** null = not created yet. */
+  readonly file: TFile | null;
+}
+
+/** A JournalNote that exists on disk. */
+export interface ExistingJournalNote extends JournalNote {
+  readonly path: string;
+  readonly file: TFile;
+}
+
+export interface EnsureNoteOptions {
+  /** Show the journal's creation-confirmation prompt. Defaults to the journal's own setting. */
+  readonly confirm?: boolean;
+}
+
+export interface OpenNoteOptions extends EnsureNoteOptions {
+  readonly openMode?: "active" | "tab" | "split" | "window";
+}
+
+export interface EnsureResult {
+  readonly note: ExistingJournalNote;
+  readonly created: boolean;
+}
+
+/** Open on purpose: new codes are an additive change, so always handle the default case. */
+export type JournalsApiErrorCode =
+  | "journal-not-found"
+  | "no-matching-journal"
+  | "invalid-date"
+  | "unmappable-date"
+  | "outside-timeline"
+  | "creation-failed"
+  | "open-failed"
+  | "aborted"
+  | "plugin-unloaded"
+  | (string & {});
+
+export interface JournalsApiError extends Error {
+  readonly code: JournalsApiErrorCode;
+  readonly journal?: string;
+}
+
+export interface JournalsApiEvents {
+  journalCreated: (event: { journal: string }) => void;
+  journalRenamed: (event: { from: string; to: string }) => void;
+  journalDeleted: (event: { journal: string }) => void;
+  noteAdded: (event: { journal: string; date: string; path: string }) => void;
+  noteRemoved: (event: { journal: string; date: string; path: string }) => void;
+}
+
+export interface JournalsApi {
+  readonly apiVersion: number;
+
+  listJournals(selector?: JournalSelector): Promise<readonly JournalInfo[]>;
+  journalInfo(name: string): Promise<JournalInfo | null>;
+
+  notesFor(selector: JournalSelector, date: DateInput): Promise<readonly JournalNote[]>;
+  journalOf(file: TFile): Promise<ExistingJournalNote | null>;
+
+  ensureNote(selector: JournalSelector, date: DateInput, options?: EnsureNoteOptions): Promise<EnsureResult>;
+  openNote(selector: JournalSelector, date: DateInput, options?: OpenNoteOptions): Promise<EnsureResult>;
+
+  /** Synchronous — returns its unsubscribe disposer. */
+  on<K extends keyof JournalsApiEvents>(event: K, handler: JournalsApiEvents[K]): () => void;
+}

--- a/packages/api/index.d.ts
+++ b/packages/api/index.d.ts
@@ -120,3 +120,12 @@ export interface JournalsApi {
   /** Synchronous — returns its unsubscribe disposer. */
   on<K extends keyof JournalsApiEvents>(event: K, handler: JournalsApiEvents[K]): () => void;
 }
+
+/**
+ * Returns the Journals plugin API, or null when Journals is not installed, not enabled, or
+ * older than the release that introduced the API.
+ *
+ * Call this at the point of use rather than caching it: there is no readiness event, and
+ * reloading the plugin replaces the object.
+ */
+export declare function getJournalsApi(app: import("obsidian").App): JournalsApi | null;

--- a/packages/api/index.js
+++ b/packages/api/index.js
@@ -1,0 +1,12 @@
+/**
+ * Returns the Journals plugin API, or null when Journals is not installed or not enabled.
+ *
+ * Call this at the point of use rather than caching it at load: there is no readiness
+ * event, and a plugin reload replaces the object.
+ *
+ * @param {import("obsidian").App} app
+ * @returns {import("./index.js").JournalsApi | null}
+ */
+export function getJournalsApi(app) {
+  return app?.plugins?.plugins?.journals?.api ?? null;
+}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -6,8 +6,20 @@
   "type": "module",
   "main": "index.js",
   "types": "index.d.ts",
-  "files": ["index.js", "index.d.ts", "README.md"],
-  "keywords": ["obsidian", "obsidian-plugin", "journals", "periodic-notes"],
+  "peerDependencies": {
+    "obsidian": ">=1.0.0"
+  },
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "README.md"
+  ],
+  "keywords": [
+    "obsidian",
+    "obsidian-plugin",
+    "journals",
+    "periodic-notes"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/srg-kostyrko/obsidian-journal.git",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "obsidian-journals-api",
+  "version": "1.0.0",
+  "description": "Types and locator for the Obsidian Journals plugin API",
+  "license": "MIT",
+  "type": "module",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "files": ["index.js", "index.d.ts", "README.md"],
+  "keywords": ["obsidian", "obsidian-plugin", "journals", "periodic-notes"],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/srg-kostyrko/obsidian-journal.git",
+    "directory": "packages/api"
+  },
+  "scripts": {
+    "prepublishOnly": "node ../../scripts/build-api-types.mjs && git diff --exit-code index.d.ts"
+  }
+}

--- a/scripts/build-api-types.mjs
+++ b/scripts/build-api-types.mjs
@@ -11,4 +11,18 @@ const banner =
   "// Generated from src/api/public-api.ts by scripts/build-api-types.mjs.\n" +
   "// Do not edit by hand — run `npm run build:api`.\n\n";
 
-writeFileSync(target, banner + readFileSync(source, "utf8"));
+// public-api.ts describes the plugin's surface but knows nothing about the package's own
+// entry point, so the locator's declaration is appended here. `import("obsidian")` is used
+// inline rather than as a top-level import so the copied body stays untouched.
+const locator = `
+/**
+ * Returns the Journals plugin API, or null when Journals is not installed, not enabled, or
+ * older than the release that introduced the API.
+ *
+ * Call this at the point of use rather than caching it: there is no readiness event, and
+ * reloading the plugin replaces the object.
+ */
+export declare function getJournalsApi(app: import("obsidian").App): JournalsApi | null;
+`;
+
+writeFileSync(target, banner + readFileSync(source, "utf8") + locator);

--- a/scripts/build-api-types.mjs
+++ b/scripts/build-api-types.mjs
@@ -1,0 +1,14 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Resolved from this file, not the working directory: `prepublishOnly` runs it from packages/api.
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const source = join(root, "src/api/public-api.ts");
+const target = join(root, "packages/api/index.d.ts");
+
+const banner =
+  "// Generated from src/api/public-api.ts by scripts/build-api-types.mjs.\n" +
+  "// Do not edit by hand — run `npm run build:api`.\n\n";
+
+writeFileSync(target, banner + readFileSync(source, "utf8"));

--- a/scripts/check-api-package.mjs
+++ b/scripts/check-api-package.mjs
@@ -1,0 +1,67 @@
+// Compiles a realistic consumer against the built package. `check:types` only proves this
+// repo compiles; nothing else proves the thing we publish is usable from TypeScript — which
+// is how the package once shipped without a declaration for its own entry point.
+import { execFileSync } from "node:child_process";
+import { cpSync, mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const scratch = mkdtempSync(join(tmpdir(), "journals-api-check-"));
+const modules = join(scratch, "node_modules");
+const installed = join(modules, "obsidian-journals-api");
+
+mkdirSync(installed, { recursive: true });
+for (const file of ["index.d.ts", "index.js", "package.json"]) {
+  cpSync(join(root, "packages/api", file), join(installed, file));
+}
+symlinkSync(join(root, "node_modules/obsidian"), join(modules, "obsidian"));
+
+writeFileSync(
+  join(scratch, "consumer.ts"),
+  `import { getJournalsApi } from "obsidian-journals-api";
+import type { JournalNote, JournalsApiErrorCode } from "obsidian-journals-api";
+import type { App, TFile } from "obsidian";
+
+export async function capture(app: App): Promise<TFile | null> {
+  const journals = getJournalsApi(app);
+  if (!journals) return null;
+
+  const dailies = await journals.listJournals({ writeType: "day", shelf: null });
+  const notes: readonly JournalNote[] = await journals.notesFor({ writeType: "day" }, "today");
+  const off = journals.on("journalRenamed", ({ from, to }) => void [from, to]);
+  off();
+
+  try {
+    const { note, created } = await journals.ensureNote(dailies[0]?.name ?? "Daily", "+1w", { confirm: false });
+    return created ? note.file : null;
+  } catch (error) {
+    const code = (error as { code: JournalsApiErrorCode }).code;
+    // The union is open, so a default branch must always compile.
+    return code === "aborted" ? null : null;
+  }
+}
+`,
+);
+
+execFileSync(
+  process.execPath,
+  [
+    join(root, "node_modules/typescript/bin/tsc"),
+    "--noEmit",
+    "--strict",
+    "--skipLibCheck",
+    "--moduleResolution",
+    "bundler",
+    "--module",
+    "esnext",
+    "--target",
+    "es2022",
+    "consumer.ts",
+  ],
+  // From the scratch dir so tsc does not pick up this repo's tsconfig.json.
+  { stdio: "inherit", cwd: scratch },
+);
+
+console.log("api package: a consumer compiles against the published types");

--- a/scripts/check-api-package.mjs
+++ b/scripts/check-api-package.mjs
@@ -2,7 +2,7 @@
 // repo compiles; nothing else proves the thing we publish is usable from TypeScript — which
 // is how the package once shipped without a declaration for its own entry point.
 import { execFileSync } from "node:child_process";
-import { cpSync, mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -16,7 +16,24 @@ mkdirSync(installed, { recursive: true });
 for (const file of ["index.d.ts", "index.js", "package.json"]) {
   cpSync(join(root, "packages/api", file), join(installed, file));
 }
+// The consumer supplies the peers, so model that rather than pretending they are absent —
+// and separately assert the package actually declares everything its types reach for.
 symlinkSync(join(root, "node_modules/obsidian"), join(modules, "obsidian"));
+
+const types = readFileSync(join(root, "packages/api/index.d.ts"), "utf8");
+const manifest = JSON.parse(readFileSync(join(root, "packages/api/package.json"), "utf8"));
+const declared = new Set([
+  ...Object.keys(manifest.dependencies ?? {}),
+  ...Object.keys(manifest.peerDependencies ?? {}),
+]);
+const referenced = new Set([...types.matchAll(/(?:from|import\()\s*"([^."][^"]*)"/g)].map((match) => match[1]));
+const undeclared = [...referenced].filter((name) => !declared.has(name));
+if (undeclared.length > 0) {
+  throw new Error(
+    `packages/api/index.d.ts references ${undeclared.join(", ")}, which packages/api/package.json ` +
+      "does not declare as a dependency or peerDependency. A consumer without it cannot resolve the types.",
+  );
+}
 
 writeFileSync(
   join(scratch, "consumer.ts"),
@@ -64,4 +81,4 @@ execFileSync(
   { stdio: "inherit", cwd: scratch },
 );
 
-console.log("api package: a consumer compiles against the published types");
+console.log("api package: declares its peers, and a consumer compiles against the published types");

--- a/src/api/convert.test.ts
+++ b/src/api/convert.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { installTestCalendar } from "@/calendar/testing";
+import { customJournal, fixedJournal } from "@/journals/testing";
+
+import { normalizeSelector, toCalendarDate, toJournalInfo } from "./convert";
+
+function anchorOf(input: Parameters<typeof toCalendarDate>[0]): string | null {
+  const parsed = toCalendarDate(input);
+  return parsed.isSome() ? parsed.value.toAnchor() : null;
+}
+
+describe("toCalendarDate", () => {
+  let teardown: () => void;
+
+  beforeEach(() => {
+    ({ teardown } = installTestCalendar());
+  });
+
+  afterEach(() => {
+    teardown();
+  });
+
+  it("reads a JS Date in local time, ignoring its clock", () => {
+    expect(anchorOf(new Date(2026, 7, 18, 23, 45))).toBe("2026-08-18");
+  });
+
+  it("accepts anything with toDate()", () => {
+    expect(anchorOf({ toDate: () => new Date(2026, 0, 2) })).toBe("2026-01-02");
+  });
+
+  it("accepts a date expression string", () => {
+    expect(anchorOf("2026-03-09")).toBe("2026-03-09");
+  });
+
+  it("accepts the relative grammar the URI handler uses", () => {
+    expect(anchorOf("today")).not.toBeNull();
+    expect(anchorOf("+1w")).not.toBe(anchorOf("today"));
+  });
+
+  it("returns none for a string it cannot read", () => {
+    expect(anchorOf("whenever")).toBeNull();
+  });
+
+  it("returns none for an invalid Date", () => {
+    expect(anchorOf(new Date(NaN))).toBeNull();
+  });
+});
+
+describe("normalizeSelector", () => {
+  it("treats a bare string as a journal name", () => {
+    expect(normalizeSelector("Work Daily")).toEqual({ journal: "Work Daily" });
+  });
+
+  it("passes an object through, keeping an explicit null shelf", () => {
+    expect(normalizeSelector({ writeType: "day", shelf: null })).toEqual({ writeType: "day", shelf: null });
+  });
+
+  it("treats undefined as matching everything", () => {
+    expect(normalizeSelector(undefined)).toEqual({});
+  });
+});
+
+describe("toJournalInfo", () => {
+  it("flattens the empty-shelf sentinel to null", () => {
+    expect(toJournalInfo("daily", fixedJournal("daily", { type: "day" }), "")).toEqual({
+      name: "daily",
+      shelf: null,
+      write: { type: "day" },
+    });
+  });
+
+  it("carries interval data for a custom journal", () => {
+    expect(toJournalInfo("sprint", customJournal("sprint", "week", 3, "2026-01-05"), "Work")).toEqual({
+      name: "sprint",
+      shelf: "Work",
+      write: { type: "custom", every: "week", duration: 3 },
+    });
+  });
+});

--- a/src/api/convert.ts
+++ b/src/api/convert.ts
@@ -1,0 +1,43 @@
+import { match } from "ts-pattern";
+
+import { parseDateExpression } from "@/calendar";
+import type { CalendarDate } from "@/calendar";
+import { Option } from "@/infrastructure/result";
+import type { JournalConfig } from "@/journals/config";
+
+import type { DateInput, JournalInfo, JournalSelector, JournalWrite, JournalWriteType } from "./public-api";
+
+export interface NormalizedSelector {
+  journal?: string;
+  writeType?: JournalWriteType;
+  shelf?: string | null;
+}
+
+function pad(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+function hasToDate(input: DateInput): input is { toDate(): Date } {
+  return typeof input === "object" && typeof (input as { toDate?: unknown }).toDate === "function";
+}
+
+export function toCalendarDate(input: DateInput): Option<CalendarDate> {
+  if (typeof input === "string") return parseDateExpression(input);
+  // A Date is a timestamp; the journal cares only about the local calendar day it names.
+  const js = hasToDate(input) ? input.toDate() : input;
+  if (Number.isNaN(js.getTime())) return Option.none();
+  return parseDateExpression(`${js.getFullYear()}-${pad(js.getMonth() + 1)}-${pad(js.getDate())}`);
+}
+
+export function normalizeSelector(selector: JournalSelector | undefined): NormalizedSelector {
+  if (selector === undefined) return {};
+  if (typeof selector === "string") return { journal: selector };
+  return { ...selector };
+}
+
+export function toJournalInfo(name: string, config: JournalConfig, shelf: string): JournalInfo {
+  const write: JournalWrite = match(config.write)
+    .with({ type: "custom" }, ({ every, duration }) => ({ type: "custom" as const, every, duration }))
+    .otherwise(({ type }) => ({ type }));
+  return { name, shelf: shelf === "" ? null : shelf, write };
+}

--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -1,0 +1,16 @@
+import type { JournalsApiErrorCode } from "./public-api";
+
+/**
+ * The only error shape that crosses the plugin boundary. Consumers discriminate on
+ * `code` — never `instanceof`, because the published package ships no constructor.
+ */
+export class ApiError extends Error {
+  constructor(
+    readonly code: JournalsApiErrorCode,
+    message: string,
+    readonly journal?: string,
+  ) {
+    super(message);
+    this.name = "JournalsApiError";
+  }
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,3 @@
+export { apiModule } from "./module";
+export { JournalsApiService } from "./journals-api";
+export type * from "./public-api";

--- a/src/api/journals-api.test.ts
+++ b/src/api/journals-api.test.ts
@@ -70,12 +70,15 @@ function buildApi(journals: Record<string, JournalConfig>, options: BuildOptions
   if (options.ready !== false) index.markReady();
 
   // Stands in for Flows: records what was invoked and registers the entry the way a real
-  // write does once metadataCache has parsed it.
+  // write does once metadataCache has parsed it. Idempotent for an entry that already
+  // exists, matching NoteCreationService.ensureNote.
   c.register(Flows).useValue({
     invoke: (cls: { name: string }, parameters: Record<string, unknown>) => {
       flowCalls.push({ flow: cls.name, parameters });
       const name = String(parameters.journalName);
       const anchor = String(parameters.anchor) as AnchorString;
+      const existing = index.entryByAnchor(name, anchor);
+      if (existing.isSome()) return AsyncResult.ok({ path: existing.value.path, created: false });
       const path = `${name}/${anchor}.md` as VaultPath;
       index.register({ journalName: name, anchor, path });
       return AsyncResult.ok({ path, created: true });
@@ -243,5 +246,144 @@ describe("JournalsApiService reads", () => {
     const { api } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
 
     expect(await api.journalOf({ path: "Random/note.md" })).toBeNull();
+  });
+});
+
+describe("JournalsApiService writes", () => {
+  let teardown: () => void;
+
+  beforeEach(() => {
+    ({ teardown } = installTestCalendar(ISO_WEEK));
+  });
+
+  afterEach(() => {
+    teardown();
+  });
+
+  it("creates the note through the ensure flow and reports created", async () => {
+    const { api, flowCalls } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+
+    const result = await api.ensureNote("daily", "2026-08-18");
+
+    expect(result.created).toBe(true);
+    expect(result.note.journal).toBe("daily");
+    expect(result.note.file).not.toBeNull();
+    expect(flowCalls.at(-1)?.flow).toBe("EnsureJournalEntryFlow");
+  });
+
+  it("opens through the open flow, passing the open mode", async () => {
+    const { api, flowCalls } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+
+    await api.openNote("daily", "2026-08-18", { openMode: "split" });
+
+    expect(flowCalls.at(-1)?.flow).toBe("OpenJournalEntryFlow");
+    expect(flowCalls.at(-1)?.parameters).toMatchObject({ openMode: "split" });
+  });
+
+  it("rejects with no-matching-journal when the selector matches nothing", async () => {
+    const { api } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+
+    await expect(api.ensureNote({ writeType: "quarter" }, "2026-08-18")).rejects.toMatchObject({
+      code: "no-matching-journal",
+    });
+  });
+
+  it("rejects with journal-not-found for an unknown name", async () => {
+    const { api } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+
+    await expect(api.ensureNote("nope", "2026-08-18")).rejects.toMatchObject({ code: "journal-not-found" });
+  });
+
+  it("rejects with outside-timeline when no note exists and the date is out of range", async () => {
+    const { api } = buildApi({
+      past: fixedJournal(
+        "past",
+        { type: "day" },
+        {
+          timeline: {
+            start: "2020-01-01" as AnchorString,
+            end: { kind: "date", date: "2020-12-31" as AnchorString },
+          },
+        },
+      ),
+    });
+
+    await expect(api.ensureNote("past", "2026-08-18")).rejects.toMatchObject({ code: "outside-timeline" });
+  });
+
+  it("still reaches a note that exists outside the timeline", async () => {
+    const { api, index } = buildApi({
+      past: fixedJournal(
+        "past",
+        { type: "day" },
+        {
+          timeline: {
+            start: "2020-01-01" as AnchorString,
+            end: { kind: "date", date: "2020-12-31" as AnchorString },
+          },
+        },
+      ),
+    });
+    index.register({
+      journalName: "past",
+      anchor: "2026-08-18" as AnchorString,
+      path: "Past/2026-08-18.md" as VaultPath,
+    });
+
+    const result = await api.ensureNote("past", "2026-08-18");
+
+    expect(result.note.path).toBe("Past/2026-08-18.md");
+    expect(result.created).toBe(false);
+  });
+
+  it("shows the picker when several journals match, and uses the choice", async () => {
+    const { api, pickedNames } = buildApi(
+      { a: fixedJournal("a", { type: "day" }), b: fixedJournal("b", { type: "day" }) },
+      { pick: "b" },
+    );
+
+    const result = await api.ensureNote({ writeType: "day" }, "2026-08-18");
+
+    expect(pickedNames).toEqual([["a", "b"]]);
+    expect(result.note.journal).toBe("b");
+  });
+
+  it("rejects with aborted when the user dismisses the picker", async () => {
+    const { api } = buildApi(
+      { a: fixedJournal("a", { type: "day" }), b: fixedJournal("b", { type: "day" }) },
+      { pick: null },
+    );
+
+    await expect(api.ensureNote({ writeType: "day" }, "2026-08-18")).rejects.toMatchObject({ code: "aborted" });
+  });
+
+  it("passes skipConfirmation only when confirm is given", async () => {
+    const { api, flowCalls } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+
+    await api.ensureNote("daily", "2026-08-18", { confirm: false });
+    expect(flowCalls.at(-1)?.parameters).toMatchObject({ skipConfirmation: true });
+
+    await api.ensureNote("daily", "2026-08-19");
+    expect(flowCalls.at(-1)?.parameters.skipConfirmation).toBeUndefined();
+  });
+
+  it("shares one flow invocation between concurrent calls for the same period", async () => {
+    const { api, flowCalls } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+
+    const [first, second] = await Promise.all([
+      api.ensureNote("daily", "2026-08-18"),
+      api.ensureNote("daily", "2026-08-18"),
+    ]);
+
+    expect(flowCalls).toHaveLength(1);
+    expect(first.note.path).toBe(second.note.path);
+  });
+
+  it("does not share invocations across different periods", async () => {
+    const { api, flowCalls } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+
+    await Promise.all([api.ensureNote("daily", "2026-08-18"), api.ensureNote("daily", "2026-08-19")]);
+
+    expect(flowCalls).toHaveLength(2);
   });
 });

--- a/src/api/journals-api.test.ts
+++ b/src/api/journals-api.test.ts
@@ -76,9 +76,10 @@ function buildApi(journals: Record<string, JournalConfig>, options: BuildOptions
   const index = c.resolve(JournalsIndex);
   if (options.ready !== false) index.markReady();
 
-  // Stands in for Flows: records what was invoked and registers the entry the way a real
-  // write does once metadataCache has parsed it. Idempotent for an entry that already
-  // exists, matching NoteCreationService.ensureNote.
+  // Stands in for Flows. It deliberately does NOT register the new entry: a real write
+  // returns as soon as the note is on disk, and JournalsIndex only learns about it once
+  // Obsidian re-parses the frontmatter. Idempotent for an entry that already exists,
+  // matching NoteCreationService.ensureNote.
   c.register(Flows).useValue({
     invoke: (cls: { name: string }, parameters: Record<string, unknown>) => {
       flowCalls.push({ flow: cls.name, parameters });
@@ -86,9 +87,7 @@ function buildApi(journals: Record<string, JournalConfig>, options: BuildOptions
       const anchor = String(parameters.anchor) as AnchorString;
       const existing = index.entryByAnchor(name, anchor);
       if (existing.isSome()) return AsyncResult.ok({ path: existing.value.path, created: false });
-      const path = `${name}/${anchor}.md` as VaultPath;
-      index.register({ journalName: name, anchor, path });
-      return AsyncResult.ok({ path, created: true });
+      return AsyncResult.ok({ path: `${name}/${anchor}.md` as VaultPath, created: true });
     },
   } as never);
   c.register(JournalsApiService).useClass(JournalsApiService);
@@ -276,6 +275,18 @@ describe("JournalsApiService writes", () => {
     expect(result.note.journal).toBe("daily");
     expect(result.note.file).not.toBeNull();
     expect(flowCalls.at(-1)?.flow).toBe("EnsureJournalEntryFlow");
+  });
+
+  it("returns the created note before the index has caught up", async () => {
+    const { api, index } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+
+    const result = await api.ensureNote("daily", "2026-08-18");
+
+    // The index is still empty — the result must come from the write, not a lookup.
+    expect(index.entryByAnchor("daily", "2026-08-18" as AnchorString).isNone()).toBe(true);
+    expect(result.note.path).toBe("daily/2026-08-18.md");
+    expect(result.note.file).not.toBeNull();
+    expect(result.note.endDate).toBe("2026-08-18");
   });
 
   it("opens through the open flow, passing the open mode", async () => {

--- a/src/api/journals-api.test.ts
+++ b/src/api/journals-api.test.ts
@@ -1,3 +1,4 @@
+import { createNanoEvents } from "nanoevents";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { AnchorString } from "@/calendar";
@@ -18,8 +19,10 @@ import { NoteCreationService } from "@/journals/notes/note-creation";
 import { NotePathService } from "@/journals/notes/note-path";
 import { NumberingService } from "@/journals/numbering";
 import { JournalsRepository } from "@/journals/repository";
-import { fakeRepo, fixedJournal } from "@/journals/testing";
+import type { JournalsEvents } from "@/journals/repository";
+import { fixedJournal } from "@/journals/testing";
 import { TimelineService } from "@/journals/timeline";
+import { JournalsEventsToken } from "@/journals/tokens";
 import { ShelvesService } from "@/shelves/service";
 import { TemplateEngine } from "@/templates";
 
@@ -45,8 +48,12 @@ function buildApi(journals: Record<string, JournalConfig>, options: BuildOptions
 
   const c = new Container();
   c.addModule(LoggerModule);
-  const repo = fakeRepo(journals);
+  // fakeRepo would build its own emitter; the API subscribes through the DI token, so both
+  // sides have to share one.
+  const journalEvents = createNanoEvents<JournalsEvents>();
+  const repo = JournalsRepository.fromParts(journals, journalEvents);
   c.register(JournalsRepository).useValue(repo);
+  c.register(JournalsEventsToken).useValue(journalEvents);
   c.register(JournalsIndex).useClass(JournalsIndex);
   c.register(CycleService).useClass(CycleService);
   c.register(TimelineService).useClass(TimelineService);
@@ -385,5 +392,108 @@ describe("JournalsApiService writes", () => {
     await Promise.all([api.ensureNote("daily", "2026-08-18"), api.ensureNote("daily", "2026-08-19")]);
 
     expect(flowCalls).toHaveLength(2);
+  });
+});
+
+describe("JournalsApiService events", () => {
+  let teardown: () => void;
+
+  beforeEach(() => {
+    ({ teardown } = installTestCalendar(ISO_WEEK));
+  });
+
+  afterEach(() => {
+    teardown();
+  });
+
+  it("reports a rename with both names", () => {
+    const { api, repo } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    const seen: { from: string; to: string }[] = [];
+    api.on("journalRenamed", (event) => {
+      seen.push(event);
+    });
+
+    repo.rename("daily", "journal");
+
+    expect(seen).toEqual([{ from: "daily", to: "journal" }]);
+  });
+
+  it("reports an added note by date", () => {
+    const { api, index } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    const seen: { journal: string; date: string; path: string }[] = [];
+    api.on("noteAdded", (event) => {
+      seen.push(event);
+    });
+
+    index.register({
+      journalName: "daily",
+      anchor: "2026-08-18" as AnchorString,
+      path: "Journal/2026-08-18.md" as VaultPath,
+    });
+
+    expect(seen).toEqual([{ journal: "daily", date: "2026-08-18", path: "Journal/2026-08-18.md" }]);
+  });
+
+  it("reports a removed note", () => {
+    const { api, index } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    index.register({
+      journalName: "daily",
+      anchor: "2026-08-18" as AnchorString,
+      path: "Journal/2026-08-18.md" as VaultPath,
+    });
+    const seen: { journal: string; date: string }[] = [];
+    api.on("noteRemoved", (event) => {
+      seen.push({ journal: event.journal, date: event.date });
+    });
+
+    index.unregister("Journal/2026-08-18.md" as VaultPath);
+
+    expect(seen).toEqual([{ journal: "daily", date: "2026-08-18" }]);
+  });
+
+  it("stops delivering after the disposer runs", () => {
+    const { api, index } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    let calls = 0;
+    const off = api.on("noteAdded", () => {
+      calls += 1;
+    });
+
+    off();
+    index.register({
+      journalName: "daily",
+      anchor: "2026-08-18" as AnchorString,
+      path: "Journal/2026-08-18.md" as VaultPath,
+    });
+
+    expect(calls).toBe(0);
+  });
+});
+
+describe("JournalsApiService unloading", () => {
+  let teardown: () => void;
+
+  beforeEach(() => {
+    ({ teardown } = installTestCalendar(ISO_WEEK));
+  });
+
+  afterEach(() => {
+    teardown();
+  });
+
+  it("rejects an in-flight call with plugin-unloaded", async () => {
+    const { api } = buildApi({ daily: fixedJournal("daily", { type: "day" }) }, { ready: false });
+    const pending = api.notesFor("daily", "2026-08-18");
+
+    await api[Symbol.asyncDispose]();
+
+    await expect(pending).rejects.toMatchObject({ code: "plugin-unloaded" });
+  });
+
+  it("rejects calls made after disposal", async () => {
+    const { api } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+
+    await api[Symbol.asyncDispose]();
+
+    await expect(api.notesFor("daily", "2026-08-18")).rejects.toMatchObject({ code: "plugin-unloaded" });
   });
 });

--- a/src/api/journals-api.test.ts
+++ b/src/api/journals-api.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { AnchorString } from "@/calendar";
+import { installTestCalendar } from "@/calendar/testing";
+import { Container } from "@/infrastructure/di";
+import { Flows } from "@/infrastructure/flows";
+import { SuggestService, WorkspaceService } from "@/infrastructure/host";
+import type { VaultPath } from "@/infrastructure/host";
+import { NoteFileService } from "@/infrastructure/host/internal/note-file-service";
+import { LoggerModule } from "@/infrastructure/logger";
+import { AsyncResult, Err, Ok } from "@/infrastructure/result";
+import type { JournalConfig } from "@/journals/config";
+import { CycleService } from "@/journals/cycle";
+import { JournalDateResolver } from "@/journals/flows";
+import { FrontmatterService } from "@/journals/frontmatter";
+import { JournalsIndex } from "@/journals/journals-index";
+import { NoteCreationService } from "@/journals/notes/note-creation";
+import { NotePathService } from "@/journals/notes/note-path";
+import { NumberingService } from "@/journals/numbering";
+import { JournalsRepository } from "@/journals/repository";
+import { fakeRepo, fixedJournal } from "@/journals/testing";
+import { TimelineService } from "@/journals/timeline";
+import { ShelvesService } from "@/shelves/service";
+import { TemplateEngine } from "@/templates";
+
+import { JournalsApiService } from "./journals-api";
+
+interface BuildOptions {
+  /** Which shelf each journal sits on. Default: none. */
+  shelfOf?: (name: string) => string;
+  /** What the picker returns when several journals match. null = dismissed. */
+  pick?: string | null;
+  /** Leave the index un-ready so whenReady() stays pending. Default true. */
+  ready?: boolean;
+}
+
+interface FlowCall {
+  flow: string;
+  parameters: Record<string, unknown>;
+}
+
+function buildApi(journals: Record<string, JournalConfig>, options: BuildOptions = {}) {
+  const pickedNames: string[][] = [];
+  const flowCalls: FlowCall[] = [];
+
+  const c = new Container();
+  c.addModule(LoggerModule);
+  const repo = fakeRepo(journals);
+  c.register(JournalsRepository).useValue(repo);
+  c.register(JournalsIndex).useClass(JournalsIndex);
+  c.register(CycleService).useClass(CycleService);
+  c.register(TimelineService).useClass(TimelineService);
+  c.register(NumberingService).useClass(NumberingService);
+  c.register(FrontmatterService).useClass(FrontmatterService);
+  c.register(TemplateEngine).useClass(TemplateEngine);
+  c.register(NotePathService).useClass(NotePathService);
+  c.register(ShelvesService).useValue({ shelfOf: options.shelfOf ?? (() => "") } as never);
+  c.register(NoteFileService).useValue({ resolve: (path: string) => ({ path }) } as never);
+  c.register(WorkspaceService).useValue({} as never);
+  c.register(SuggestService).useValue({
+    open: (_definition: unknown, names: string[]) => {
+      pickedNames.push([...names]);
+      return Promise.resolve(options.pick == null ? new Err(new Error("dismissed")) : new Ok(options.pick));
+    },
+  } as never);
+  c.register(JournalDateResolver).useClass(JournalDateResolver);
+  c.register(NoteCreationService).useValue({} as never);
+
+  const index = c.resolve(JournalsIndex);
+  if (options.ready !== false) index.markReady();
+
+  // Stands in for Flows: records what was invoked and registers the entry the way a real
+  // write does once metadataCache has parsed it.
+  c.register(Flows).useValue({
+    invoke: (cls: { name: string }, parameters: Record<string, unknown>) => {
+      flowCalls.push({ flow: cls.name, parameters });
+      const name = String(parameters.journalName);
+      const anchor = String(parameters.anchor) as AnchorString;
+      const path = `${name}/${anchor}.md` as VaultPath;
+      index.register({ journalName: name, anchor, path });
+      return AsyncResult.ok({ path, created: true });
+    },
+  } as never);
+  c.register(JournalsApiService).useClass(JournalsApiService);
+
+  return { api: c.resolve(JournalsApiService), index, repo, pickedNames, flowCalls };
+}
+
+const ISO_WEEK = { dow: 1, doy: 4 };
+
+describe("JournalsApiService reads", () => {
+  let teardown: () => void;
+
+  beforeEach(() => {
+    ({ teardown } = installTestCalendar(ISO_WEEK));
+  });
+
+  afterEach(() => {
+    teardown();
+  });
+
+  it("lists every journal when the selector is omitted", async () => {
+    const { api } = buildApi({
+      daily: fixedJournal("daily", { type: "day" }),
+      weekly: fixedJournal("weekly", { type: "week" }),
+    });
+
+    const listed = await api.listJournals();
+
+    expect(listed.map((info) => info.name).toSorted()).toEqual(["daily", "weekly"]);
+  });
+
+  it("does not wait for the index to be ready", async () => {
+    const { api } = buildApi({ daily: fixedJournal("daily", { type: "day" }) }, { ready: false });
+
+    const listed = await api.listJournals();
+
+    expect(listed.map((info) => info.name)).toEqual(["daily"]);
+  });
+
+  it("ANDs the selector fields", async () => {
+    const { api } = buildApi(
+      {
+        workDaily: fixedJournal("workDaily", { type: "day" }),
+        homeDaily: fixedJournal("homeDaily", { type: "day" }),
+        workWeekly: fixedJournal("workWeekly", { type: "week" }),
+      },
+      { shelfOf: (name) => (name.startsWith("work") ? "Work" : "") },
+    );
+
+    const listed = await api.listJournals({ writeType: "day", shelf: "Work" });
+
+    expect(listed.map((info) => info.name)).toEqual(["workDaily"]);
+  });
+
+  it("selects off-shelf journals with a null shelf", async () => {
+    const { api } = buildApi(
+      { onShelf: fixedJournal("onShelf", { type: "day" }), loose: fixedJournal("loose", { type: "day" }) },
+      { shelfOf: (name) => (name === "onShelf" ? "Work" : "") },
+    );
+
+    const listed = await api.listJournals({ shelf: null });
+
+    expect(listed.map((info) => info.name)).toEqual(["loose"]);
+  });
+
+  it("returns null from journalInfo for an unknown journal", async () => {
+    const { api } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+
+    expect(await api.journalInfo("nope")).toBeNull();
+  });
+
+  it("reports a period with no note as file null and a predicted path", async () => {
+    const { api } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+
+    const [note] = await api.notesFor("daily", "2026-08-18");
+
+    expect(note?.date).toBe("2026-08-18");
+    expect(note?.displayDate).toBe("2026-08-18");
+    expect(note?.endDate).toBe("2026-08-18");
+    expect(note?.path).toBe("2026-08-18.md");
+    expect(note?.file).toBeNull();
+  });
+
+  it("gives a weekly note its first day as date and its representative as displayDate", async () => {
+    const { api } = buildApi({ weekly: fixedJournal("weekly", { type: "week" }) });
+
+    const [note] = await api.notesFor("weekly", "2026-01-01");
+
+    expect(note?.date).toBe("2025-12-29");
+    expect(note?.displayDate).toBe("2026-01-01");
+    expect(note?.endDate).toBe("2026-01-04");
+  });
+
+  it("reports the note's real path when one exists, not the rendered one", async () => {
+    const { api, index } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    index.register({
+      journalName: "daily",
+      anchor: "2026-08-18" as AnchorString,
+      path: "Somewhere/Else/renamed.md" as VaultPath,
+    });
+
+    const [note] = await api.notesFor("daily", "2026-08-18");
+
+    expect(note?.path).toBe("Somewhere/Else/renamed.md");
+    expect(note?.file).not.toBeNull();
+  });
+
+  it("fans out across every matching journal", async () => {
+    const { api } = buildApi({
+      a: fixedJournal("a", { type: "day" }),
+      b: fixedJournal("b", { type: "day" }),
+    });
+
+    const notes = await api.notesFor({ writeType: "day" }, "2026-08-18");
+
+    expect(notes.map((note) => note.journal).toSorted()).toEqual(["a", "b"]);
+  });
+
+  it("gives a null path for a date outside the timeline with no note", async () => {
+    const { api } = buildApi({
+      past: fixedJournal(
+        "past",
+        { type: "day" },
+        {
+          timeline: {
+            start: "2020-01-01" as AnchorString,
+            end: { kind: "date", date: "2020-12-31" as AnchorString },
+          },
+        },
+      ),
+    });
+
+    const [note] = await api.notesFor("past", "2026-08-18");
+
+    expect(note?.path).toBeNull();
+    expect(note?.file).toBeNull();
+  });
+
+  it("rejects a date it cannot read with invalid-date", async () => {
+    const { api } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+
+    await expect(api.notesFor("daily", "whenever")).rejects.toMatchObject({ code: "invalid-date" });
+  });
+
+  it("resolves journalOf from the file it was handed", async () => {
+    const { api, index } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    index.register({
+      journalName: "daily",
+      anchor: "2026-08-18" as AnchorString,
+      path: "Journal/2026-08-18.md" as VaultPath,
+    });
+    const file = { path: "Journal/2026-08-18.md" } as never;
+
+    const note = await api.journalOf(file);
+
+    expect(note?.journal).toBe("daily");
+    expect(note?.date).toBe("2026-08-18");
+    expect(note?.file).toBe(file);
+  });
+
+  it("returns null from journalOf for a note that is not connected", async () => {
+    const { api } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+
+    expect(await api.journalOf({ path: "Random/note.md" })).toBeNull();
+  });
+});

--- a/src/api/journals-api.ts
+++ b/src/api/journals-api.ts
@@ -1,0 +1,133 @@
+import type { CalendarDate, AnchorString } from "@/calendar";
+import { inject } from "@/infrastructure/di";
+import type { VaultPath } from "@/infrastructure/host";
+import { NoteFileService } from "@/infrastructure/host/internal/note-file-service";
+import { CycleService } from "@/journals/cycle";
+import { FrontmatterService } from "@/journals/frontmatter";
+import { JournalsIndex } from "@/journals/journals-index";
+import { NotePathService } from "@/journals/notes/note-path";
+import { JournalsRepository } from "@/journals/repository";
+import { TimelineService } from "@/journals/timeline";
+import { ShelvesService } from "@/shelves/service";
+
+import { normalizeSelector, toCalendarDate, toJournalInfo } from "./convert";
+import { ApiError } from "./errors";
+
+import type { DateInput, ExistingJournalNote, JournalInfo, JournalNote, JournalSelector } from "./public-api";
+
+const API_VERSION = 1;
+
+function describeDateInput(input: DateInput): string {
+  if (typeof input === "string") return `"${input}"`;
+  if (input instanceof Date) return "an invalid Date";
+  return "the given date-like value";
+}
+
+export class JournalsApiService {
+  readonly #journals = inject(JournalsRepository);
+  readonly #shelves = inject(ShelvesService);
+  readonly #cycle = inject(CycleService);
+  readonly #timeline = inject(TimelineService);
+  readonly #index = inject(JournalsIndex);
+  readonly #frontmatter = inject(FrontmatterService);
+  readonly #paths = inject(NotePathService);
+  readonly #files = inject(NoteFileService);
+
+  readonly apiVersion = API_VERSION;
+
+  // listJournals/journalInfo read the settings-backed repository, which is populated before
+  // `api` is even assigned; only the index reads wait, because the index is filled by a
+  // whole-vault walk that takes seconds and answers "no note" for real notes until it lands.
+  async #readyForNotes(): Promise<void> {
+    await this.#index.whenReady();
+  }
+
+  #date(input: DateInput): CalendarDate {
+    const parsed = toCalendarDate(input);
+    if (parsed.isNone()) throw new ApiError("invalid-date", `Could not read a date from ${describeDateInput(input)}`);
+    return parsed.value;
+  }
+
+  #select(selector: JournalSelector | undefined): string[] {
+    const normalized = normalizeSelector(selector);
+    return [...this.#journals.find().entries()]
+      .filter(([name, config]) => {
+        if (normalized.journal !== undefined && normalized.journal !== name) return false;
+        if (normalized.writeType !== undefined && normalized.writeType !== config.write.type) return false;
+        if (normalized.shelf !== undefined && (normalized.shelf ?? "") !== this.#shelves.shelfOf(name)) return false;
+        return true;
+      })
+      .map(([name]) => name);
+  }
+
+  #renderedPath(name: string, anchor: AnchorString): string | null {
+    const metadata = this.#frontmatter.buildMetadata(name, anchor);
+    if (metadata.kind === "err") return null;
+    const path = this.#paths.pathFor(name, metadata.value);
+    return path.kind === "err" ? null : path.value;
+  }
+
+  // A connected note the user has since moved keeps its real path; the rendered template
+  // answers only for a note that does not exist yet.
+  #pathOf(name: string, anchor: AnchorString, existingPath: string | null): string | null {
+    if (existingPath !== null) return existingPath;
+    return this.#timeline.contains(name, anchor) ? this.#renderedPath(name, anchor) : null;
+  }
+
+  #noteAt(name: string, date: CalendarDate): JournalNote | null {
+    const anchorOption = this.#cycle.anchorOf(name, date);
+    if (anchorOption.isNone()) return null;
+    return this.#noteAtAnchor(name, anchorOption.value);
+  }
+
+  #noteAtAnchor(name: string, anchor: AnchorString): JournalNote | null {
+    const display = this.#cycle.representativeOf(name, anchor);
+    const end = this.#cycle.endOf(name, anchor);
+    if (display.isNone() || end.isNone()) return null;
+
+    const entry = this.#index.entryByAnchor(name, anchor);
+    const existingPath = entry.isSome() ? entry.value.path : null;
+
+    return {
+      journal: name,
+      date: anchor,
+      displayDate: display.value.toAnchor(),
+      endDate: end.value.toAnchor(),
+      path: this.#pathOf(name, anchor, existingPath),
+      file: existingPath === null ? null : this.#files.resolve(existingPath),
+    };
+  }
+
+  async listJournals(selector?: JournalSelector): Promise<readonly JournalInfo[]> {
+    return this.#select(selector).flatMap((name) => {
+      const config = this.#journals.get(name);
+      return config.isNone() ? [] : [toJournalInfo(name, config.value, this.#shelves.shelfOf(name))];
+    });
+  }
+
+  async journalInfo(name: string): Promise<JournalInfo | null> {
+    const config = this.#journals.get(name);
+    return config.isNone() ? null : toJournalInfo(name, config.value, this.#shelves.shelfOf(name));
+  }
+
+  async notesFor(selector: JournalSelector, date: DateInput): Promise<readonly JournalNote[]> {
+    await this.#readyForNotes();
+    const calendarDate = this.#date(date);
+    // A journal that cannot place this date is omitted rather than failing the fan-out.
+    return this.#select(selector).flatMap((name) => {
+      const note = this.#noteAt(name, calendarDate);
+      return note === null ? [] : [note];
+    });
+  }
+
+  async journalOf(file: { path: string }): Promise<ExistingJournalNote | null> {
+    await this.#readyForNotes();
+    const entry = this.#index.entryByPath(file.path as VaultPath);
+    if (entry.isNone()) return null;
+    const note = this.#noteAtAnchor(entry.value.journalName, entry.value.anchor);
+    if (note === null) return null;
+    // We were handed the file; re-resolving entry.path would add a null branch that
+    // conflates "not a journal note" with a resolution hiccup.
+    return { ...note, path: entry.value.path, file: file as ExistingJournalNote["file"] };
+  }
+}

--- a/src/api/journals-api.ts
+++ b/src/api/journals-api.ts
@@ -1,8 +1,12 @@
 import type { CalendarDate, AnchorString } from "@/calendar";
 import { inject } from "@/infrastructure/di";
+import { Flows, UserAborted } from "@/infrastructure/flows";
+import { WorkspaceOpenError } from "@/infrastructure/host";
 import type { VaultPath } from "@/infrastructure/host";
 import { NoteFileService } from "@/infrastructure/host/internal/note-file-service";
 import { CycleService } from "@/journals/cycle";
+import { EnsureJournalEntryFlow, JournalDateResolver, OpenJournalEntryFlow } from "@/journals/flows";
+import type { ApplicableJournal } from "@/journals/flows";
 import { FrontmatterService } from "@/journals/frontmatter";
 import { JournalsIndex } from "@/journals/journals-index";
 import { NotePathService } from "@/journals/notes/note-path";
@@ -13,7 +17,16 @@ import { ShelvesService } from "@/shelves/service";
 import { normalizeSelector, toCalendarDate, toJournalInfo } from "./convert";
 import { ApiError } from "./errors";
 
-import type { DateInput, ExistingJournalNote, JournalInfo, JournalNote, JournalSelector } from "./public-api";
+import type {
+  DateInput,
+  EnsureNoteOptions,
+  EnsureResult,
+  ExistingJournalNote,
+  JournalInfo,
+  JournalNote,
+  JournalSelector,
+  OpenNoteOptions,
+} from "./public-api";
 
 const API_VERSION = 1;
 
@@ -32,6 +45,9 @@ export class JournalsApiService {
   readonly #frontmatter = inject(FrontmatterService);
   readonly #paths = inject(NotePathService);
   readonly #files = inject(NoteFileService);
+  readonly #resolver = inject(JournalDateResolver);
+  readonly #flows = inject(Flows);
+  readonly #inFlight = new Map<string, Promise<EnsureResult>>();
 
   readonly apiVersion = API_VERSION;
 
@@ -98,6 +114,81 @@ export class JournalsApiService {
     };
   }
 
+  // Eligibility is "a note exists OR the date is in timeline", not the resolver's
+  // timeline-only rule. Refusing a note the API just reported as existing would make
+  // `ensure` a lie; the calendar's stricter gate is a UI affordance, not a data rule.
+  #eligible(names: readonly string[], date: CalendarDate): ApplicableJournal[] {
+    return names.flatMap((name) => {
+      const resolved = this.#cycle.anchorOf(name, date);
+      if (resolved.isNone()) return [];
+      const anchor = resolved.value;
+      const exists = this.#index.entryByAnchor(name, anchor).isSome();
+      if (!exists && !this.#timeline.contains(name, anchor)) return [];
+      return [{ name, anchor }];
+    });
+  }
+
+  async #resolveOne(selector: JournalSelector, date: DateInput): Promise<ApplicableJournal> {
+    const calendarDate = this.#date(date);
+    const names = this.#select(selector);
+    if (names.length === 0) {
+      const normalized = normalizeSelector(selector);
+      if (normalized.journal !== undefined && this.#journals.get(normalized.journal).isNone()) {
+        throw new ApiError("journal-not-found", `Journal not found: ${normalized.journal}`, normalized.journal);
+      }
+      throw new ApiError("no-matching-journal", "No journal matches that selector");
+    }
+
+    const eligible = this.#eligible(names, calendarDate);
+    if (eligible.length === 0) {
+      // "No period for that date" means the journal is misconfigured for this input;
+      // "a period, out of range" is a different answer callers act on differently.
+      const mappable = names.some((name) => this.#cycle.anchorOf(name, calendarDate).isSome());
+      throw mappable
+        ? new ApiError("outside-timeline", "That date is outside the journal's timeline")
+        : new ApiError("unmappable-date", "That date cannot be placed in a period of that journal");
+    }
+
+    const [only] = eligible;
+    if (eligible.length === 1 && only !== undefined) return only;
+
+    const chosen = await this.#resolver.pick(eligible.map((entry) => entry.name));
+    if (chosen === null) throw new ApiError("aborted", "The journal picker was dismissed");
+    const match = eligible.find((entry) => entry.name === chosen);
+    if (match === undefined) throw new ApiError("no-matching-journal", `No journal named ${chosen} matched`);
+    return match;
+  }
+
+  #existing(name: string, anchor: AnchorString): ExistingJournalNote {
+    const note = this.#noteAtAnchor(name, anchor);
+    if (note?.path == null || note.file === null) {
+      throw new ApiError("creation-failed", `The note for ${name} could not be read back`, name);
+    }
+    return { ...note, path: note.path, file: note.file };
+  }
+
+  // Between the existence check and the write, NoteCreationService may await a confirmation
+  // modal — seconds wide. Two callers ensuring the same period would otherwise get two
+  // prompts and one NoteAlreadyExistsError.
+  #dedupe(name: string, anchor: AnchorString, run: () => Promise<EnsureResult>): Promise<EnsureResult> {
+    const key = `${name}\u{0}${anchor}`;
+    const pending = this.#inFlight.get(key);
+    if (pending) return pending;
+    const started = run().finally(() => this.#inFlight.delete(key));
+    this.#inFlight.set(key, started);
+    return started;
+  }
+
+  #skipConfirmation(options: EnsureNoteOptions | undefined): boolean | undefined {
+    return options?.confirm === undefined ? undefined : !options.confirm;
+  }
+
+  #toApiError(cause: unknown, journal: string): ApiError {
+    if (cause instanceof UserAborted) return new ApiError("aborted", "The operation was cancelled", journal);
+    if (cause instanceof WorkspaceOpenError) return new ApiError("open-failed", cause.message, journal);
+    return new ApiError("creation-failed", cause instanceof Error ? cause.message : String(cause), journal);
+  }
+
   async listJournals(selector?: JournalSelector): Promise<readonly JournalInfo[]> {
     return this.#select(selector).flatMap((name) => {
       const config = this.#journals.get(name);
@@ -117,6 +208,39 @@ export class JournalsApiService {
     return this.#select(selector).flatMap((name) => {
       const note = this.#noteAt(name, calendarDate);
       return note === null ? [] : [note];
+    });
+  }
+
+  async ensureNote(selector: JournalSelector, date: DateInput, options?: EnsureNoteOptions): Promise<EnsureResult> {
+    await this.#readyForNotes();
+    const { name, anchor } = await this.#resolveOne(selector, date);
+    return this.#dedupe(name, anchor, async () => {
+      const result = await this.#flows.invoke(
+        EnsureJournalEntryFlow,
+        { journalName: name, anchor, skipConfirmation: this.#skipConfirmation(options) },
+        { notify: false, context: { via: "api" } },
+      );
+      if (result.isErr()) throw this.#toApiError(result.error, name);
+      return { note: this.#existing(name, anchor), created: result.value.created };
+    });
+  }
+
+  async openNote(selector: JournalSelector, date: DateInput, options?: OpenNoteOptions): Promise<EnsureResult> {
+    await this.#readyForNotes();
+    const { name, anchor } = await this.#resolveOne(selector, date);
+    return this.#dedupe(name, anchor, async () => {
+      const result = await this.#flows.invoke(
+        OpenJournalEntryFlow,
+        {
+          journalName: name,
+          anchor,
+          openMode: options?.openMode,
+          skipConfirmation: this.#skipConfirmation(options),
+        },
+        { notify: false, context: { via: "api" } },
+      );
+      if (result.isErr()) throw this.#toApiError(result.error, name);
+      return { note: this.#existing(name, anchor), created: result.value.created };
     });
   }
 

--- a/src/api/journals-api.ts
+++ b/src/api/journals-api.ts
@@ -181,12 +181,24 @@ export class JournalsApiService implements JournalsApi {
     return match;
   }
 
-  #existing(name: string, anchor: AnchorString): ExistingJournalNote {
-    const note = this.#noteAtAnchor(name, anchor);
-    if (note?.path == null || note.file === null) {
+  // Built from the write's own result, never re-read through the index: JournalsIndex only
+  // learns about a new note once Obsidian re-parses its frontmatter, so a lookup here
+  // reports `file: null` for the note we just created.
+  #existing(name: string, anchor: AnchorString, path: string): ExistingJournalNote {
+    const display = this.#cycle.representativeOf(name, anchor);
+    const end = this.#cycle.endOf(name, anchor);
+    const file = this.#files.resolve(path);
+    if (display.isNone() || end.isNone() || file === null) {
       throw new ApiError("creation-failed", `The note for ${name} could not be read back`, name);
     }
-    return { ...note, path: note.path, file: note.file };
+    return {
+      journal: name,
+      date: anchor,
+      displayDate: display.value.toAnchor(),
+      endDate: end.value.toAnchor(),
+      path,
+      file,
+    };
   }
 
   // Between the existence check and the write, NoteCreationService may await a confirmation
@@ -243,7 +255,7 @@ export class JournalsApiService implements JournalsApi {
         { notify: false, context: { via: "api" } },
       );
       if (result.isErr()) throw this.#toApiError(result.error, name);
-      return { note: this.#existing(name, anchor), created: result.value.created };
+      return { note: this.#existing(name, anchor, result.value.path), created: result.value.created };
     });
   }
 
@@ -262,7 +274,7 @@ export class JournalsApiService implements JournalsApi {
         { notify: false, context: { via: "api" } },
       );
       if (result.isErr()) throw this.#toApiError(result.error, name);
-      return { note: this.#existing(name, anchor), created: result.value.created };
+      return { note: this.#existing(name, anchor, result.value.path), created: result.value.created };
     });
   }
 

--- a/src/api/journals-api.ts
+++ b/src/api/journals-api.ts
@@ -1,3 +1,5 @@
+import { match } from "ts-pattern";
+
 import type { CalendarDate, AnchorString } from "@/calendar";
 import { inject } from "@/infrastructure/di";
 import { Flows, UserAborted } from "@/infrastructure/flows";
@@ -12,6 +14,7 @@ import { JournalsIndex } from "@/journals/journals-index";
 import { NotePathService } from "@/journals/notes/note-path";
 import { JournalsRepository } from "@/journals/repository";
 import { TimelineService } from "@/journals/timeline";
+import { JournalsEventsToken } from "@/journals/tokens";
 import { ShelvesService } from "@/shelves/service";
 
 import { normalizeSelector, toCalendarDate, toJournalInfo } from "./convert";
@@ -25,6 +28,8 @@ import type {
   JournalInfo,
   JournalNote,
   JournalSelector,
+  JournalsApi,
+  JournalsApiEvents,
   OpenNoteOptions,
 } from "./public-api";
 
@@ -36,8 +41,9 @@ function describeDateInput(input: DateInput): string {
   return "the given date-like value";
 }
 
-export class JournalsApiService {
+export class JournalsApiService implements JournalsApi {
   readonly #journals = inject(JournalsRepository);
+  readonly #journalEvents = inject(JournalsEventsToken);
   readonly #shelves = inject(ShelvesService);
   readonly #cycle = inject(CycleService);
   readonly #timeline = inject(TimelineService);
@@ -48,14 +54,30 @@ export class JournalsApiService {
   readonly #resolver = inject(JournalDateResolver);
   readonly #flows = inject(Flows);
   readonly #inFlight = new Map<string, Promise<EnsureResult>>();
+  readonly #unloaded: Promise<never>;
+  #rejectUnloaded: ((reason: unknown) => void) | undefined;
+  #disposed = false;
 
   readonly apiVersion = API_VERSION;
+
+  constructor() {
+    this.#unloaded = new Promise<never>((_, reject) => {
+      this.#rejectUnloaded = reject;
+    });
+    // Nothing may be awaiting it at disposal time; without a terminal handler that
+    // rejection surfaces as an unhandled rejection in the host.
+    void this.#unloaded.catch(() => null);
+  }
 
   // listJournals/journalInfo read the settings-backed repository, which is populated before
   // `api` is even assigned; only the index reads wait, because the index is filled by a
   // whole-vault walk that takes seconds and answers "no note" for real notes until it lands.
   async #readyForNotes(): Promise<void> {
-    await this.#index.whenReady();
+    if (this.#disposed) throw new ApiError("plugin-unloaded", "Journals has been unloaded");
+    // whenReady never settles if readiness never arrives, so a consumer awaiting a call
+    // when the user disables Journals would hang forever inside their own plugin.
+    await Promise.race([this.#index.whenReady(), this.#unloaded]);
+    if (this.#disposed) throw new ApiError("plugin-unloaded", "Journals has been unloaded");
   }
 
   #date(input: DateInput): CalendarDate {
@@ -253,5 +275,53 @@ export class JournalsApiService {
     // We were handed the file; re-resolving entry.path would add a null branch that
     // conflates "not a journal note" with a resolution hiccup.
     return { ...note, path: entry.value.path, file: file as ExistingJournalNote["file"] };
+  }
+
+  on<K extends keyof JournalsApiEvents>(event: K, handler: JournalsApiEvents[K]): () => void {
+    // Widened off the generic: matching on `K` leaves ts-pattern excluding arms it has not
+    // seen, so exhaustiveness stops type-checking after the third one.
+    const name: keyof JournalsApiEvents = event;
+    return match(name)
+      .with("journalCreated", () =>
+        this.#journalEvents.on("created", (name) => {
+          (handler as JournalsApiEvents["journalCreated"])({ journal: name });
+        }),
+      )
+      .with("journalDeleted", () =>
+        this.#journalEvents.on("deleted", (name) => {
+          (handler as JournalsApiEvents["journalDeleted"])({ journal: name });
+        }),
+      )
+      .with("journalRenamed", () =>
+        this.#journalEvents.on("renamed", (from, to) => {
+          (handler as JournalsApiEvents["journalRenamed"])({ from, to });
+        }),
+      )
+      .with("noteAdded", () =>
+        this.#index.events.on("entryChanged", ({ entry, kind }) => {
+          if (kind !== "added") return;
+          (handler as JournalsApiEvents["noteAdded"])({
+            journal: entry.journalName,
+            date: entry.anchor,
+            path: entry.path,
+          });
+        }),
+      )
+      .with("noteRemoved", () =>
+        this.#index.events.on("entryChanged", ({ entry, kind }) => {
+          if (kind !== "removed") return;
+          (handler as JournalsApiEvents["noteRemoved"])({
+            journal: entry.journalName,
+            date: entry.anchor,
+            path: entry.path,
+          });
+        }),
+      )
+      .exhaustive();
+  }
+
+  async [Symbol.asyncDispose](): Promise<void> {
+    this.#disposed = true;
+    this.#rejectUnloaded?.(new ApiError("plugin-unloaded", "Journals has been unloaded"));
   }
 }

--- a/src/api/module.ts
+++ b/src/api/module.ts
@@ -1,0 +1,11 @@
+import type { Module } from "@/infrastructure/di";
+import { NoteFileService } from "@/infrastructure/host/internal/note-file-service";
+
+import { JournalsApiService } from "./journals-api";
+
+export const apiModule: Module = {
+  register(c) {
+    c.register(NoteFileService).useClass(NoteFileService);
+    c.register(JournalsApiService).useClass(JournalsApiService);
+  },
+};

--- a/src/api/public-api.ts
+++ b/src/api/public-api.ts
@@ -1,0 +1,119 @@
+import type { TFile } from "obsidian";
+
+/** Anything with toDate() — notably a moment, which is what Obsidian hands out. */
+export interface DateLike {
+  toDate(): Date;
+}
+
+/** "YYYY-MM-DD", "today", a relative shift like "+1w" / "-3d", a Date, or a moment. */
+export type DateInput = Date | DateLike | string;
+
+export type JournalWriteType = "day" | "week" | "month" | "quarter" | "year" | "custom";
+
+/**
+ * Selects journals. A bare string is shorthand for { journal: name }.
+ * Fields are ANDed; an empty selector matches every journal.
+ */
+export type JournalSelector =
+  | string
+  | {
+      readonly journal?: string;
+      readonly writeType?: JournalWriteType;
+      /** undefined = any shelf; null = journals on no shelf; a name = that shelf. */
+      readonly shelf?: string | null;
+    };
+
+export type JournalWrite =
+  | { readonly type: "day" | "week" | "month" | "quarter" | "year" }
+  | {
+      readonly type: "custom";
+      readonly every: "day" | "week" | "month" | "quarter" | "year";
+      readonly duration: number;
+    };
+
+export interface JournalInfo {
+  readonly name: string;
+  readonly shelf: string | null;
+  readonly write: JournalWrite;
+}
+
+/** The journal's note for a period — on disk, or where it would go. */
+export interface JournalNote {
+  readonly journal: string;
+  /** "YYYY-MM-DD" — the period's first day, and its identity. The note's `journal-date`. */
+  readonly date: string;
+  /**
+   * "YYYY-MM-DD" — the day this period's dates are formatted from. Equals `date` for every
+   * period kind except a week: the ISO week containing 2026-01-01 has date 2025-12-29 but
+   * displayDate 2026-01-01, and is named 2026-W01. Format from this; correlate on `date`.
+   */
+  readonly displayDate: string;
+  /** "YYYY-MM-DD" — the period's last day, inclusive. The note's `journal-end-date`. */
+  readonly endDate: string;
+  /** Where the note is, or would be created. null = no note can be placed here. */
+  readonly path: string | null;
+  /** null = not created yet. */
+  readonly file: TFile | null;
+}
+
+/** A JournalNote that exists on disk. */
+export interface ExistingJournalNote extends JournalNote {
+  readonly path: string;
+  readonly file: TFile;
+}
+
+export interface EnsureNoteOptions {
+  /** Show the journal's creation-confirmation prompt. Defaults to the journal's own setting. */
+  readonly confirm?: boolean;
+}
+
+export interface OpenNoteOptions extends EnsureNoteOptions {
+  readonly openMode?: "active" | "tab" | "split" | "window";
+}
+
+export interface EnsureResult {
+  readonly note: ExistingJournalNote;
+  readonly created: boolean;
+}
+
+/** Open on purpose: new codes are an additive change, so always handle the default case. */
+export type JournalsApiErrorCode =
+  | "journal-not-found"
+  | "no-matching-journal"
+  | "invalid-date"
+  | "unmappable-date"
+  | "outside-timeline"
+  | "creation-failed"
+  | "open-failed"
+  | "aborted"
+  | "plugin-unloaded"
+  | (string & {});
+
+export interface JournalsApiError extends Error {
+  readonly code: JournalsApiErrorCode;
+  readonly journal?: string;
+}
+
+export interface JournalsApiEvents {
+  journalCreated: (event: { journal: string }) => void;
+  journalRenamed: (event: { from: string; to: string }) => void;
+  journalDeleted: (event: { journal: string }) => void;
+  noteAdded: (event: { journal: string; date: string; path: string }) => void;
+  noteRemoved: (event: { journal: string; date: string; path: string }) => void;
+}
+
+export interface JournalsApi {
+  readonly apiVersion: number;
+
+  listJournals(selector?: JournalSelector): Promise<readonly JournalInfo[]>;
+  journalInfo(name: string): Promise<JournalInfo | null>;
+
+  notesFor(selector: JournalSelector, date: DateInput): Promise<readonly JournalNote[]>;
+  journalOf(file: TFile): Promise<ExistingJournalNote | null>;
+
+  ensureNote(selector: JournalSelector, date: DateInput, options?: EnsureNoteOptions): Promise<EnsureResult>;
+  openNote(selector: JournalSelector, date: DateInput, options?: OpenNoteOptions): Promise<EnsureResult>;
+
+  /** Synchronous — returns its unsubscribe disposer. */
+  on<K extends keyof JournalsApiEvents>(event: K, handler: JournalsApiEvents[K]): () => void;
+}

--- a/src/infrastructure/host/internal/note-file-service.test.ts
+++ b/src/infrastructure/host/internal/note-file-service.test.ts
@@ -1,0 +1,36 @@
+import { TFile, TFolder } from "obsidian";
+import { describe, expect, it } from "vitest";
+
+import { Container } from "@/infrastructure/di";
+
+import { NoteFileService } from "./note-file-service";
+import { InternalObsidianAppToken } from "./tokens";
+
+function serviceWith(files: Record<string, TFile | TFolder>): NoteFileService {
+  const c = new Container();
+  c.register(InternalObsidianAppToken).useValue({
+    vault: { getAbstractFileByPath: (path: string) => files[path] ?? null },
+  } as never);
+  c.register(NoteFileService).useClass(NoteFileService);
+  return c.resolve(NoteFileService);
+}
+
+function fileAt(path: string): TFile {
+  return Object.assign(new TFile(), { path });
+}
+
+describe("NoteFileService", () => {
+  it("resolves a path to its TFile", () => {
+    const file = fileAt("Journal/2026-08-18.md");
+    expect(serviceWith({ "Journal/2026-08-18.md": file }).resolve("Journal/2026-08-18.md")).toBe(file);
+  });
+
+  it("returns null when nothing is there", () => {
+    expect(serviceWith({}).resolve("Journal/missing.md")).toBeNull();
+  });
+
+  it("returns null for a folder", () => {
+    const folder = Object.assign(new TFolder(), { path: "Journal" });
+    expect(serviceWith({ Journal: folder }).resolve("Journal")).toBeNull();
+  });
+});

--- a/src/infrastructure/host/internal/note-file-service.ts
+++ b/src/infrastructure/host/internal/note-file-service.ts
@@ -1,0 +1,20 @@
+import { TFile } from "obsidian";
+
+import { inject } from "@/infrastructure/di";
+
+import { InternalObsidianAppToken } from "./tokens";
+
+/**
+ * The one place a raw `TFile` leaves the host layer. It exists because the public
+ * plugin API hands integrators a `TFile`, which every other consumer gets as the
+ * domain `Note` instead. Not exported from the host barrel, and lint-fenced to
+ * `src/api/**` — widen neither without revisiting that decision.
+ */
+export class NoteFileService {
+  readonly #app = inject(InternalObsidianAppToken);
+
+  resolve(path: string): TFile | null {
+    const file = this.#app.vault.getAbstractFileByPath(path);
+    return file instanceof TFile ? file : null;
+  }
+}

--- a/src/journals/flows/ensure-journal-entry.flow.test.ts
+++ b/src/journals/flows/ensure-journal-entry.flow.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import { anchor } from "@/calendar/testing";
+import { Container } from "@/infrastructure/di";
+import { Flows, FlowsModule } from "@/infrastructure/flows";
+import { NotesService, NoticeService, TemplaterService, WorkspaceService } from "@/infrastructure/host";
+import type { VaultPath } from "@/infrastructure/host";
+import { ModalService } from "@/infrastructure/host/modals";
+import { FakeModalService } from "@/infrastructure/host/modals/testing";
+import {
+  FakeNoticeService,
+  FakeNotesService,
+  FakeTemplaterService,
+  FakeWorkspaceService,
+} from "@/infrastructure/host/testing";
+import { LoggerModule } from "@/infrastructure/logger";
+import { TemplateEngine } from "@/templates";
+
+import { CycleService } from "../cycle";
+import { FrontmatterService } from "../frontmatter";
+import { JournalsIndex } from "../journals-index";
+import { NoteCreationService } from "../notes/note-creation";
+import { NotePathService } from "../notes/note-path";
+import { SelfWriteGuard } from "../notes/self-write-guard";
+import { TemplateContentService } from "../notes/template-content";
+import { NumberingService } from "../numbering";
+import { JournalsRepository } from "../repository";
+import { fakeRepo, fixedJournal } from "../testing";
+
+import { EnsureJournalEntryFlow } from "./ensure-journal-entry.flow";
+
+import type { JournalConfig } from "../config";
+
+function build(journals: Record<string, JournalConfig>) {
+  const c = new Container();
+  const notes = new FakeNotesService();
+  const workspace = new FakeWorkspaceService();
+  const modals = new FakeModalService();
+  c.addModule(LoggerModule);
+  c.addModule(FlowsModule);
+  c.register(NoticeService).useValue(new FakeNoticeService());
+  c.register(JournalsRepository).useValue(fakeRepo(journals));
+  c.register(NotesService).useValue(notes as unknown as NotesService);
+  c.register(WorkspaceService).useValue(workspace as unknown as WorkspaceService);
+  c.register(ModalService).useValue(modals as unknown as ModalService);
+  c.register(TemplaterService).useValue(new FakeTemplaterService() as unknown as TemplaterService);
+  c.register(JournalsIndex).useClass(JournalsIndex);
+  c.register(CycleService).useClass(CycleService);
+  c.register(NumberingService).useClass(NumberingService);
+  c.register(FrontmatterService).useClass(FrontmatterService);
+  c.register(TemplateEngine).useClass(TemplateEngine);
+  c.register(NotePathService).useClass(NotePathService);
+  c.register(TemplateContentService).useClass(TemplateContentService);
+  c.register(SelfWriteGuard).useClass(SelfWriteGuard);
+  c.register(NoteCreationService).useClass(NoteCreationService);
+  c.register(EnsureJournalEntryFlow).useClass(EnsureJournalEntryFlow);
+  return { flows: c.resolve(Flows), notes, workspace, modals };
+}
+
+describe("EnsureJournalEntryFlow", () => {
+  it("creates the note without opening it", async () => {
+    const { flows, notes, workspace } = build({ daily: fixedJournal("daily", { type: "day" }) });
+
+    const result = await flows.invoke(EnsureJournalEntryFlow, {
+      journalName: "daily",
+      anchor: anchor("2026-05-19"),
+    });
+
+    expect(result.isOk() && result.value).toEqual({ path: "2026-05-19.md", created: true });
+    expect(notes.find("2026-05-19.md" as VaultPath).isSome()).toBe(true);
+    expect(workspace.isOpen("2026-05-19.md" as VaultPath)).toBe(false);
+  });
+
+  it("reports created false for a note that already exists", async () => {
+    const { flows, notes } = build({ daily: fixedJournal("daily", { type: "day" }) });
+    notes.seed("2026-05-19.md" as VaultPath, "existing");
+
+    const result = await flows.invoke(EnsureJournalEntryFlow, {
+      journalName: "daily",
+      anchor: anchor("2026-05-19"),
+    });
+
+    expect(result.isOk() && result.value.created).toBe(false);
+  });
+
+  it("honors the journal's creation prompt by default", async () => {
+    const { flows, modals } = build({
+      daily: fixedJournal("daily", { type: "day" }, { confirmCreation: true }),
+    });
+
+    const pending = flows.invoke(EnsureJournalEntryFlow, {
+      journalName: "daily",
+      anchor: anchor("2026-05-19"),
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(modals.opens).toHaveLength(1);
+
+    modals.lastOpen<unknown, boolean>().submit(true);
+    const settled = await pending;
+    expect(settled.isOk()).toBe(true);
+  });
+
+  it("skips the creation prompt when asked to", async () => {
+    const { flows, modals } = build({
+      daily: fixedJournal("daily", { type: "day" }, { confirmCreation: true }),
+    });
+
+    const result = await flows.invoke(EnsureJournalEntryFlow, {
+      journalName: "daily",
+      anchor: anchor("2026-05-19"),
+      skipConfirmation: true,
+    });
+
+    expect(modals.opens).toHaveLength(0);
+    expect(result.isOk() && result.value.created).toBe(true);
+  });
+});

--- a/src/journals/flows/ensure-journal-entry.flow.ts
+++ b/src/journals/flows/ensure-journal-entry.flow.ts
@@ -1,0 +1,39 @@
+import type { AnchorString } from "@/calendar";
+import { inject } from "@/infrastructure/di";
+import type { Flow } from "@/infrastructure/flows";
+import { attempt } from "@/infrastructure/result";
+import type { AsyncResult } from "@/infrastructure/result";
+
+import { FrontmatterService } from "../frontmatter";
+import { NoteCreationService } from "../notes/note-creation";
+
+import type { OpenJournalEntryResult } from "./open-journal-entry.flow";
+import type { NoteCreationError } from "../notes/note-creation";
+
+export interface EnsureJournalEntryParameters {
+  journalName: string;
+  anchor: AnchorString;
+  skipConfirmation?: boolean;
+}
+
+/**
+ * Creation without opening. OpenJournalEntryFlow keeps its own copy of these two steps
+ * rather than invoking this one, because flows compose by yield*-ing operations.
+ */
+export class EnsureJournalEntryFlow implements Flow<
+  EnsureJournalEntryParameters,
+  OpenJournalEntryResult,
+  NoteCreationError
+> {
+  readonly #frontmatter = inject(FrontmatterService);
+  readonly #creation = inject(NoteCreationService);
+
+  execute(p: EnsureJournalEntryParameters): AsyncResult<OpenJournalEntryResult, NoteCreationError> {
+    return attempt.in(this, async function* (this: EnsureJournalEntryFlow) {
+      const metadata = yield* this.#frontmatter.buildMetadata(p.journalName, p.anchor);
+      return yield* this.#creation.ensureNote(p.journalName, metadata, {
+        skipConfirmation: p.skipConfirmation,
+      });
+    });
+  }
+}

--- a/src/journals/flows/index.ts
+++ b/src/journals/flows/index.ts
@@ -1,3 +1,4 @@
+export { EnsureJournalEntryFlow, type EnsureJournalEntryParameters } from "./ensure-journal-entry.flow";
 export { JournalDateResolver, type ApplicableJournal } from "./journal-date-resolver";
 export { OpenDateFlow } from "./open-date.flow";
 export { OpenJournalEntryFlow } from "./open-journal-entry.flow";

--- a/src/journals/flows/module.ts
+++ b/src/journals/flows/module.ts
@@ -1,11 +1,13 @@
 import type { Module } from "@/infrastructure/di";
 
+import { EnsureJournalEntryFlow } from "./ensure-journal-entry.flow";
 import { JournalDateResolver } from "./journal-date-resolver";
 import { OpenDateFlow } from "./open-date.flow";
 import { OpenJournalEntryFlow } from "./open-journal-entry.flow";
 
 export const journalFlowsModule: Module = {
   register(c) {
+    c.register(EnsureJournalEntryFlow).useClass(EnsureJournalEntryFlow);
     c.register(JournalDateResolver).useClass(JournalDateResolver);
     c.register(OpenDateFlow).useClass(OpenDateFlow);
     c.register(OpenJournalEntryFlow).useClass(OpenJournalEntryFlow);

--- a/src/journals/flows/open-journal-entry.flow.ts
+++ b/src/journals/flows/open-journal-entry.flow.ts
@@ -15,6 +15,7 @@ export interface OpenJournalEntryParameters {
   journalName: string;
   anchor: AnchorString;
   openMode?: OpenMode;
+  skipConfirmation?: boolean;
 }
 
 export interface OpenJournalEntryResult {
@@ -35,7 +36,9 @@ export class OpenJournalEntryFlow implements Flow<
   execute(p: OpenJournalEntryParameters): AsyncResult<OpenJournalEntryResult, NoteCreationError | WorkspaceOpenError> {
     return attempt.in(this, async function* (this: OpenJournalEntryFlow) {
       const metadata = yield* this.#frontmatter.buildMetadata(p.journalName, p.anchor);
-      const { path, created } = yield* this.#creation.ensureNote(p.journalName, metadata);
+      const { path, created } = yield* this.#creation.ensureNote(p.journalName, metadata, {
+        skipConfirmation: p.skipConfirmation,
+      });
       yield* this.#workspace.openNote(path, p.openMode ?? "active");
       if (created) yield* this.#templater.cursorJump(path);
       return { path, created };

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,8 @@ import { getLanguage, Notice, Plugin } from "obsidian";
 
 import "./styles.css";
 
+import { apiModule, JournalsApiService } from "@/api";
+import type { JournalsApi } from "@/api";
 import { CalendarModule, calendarSettingsModule } from "@/calendar";
 import { codeBlocksModule } from "@/code-blocks";
 import { navBlockSettingsModule } from "@/code-blocks/nav/settings/module";
@@ -32,6 +34,9 @@ import { viewsModule, ViewHostService } from "@/views";
 export default class JournalPlugin extends Plugin {
   #container?: Container;
 
+  /** The public plugin API. See docs/plugin-api.md. */
+  api?: JournalsApi;
+
   async onload(): Promise<void> {
     initLocale(getLanguage());
 
@@ -58,6 +63,7 @@ export default class JournalPlugin extends Plugin {
     container.addModule(startupModule);
     container.addModule(loggingModule);
     container.addModule(maintenanceModule);
+    container.addModule(apiModule);
 
     const init = await container.resolve(SettingsService).initialize();
     if (init.kind === "err") {
@@ -65,6 +71,11 @@ export default class JournalPlugin extends Plugin {
       await container.dispose();
       return;
     }
+
+    // Before autoLoad on purpose: assigning at the end of onload would leave `api` undefined
+    // during our own async initialization, and a consumer probing then reads "Journals is not
+    // installed" rather than "not ready yet".
+    this.api = container.resolve(JournalsApiService);
 
     await container.autoLoad();
 
@@ -90,6 +101,7 @@ export default class JournalPlugin extends Plugin {
   }
 
   onunload(): void {
+    this.api = undefined;
     void this.#container?.dispose().catch(() => null);
     this.#container = undefined;
   }


### PR DESCRIPTION
Closes #78.

Adds a documented API other plugins can use to discover journals and read, create and open journal notes, plus an `obsidian-journals-api` package carrying its types and a locator.

Design: `.superpowers/specs/2026-08-18-plugin-api-design.md`. Builds on #260.

## The shape

```ts
import { getJournalsApi } from "obsidian-journals-api";

const journals = getJournalsApi(this.app);
const [today] = await journals.notesFor({ writeType: "day" }, "today");
const { note, created } = await journals.ensureNote("Work Daily", "today");
```

Seven methods: `listJournals`, `journalInfo`, `notesFor`, `journalOf`, `ensureNote`, `openNote`, `on`.

The decision that shapes everything: **a vault can hold several journals of the same write type**, which is why the 2024 thread stalled. So reads fan out to an array, and writes resolve to exactly one — showing the same journal picker a calendar click does. The API is a facade over the existing flows and behaves as the plugin behaves, including honouring _Confirm creation_.

## Notable design points

- **Dates are `"YYYY-MM-DD"` strings, not `Date`.** A `Date` is a timestamp; returning one makes the obvious containment check silently exclude the last day of every period.
- **`date` vs `displayDate`.** They differ only for year-edge weeks — the ISO week containing 2026-01-01 has `date: "2025-12-29"` but is named `2026-W01`. Consumers cannot compute this themselves because it depends on the vault's week configuration, so it is exposed.
- **The error-code union is open** (`| (string & {})`), so the typechecker forces a `default` branch. New codes are an additive change and would otherwise break exhaustive switches.
- **Concurrent writes to the same period share one flow invocation.** There is an await between the existence check and the write — the confirmation modal — so two callers would otherwise get two prompts and one `NoteAlreadyExistsError`.
- **An existing note is reachable even outside its journal's timeline.** A deliberate divergence: the calendar's stricter gate is a UI affordance, and refusing a note the API just reported as existing would make `ensure` a lie.
- **`NoteFileService`** is the single place a raw `TFile` leaves the host layer — host-internal, out of the barrel, and lint-fenced to `src/api/**` so `check:lint` proves it has one consumer.

## Guardrail

`packages/api/index.d.ts` is generated from `src/api/public-api.ts` and committed; `checks.yml` regenerates and runs `git diff --exit-code`. Any change to the public surface shows up as a reviewable diff in the PR that caused it — `check:types` proves only that *this* repo still compiles, not that downstream plugins still do. A file-scoped eslint rule keeps `public-api.ts` importing nothing but `type { TFile } from "obsidian"`, which is what makes the copy a valid `.d.ts`.

The package is published manually from `packages/api` (runbook in `docs/releasing.md`), after the plugin release that contains the matching surface.

## Verification

- `npm test` — 4001 passed
- `check:types`, `check:lint`, `check:i18n` — clean
- `e2e/integration/plugin-api.e2e.ts` — 4 passing against real Obsidian

The e2e caught a bug unit tests could not: `ensureNote` built its result by re-reading `JournalsIndex`, which only learns about a note once Obsidian re-parses its frontmatter — so every creation threw `creation-failed` for a note that had just been created. It now builds from the write's own result, and the `Flows` fake withholds the index registration so the unit suite models the lag.

## Docs

`docs/plugin-api.md` is the owner doc (routed from `CLAUDE.md`), covering the surface, selectors, the date guidance, errors, the rename obligation, why `path` is for display rather than writing, the stability policy, and a migration table for `obsidian-daily-notes-interface` users — two of the four people on #78 arrive with code written against that shape.