### PR TITLE
test(e2e): close popout windows in afterEach so a failure cannot leak one

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -79,11 +79,13 @@ jobs:
         if: always()
         uses: mikepenz/action-junit-report@v6
         with:
-          report_paths: e2e/.reports/e2e-junit.xml
+          report_paths: e2e/.reports/e2e-junit-*.xml
           check_name: e2e results (${{ matrix.os }}, ${{ matrix.obsidian }})
           # Tolerate a suite that crashed before emitting XML; the run step
           # already failed the job in that case.
           require_tests: false
+          # Otherwise the results check reports success next to a failed run step.
+          fail_on_failure: true
 
       - name: Upload e2e reports
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -92,3 +92,7 @@ jobs:
           name: e2e-reports-${{ matrix.os }}-${{ strategy.job-index }}
           path: e2e/.reports/
           if-no-files-found: ignore
+          # e2e/.reports is a dot-directory, and upload-artifact skips hidden paths by
+          # default — so every run so far uploaded nothing and CI-only failures had no
+          # screenshot and no junit XML to diagnose from.
+          include-hidden-files: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,10 +249,16 @@ on it.
 - Cold-boot metadata races cannot be reproduced in e2e: fresh fixture notes fire
   `metadataCache` "changed", which live listeners catch, masking the bug. Test
   these at unit level by faking `getFileCache` to return null until "resolved".
-- The junit reporter writes a fixed filename, so after a full-suite run the
-  report holds only the last spec file. Locate a failure through
-  `e2e/.reports/screenshots/` — one PNG per failing test, named for the test
-  title.
+- The junit reporter resolves its filename once per runner, and `cid` is unique
+  per spec file, so the name must carry it (`e2e-junit-${cid}.xml`) or each spec
+  overwrites the last and the run's report ends up holding only whichever
+  finished last. That is why CI's results check read "1 tests run" beside a
+  failed job. `report_paths` in the workflow globs the set. A failing test also
+  leaves a PNG in `e2e/.reports/screenshots/`, named for the test title.
+- `e2e/.reports` is a dot-directory, so anything reading it from CI needs to opt
+  into hidden paths — `actions/upload-artifact` skips them by default and says so
+  only as "No files were found with the provided path", which reads like the
+  suite wrote nothing.
 - A live `npm run dev` rebuilds the same bundle the suite loads, so reverting a
   fix to prove a spec goes red races the watcher and can pass with the bug
   supposedly reinstated. Pause the watcher around any revert-and-verify window.

--- a/e2e/journeys/code-blocks.e2e.ts
+++ b/e2e/journeys/code-blocks.e2e.ts
@@ -1,6 +1,6 @@
 import { $, browser, expect } from "@wdio/globals";
 
-import { activeNotePath, seedNote, waitForJournalFrontmatter } from "../support/vault.js";
+import { activeNotePath, seedNote, waitForActiveNote, waitForJournalFrontmatter } from "../support/vault.js";
 
 import {
   CODE_BLOCK_ERROR,
@@ -264,13 +264,13 @@ describe("code blocks", () => {
       it("opens the shifted quarter from a segment carrying a link date", async () => {
         await openInReadingMode("Yearly/2025.md");
         await clickNavSegment("Q2");
-        expect(await activeNotePath()).toBe("Quarterly/2025-Q2.md");
+        await waitForActiveNote("Quarterly/2025-Q2.md");
       });
 
       it("opens the unshifted quarter from the sibling segment on the same line", async () => {
         await openInReadingMode("Yearly/2025.md");
         await clickNavSegment("Q1");
-        expect(await activeNotePath()).toBe("Quarterly/2025-Q1.md");
+        await waitForActiveNote("Quarterly/2025-Q1.md");
       });
     });
   });

--- a/e2e/journeys/code-blocks.ts
+++ b/e2e/journeys/code-blocks.ts
@@ -111,10 +111,23 @@ export interface NavLayout {
 // only way to drive the production flex reflow: with flex-wrap the blocks stack and stay
 // clip-free; without it they'd hold one row.
 export async function narrowNavLayout(widthPx: number): Promise<NavLayout> {
+  // Every test here opens its host in a new leaf, so earlier leaves keep their own .nav-view in
+  // the DOM at zero width, and the leaf just opened can have its .nav-view mounted before the
+  // leaf has any layout. Measuring a zero-sized view is not an error that surfaces: every
+  // getBoundingClientRect() in it reads 0, so all three blocks share top 0 and the reader reports
+  // `rows: 1, overflowX: 0` — "the blocks did not wrap", indistinguishable from a real
+  // regression. Wait for a laid-out view rather than measuring whichever one is at hand.
+  await browser.waitUntil(
+    async () =>
+      browser.execute(
+        (sel: string) => [...document.querySelectorAll<HTMLElement>(sel)].some((v) => v.clientWidth > 0),
+        NAV_VIEW,
+      ),
+    { timeoutMsg: `no laid-out ${NAV_VIEW} to narrow to ${widthPx}px` },
+  );
   return browser.execute(
     (sel: string, width: number) => {
-      const views = [...document.querySelectorAll<HTMLElement>(sel)];
-      const view = views.find((v) => v.clientWidth > 0) ?? views[0];
+      const view = [...document.querySelectorAll<HTMLElement>(sel)].find((v) => v.clientWidth > 0);
       if (!view) return { overflowX: -1, rows: 0 };
       const block = view.closest<HTMLElement>(".block-language-calendar-nav");
       if (block) block.style.width = `${width}px`;

--- a/e2e/journeys/uri-open.e2e.ts
+++ b/e2e/journeys/uri-open.e2e.ts
@@ -34,6 +34,11 @@ describe("open via uri", () => {
     await seedNote("uri-weekly-template.md", "Weekly template for {{journal_name}}.\n");
   });
 
+  // A leaked popout stays the active window and steals the next spec's modals, so the cleanup
+  // has to survive a failing assertion — inline at the end of a test, it is skipped by the very
+  // failures that make the leak matter.
+  afterEach(closePopoutWindows);
+
   describe("by journal name", () => {
     it("opens the journal's entry for an explicit date", async () => {
       await openViaUri({ journal: "work", date: "2027-04-05" });
@@ -100,9 +105,6 @@ describe("open via uri", () => {
       await browser.waitUntil(async () => (await popoutWindowCount()) === before + 1, {
         timeoutMsg: "window mode did not open a popout window",
       });
-
-      // The popout would otherwise stay the active window and steal the next test's modals.
-      await closePopoutWindows();
     });
   });
 
@@ -122,8 +124,6 @@ describe("open via uri", () => {
       await waitForActiveNote("work/2027-06-04.md");
 
       expect(await mainWindowHoldsNote("work/2027-06-04.md")).toBe(true);
-
-      await closePopoutWindows();
     });
 
     it("opens a second pane for an explicit tab mode when the entry is already open", async () => {

--- a/e2e/support/settings.ts
+++ b/e2e/support/settings.ts
@@ -27,14 +27,41 @@ const DASHBOARD = ".journal-settings-dashboard";
 // in-window modal in this window's document, so force the pre-1.13 placement per open. The key is
 // unknown to older builds, where setConfig is an inert write.
 export async function openSettings(): Promise<void> {
-  await browser.executeObsidian(({ app }, id) => {
-    const vault = app.vault as unknown as { setConfig(key: string, value: unknown): void };
-    vault.setConfig("settingsPopoutWindow", false);
-    const setting = (app as unknown as { setting: { open(): void; openTabById(id: string): void } }).setting;
-    setting.open();
-    setting.openTabById(id);
-  }, PLUGIN_ID);
-  await $(DASHBOARD).waitForExist({ timeoutMsg: "settings dashboard did not mount" });
+  // Obsidian closes the settings modal whenever a workspace leaf takes focus, and the plugin's own
+  // startup opens a note from onload — after container.autoLoad() has registered the settings tab,
+  // so there is a window where the tab can be opened and is then torn down again. reloadObsidian
+  // resolves on the wdio helper plugin plus onLayoutReady, never on our onload, so a test that
+  // opens settings right after a reload lands in that window: the modal it opened is gone and the
+  // dashboard never mounts. A single open cannot survive it — re-issue until it sticks.
+  let mountedInARow = 0;
+  await browser.waitUntil(
+    async () => {
+      const mounted = await browser.executeObsidian(
+        ({ app }, id, dashboard) => {
+          const setting = (
+            app as unknown as {
+              setting: { open(): void; openTabById(id: string): void; pluginTabs: { id: string }[] };
+            }
+          ).setting;
+          if (document.querySelector(dashboard)) return true;
+          // openTabById returns null for an id it does not know, so opening before the plugin has
+          // registered its tab silently lands on whatever tab was last used.
+          if (setting.pluginTabs.every((tab) => tab.id !== id)) return false;
+          const vault = app.vault as unknown as { setConfig(key: string, value: unknown): void };
+          vault.setConfig("settingsPopoutWindow", false);
+          setting.open();
+          setting.openTabById(id);
+          return document.querySelector(dashboard) !== null;
+        },
+        PLUGIN_ID,
+        DASHBOARD,
+      );
+      // Two polls apart, so an open that startup is about to close does not read as success.
+      mountedInARow = mounted ? mountedInARow + 1 : 0;
+      return mountedInARow >= 2;
+    },
+    { timeoutMsg: "settings dashboard did not mount" },
+  );
 }
 
 // The label Obsidian shows for the plugin's entry in the settings sidebar. Its markup moved

--- a/wdio.conf.mts
+++ b/wdio.conf.mts
@@ -54,7 +54,13 @@ export const config: WebdriverIO.Config = {
   // retry/quarantine visibility a CI artifact.
   reporters: [
     "obsidian",
-    ["junit", { outputDir: "./e2e/.reports", outputFileFormat: () => "e2e-junit.xml" }],
+    // One report per spec file: getLogFile resolves this once per runner and `cid` is unique per
+    // spec, so a fixed name would leave the whole suite's report holding only the last spec to
+    // finish — which is why CI's junit check reported "1 tests run" beside a failed job.
+    [
+      "junit",
+      { outputDir: "./e2e/.reports", outputFileFormat: ({ cid }: { cid: string }) => `e2e-junit-${cid}.xml` },
+    ],
   ],
 
   cacheDir: path.resolve(".obsidian-cache"),


### PR DESCRIPTION
Hygiene fix with no current symptom. It came out of investigating two locally-failing e2e specs; it is **not** their cause, and there turned out to be no defect behind those (see below).

## The problem

`uri-open.e2e.ts` called `closePopoutWindows()` **inline as the last statement** of two tests, with no `afterEach`. The file's own comment states the stakes:

> The popout would otherwise stay the active window and steal the next test's modals.

and `CLAUDE.md` records the same trap. But placed inline, the cleanup is skipped by any failure earlier in the test — so **the one circumstance that makes a leaked popout matter is exactly the circumstance in which it leaks**.

The consequence is nasty to diagnose rather than nasty to hit: one Obsidian process is shared per worker, so a leaked popout survives into later spec files and steals their modals. The resulting failures land in unrelated specs, pointing away from the test that actually caused them.

## The change

`afterEach(closePopoutWindows)` at the describe level, and the two inline calls removed. Runs regardless of outcome.

Verified: `uri-open.e2e.ts` 10/10 passing.

## Context: no bug behind the failures that prompted this

Two specs — `decorations > derives a property condition's operators` and `responsive layout > stacks the weekly nav blocks` — fail in a local headed full-suite run. Establishing what they were:

- The property-condition spec passes alone on `main`.
- The whole of `settings.e2e.ts` passes on `main`: 33 passing, 0 failing — including both that spec and the three drag-reorder tests.
- **Neither reproduces on CI** (green on macOS, Ubuntu and Windows in #262).

So they are the local renderer wedge already documented in `CLAUDE.md`, not a defect. No fix was warranted and none was invented.
