### PR TITLE
fix(deps): supply expect-webdriverio's missing `some` declaration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,6 +200,18 @@ on it.
   does not cover call-expression type arguments. Use the
   `new Promise<void>((resolve) => ...)` longhand. The rule is off in test files,
   and non-void type arguments are fine everywhere.
+- `expect-webdriverio` 6.x ships `types/expect-webdriverio.d.ts` importing
+  `../src/matchers/modifiers/some.js`, but its `.npmignore` re-includes only
+  `lib/**/*.js` and `types/**/*.d.ts`, so `src/` never reaches the tarball. The
+  dangling import turns `Expect` into an error type, `skipLibCheck` hides that
+  from `tsc` and `check:types` stays green, and then every `expect()` under
+  `e2e/` trips `@typescript-eslint/no-unsafe-call` — 60 errors across files
+  nobody edited, from a transitive bump. `@wdio/globals` peers
+  `expect-webdriverio@^6.0.5` and every published 6.x carries the same dangling
+  import, so pinning back is not available;
+  `patches/expect-webdriverio+6.0.5.patch` supplies the missing declaration
+  through `patch-package`'s `postinstall`. Delete the patch once upstream ships
+  `src/` or inlines the type.
 - Never write requirement or design section numbers in comments ("Satisfies
   Requirement 5.3", "(Requirement 2.5)"), in source, in tests, or in
   `describe()` labels. Bare numbers point nowhere and rot on renumbering.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2784,9 +2784,9 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "14.6.4",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.4.tgz",
-      "integrity": "sha512-QCGwP6QrjypBLwyj5cuyfVamkaIEy/XGY+1VDehbtbQqOggYmTFpFOdWR5mPz14vX8vXLMVjDHlRNBcClyO9ew==",
+      "version": "14.6.5",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.5.tgz",
+      "integrity": "sha512-FhqjldLTpteueBaKflhNFlMT3+PM0O5fiBUivht6b9CZ1eesJyy7+g3Jr7XwJzt/Hip3ZG5hWwK1MX1FuDiE4w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3766,14 +3766,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
-      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.11.tgz",
+      "integrity": "sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.10",
+        "@vitest/utils": "4.1.11",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -3787,13 +3787,41 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.10",
-        "vitest": "4.1.10"
+        "@vitest/browser": "4.1.11",
+        "vitest": "4.1.11"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/eslint-plugin": {
@@ -3828,16 +3856,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
-      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -3845,14 +3873,42 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/mocker": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
-      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+    "node_modules/@vitest/expect/node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.10",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -3896,14 +3952,42 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
-      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.10",
+        "@vitest/utils": "4.1.11",
         "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -3955,9 +4039,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
-      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4306,19 +4390,19 @@
       }
     },
     "node_modules/@wdio/cli": {
-      "version": "9.30.1",
-      "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-9.30.1.tgz",
-      "integrity": "sha512-Xrka5FQO/z2hc8vURfUSpGc2W99APCtSjLD2QJtN2C83FtrkyWq2nQDQWNYfwn9V1sSo6+7AZ4UbpGmJX9ap6Q==",
+      "version": "9.31.1",
+      "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-9.31.1.tgz",
+      "integrity": "sha512-mLBbwcXsXsPv5w/bbNJfJYj3OrMe2igIEaY+tTgh2K9z1NWSJ8nFyyJFQliHq7t6Vk1d8eJt5Gx1vf7Zz4+bIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/snapshot": "^2.1.1",
-        "@wdio/config": "9.30.1",
-        "@wdio/globals": "9.29.1",
+        "@wdio/config": "9.31.1",
+        "@wdio/globals": "9.31.1",
         "@wdio/logger": "9.29.1",
-        "@wdio/protocols": "9.30.1",
-        "@wdio/types": "9.30.1",
-        "@wdio/utils": "9.30.1",
+        "@wdio/protocols": "9.31.1",
+        "@wdio/types": "9.31.1",
+        "@wdio/utils": "9.31.1",
         "async-exit-hook": "^2.0.1",
         "chalk": "^5.4.1",
         "chokidar": "^4.0.0",
@@ -4330,7 +4414,7 @@
         "lodash.union": "^4.6.0",
         "read-pkg-up": "^10.0.0",
         "tsx": "^4.7.2",
-        "webdriverio": "9.30.1",
+        "webdriverio": "9.31.1",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -4340,16 +4424,46 @@
         "node": ">=18.20.0"
       }
     },
+    "node_modules/@wdio/cli/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@wdio/cli/node_modules/@wdio/types": {
+      "version": "9.31.1",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.31.1.tgz",
+      "integrity": "sha512-JscpbRC8L98iv2LxgfzLpKZR+dbAq2Ag11K1HGbKj7LmunozuQXW5hYhOtqYFihWhvghLWe25Kjc+OjJWD6/XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/cli/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@wdio/config": {
-      "version": "9.30.1",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.30.1.tgz",
-      "integrity": "sha512-55D7g1RBCyHTwMkb4b6sQU0ET5lf5UUM3SgTHDGOo2KHfiydtCqOvfGwzxaf9nv200+QGY6BqI6yD0Ad1VGV0g==",
+      "version": "9.31.1",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.31.1.tgz",
+      "integrity": "sha512-Myadoom9ljZZEPsouLRrwjhed23UYZNzaPINtGb/gvSdFq7nBT98NT+/dtlBb738b7XKCnIdxbWk8BQAbMeMAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@wdio/logger": "9.29.1",
-        "@wdio/types": "9.30.1",
-        "@wdio/utils": "9.30.1",
+        "@wdio/types": "9.31.1",
+        "@wdio/utils": "9.31.1",
         "deepmerge-ts": "^7.0.3",
         "glob": "^10.2.2",
         "import-meta-resolve": "^4.0.0",
@@ -4359,32 +4473,109 @@
         "node": ">=18.20.0"
       }
     },
-    "node_modules/@wdio/dot-reporter": {
-      "version": "9.30.1",
-      "resolved": "https://registry.npmjs.org/@wdio/dot-reporter/-/dot-reporter-9.30.1.tgz",
-      "integrity": "sha512-YPRrKLuubvu9Gh39/fZqXiDM4nAYHqZ0yLlFCrPjHhmR7CX/tfBrMqVBSAHAE6xCrM8Txa193fcIzwzQtGxoFQ==",
+    "node_modules/@wdio/config/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@wdio/reporter": "9.30.1",
-        "@wdio/types": "9.30.1",
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@wdio/config/node_modules/@wdio/types": {
+      "version": "9.31.1",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.31.1.tgz",
+      "integrity": "sha512-JscpbRC8L98iv2LxgfzLpKZR+dbAq2Ag11K1HGbKj7LmunozuQXW5hYhOtqYFihWhvghLWe25Kjc+OjJWD6/XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/config/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@wdio/dot-reporter": {
+      "version": "9.31.1",
+      "resolved": "https://registry.npmjs.org/@wdio/dot-reporter/-/dot-reporter-9.31.1.tgz",
+      "integrity": "sha512-3LQQsiKPOMOsl3BDdottnRJqt+1iQpfI8EWvedJX0c3bA8oF73Odgcp995Y/cYh2gzUsEncDO26kSNGinnKfMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wdio/reporter": "9.31.1",
+        "@wdio/types": "9.31.1",
         "chalk": "^5.0.1"
       },
       "engines": {
         "node": ">=18.20.0"
       }
     },
+    "node_modules/@wdio/dot-reporter/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@wdio/dot-reporter/node_modules/@wdio/reporter": {
+      "version": "9.31.1",
+      "resolved": "https://registry.npmjs.org/@wdio/reporter/-/reporter-9.31.1.tgz",
+      "integrity": "sha512-xlkqP9XE3a37bgEpq0rNBMJtfdffZWoEkNSfDwmRHPaNjg6Ji3BGWR9PYKfhRXu/MjWyooPsoyER7r9WwOj6Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0",
+        "@wdio/logger": "9.29.1",
+        "@wdio/types": "9.31.1",
+        "diff": "^8.0.2",
+        "object-inspect": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/dot-reporter/node_modules/@wdio/types": {
+      "version": "9.31.1",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.31.1.tgz",
+      "integrity": "sha512-JscpbRC8L98iv2LxgfzLpKZR+dbAq2Ag11K1HGbKj7LmunozuQXW5hYhOtqYFihWhvghLWe25Kjc+OjJWD6/XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/dot-reporter/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@wdio/globals": {
-      "version": "9.29.1",
-      "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-9.29.1.tgz",
-      "integrity": "sha512-F96BKppx4HGD64v+s57TM4K4zaxqUCg2RXHk6sjB2xrSa7P+d2VYV28ID2ddF7iSodVfPlpa1i2/jy8jMGrU8w==",
+      "version": "9.31.1",
+      "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-9.31.1.tgz",
+      "integrity": "sha512-DpqShIge3Py1QlW2kC7enAXt59tsw5/6So0duXAitTa/rcxgkt53Hnx/co80ebm4EK7B8tLrtCz+0Fp0WNNJVg==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.20.0"
       },
       "peerDependencies": {
-        "expect-webdriverio": "^5.6.5",
+        "expect-webdriverio": "^6.0.5",
         "webdriverio": "^9.0.0"
       },
       "peerDependenciesMeta": {
@@ -4397,14 +4588,14 @@
       }
     },
     "node_modules/@wdio/junit-reporter": {
-      "version": "9.30.1",
-      "resolved": "https://registry.npmjs.org/@wdio/junit-reporter/-/junit-reporter-9.30.1.tgz",
-      "integrity": "sha512-qJZRXL6vlIJ2EarNry3FEIzX7Z5isJ32ktuP3nKaM4q9Z/NXFaqTqOu01sSO0V1gARthGPgyl3GtKymFrEK8XQ==",
+      "version": "9.31.1",
+      "resolved": "https://registry.npmjs.org/@wdio/junit-reporter/-/junit-reporter-9.31.1.tgz",
+      "integrity": "sha512-CCQgIPGUgIFre9aGI6NhYmvGp5AC9jeSr74iEagwhggAdZobKWQlC2uvouaxybF1HpwNdhhvXE4QmmkvSG1ewg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@wdio/reporter": "9.30.1",
-        "@wdio/types": "9.30.1",
+        "@wdio/reporter": "9.31.1",
+        "@wdio/types": "9.31.1",
         "json-stringify-safe": "^5.0.1",
         "junit-report-builder": "^5.1.1"
       },
@@ -4412,21 +4603,68 @@
         "node": ">=18.20.0"
       }
     },
+    "node_modules/@wdio/junit-reporter/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@wdio/junit-reporter/node_modules/@wdio/reporter": {
+      "version": "9.31.1",
+      "resolved": "https://registry.npmjs.org/@wdio/reporter/-/reporter-9.31.1.tgz",
+      "integrity": "sha512-xlkqP9XE3a37bgEpq0rNBMJtfdffZWoEkNSfDwmRHPaNjg6Ji3BGWR9PYKfhRXu/MjWyooPsoyER7r9WwOj6Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0",
+        "@wdio/logger": "9.29.1",
+        "@wdio/types": "9.31.1",
+        "diff": "^8.0.2",
+        "object-inspect": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/junit-reporter/node_modules/@wdio/types": {
+      "version": "9.31.1",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.31.1.tgz",
+      "integrity": "sha512-JscpbRC8L98iv2LxgfzLpKZR+dbAq2Ag11K1HGbKj7LmunozuQXW5hYhOtqYFihWhvghLWe25Kjc+OjJWD6/XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/junit-reporter/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@wdio/local-runner": {
-      "version": "9.30.1",
-      "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-9.30.1.tgz",
-      "integrity": "sha512-nYacWDfVHolKQIZggbj4pB0Ndtr9YwRnVqdvw7bxT1YdUbGwLdJHJVL3Y/e5S+Cu57ntWI/MdhS0JXFgfBjzhA==",
+      "version": "9.31.1",
+      "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-9.31.1.tgz",
+      "integrity": "sha512-FgHosy1m09N01RmEwI8KI7L3JEtSyBzud6P2YEdUh0e2FjTK94vYA3LN9Pzog0PXNOc48xQscUvGcwc+j6I+aA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0",
         "@wdio/logger": "9.29.1",
         "@wdio/repl": "9.16.2",
-        "@wdio/runner": "9.30.1",
-        "@wdio/types": "9.30.1",
-        "@wdio/xvfb": "9.30.1",
+        "@wdio/runner": "9.31.1",
+        "@wdio/types": "9.31.1",
+        "@wdio/xvfb": "9.31.1",
         "exit-hook": "^4.0.0",
-        "expect-webdriverio": "^5.6.5",
+        "expect-webdriverio": "^6.0.5",
         "split2": "^4.1.0",
         "stream-buffers": "^3.0.2"
       },
@@ -4442,6 +4680,19 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@wdio/local-runner/node_modules/@wdio/types": {
+      "version": "9.31.1",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.31.1.tgz",
+      "integrity": "sha512-JscpbRC8L98iv2LxgfzLpKZR+dbAq2Ag11K1HGbKj7LmunozuQXW5hYhOtqYFihWhvghLWe25Kjc+OjJWD6/XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
       }
     },
     "node_modules/@wdio/local-runner/node_modules/undici-types": {
@@ -4469,17 +4720,17 @@
       }
     },
     "node_modules/@wdio/mocha-framework": {
-      "version": "9.30.1",
-      "resolved": "https://registry.npmjs.org/@wdio/mocha-framework/-/mocha-framework-9.30.1.tgz",
-      "integrity": "sha512-wGklhggr0kTMk6yDynCE+sdIQg+oSaHTDXWyXk0p0AGOjhTbm3sedg2fzawJLs/ecYjYS0VqPw/0JrBsWi3AaA==",
+      "version": "9.31.1",
+      "resolved": "https://registry.npmjs.org/@wdio/mocha-framework/-/mocha-framework-9.31.1.tgz",
+      "integrity": "sha512-1Uog3+8IcQSXurKKmdnq1ie6LQjY7fKWTADBmBfJYHvSluSvLdkMzlAEBJJE9zzjcRsYVBE4sNgdaPB4J7iO0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.11.28",
         "@wdio/logger": "9.29.1",
-        "@wdio/types": "9.30.1",
-        "@wdio/utils": "9.30.1",
+        "@wdio/types": "9.31.1",
+        "@wdio/utils": "9.31.1",
         "mocha": "^10.3.0"
       },
       "engines": {
@@ -4494,6 +4745,19 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@wdio/mocha-framework/node_modules/@wdio/types": {
+      "version": "9.31.1",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.31.1.tgz",
+      "integrity": "sha512-JscpbRC8L98iv2LxgfzLpKZR+dbAq2Ag11K1HGbKj7LmunozuQXW5hYhOtqYFihWhvghLWe25Kjc+OjJWD6/XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
       }
     },
     "node_modules/@wdio/mocha-framework/node_modules/ansi-styles": {
@@ -4791,9 +5055,9 @@
       }
     },
     "node_modules/@wdio/protocols": {
-      "version": "9.30.1",
-      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.30.1.tgz",
-      "integrity": "sha512-kV0eHy6scYoXqZuAWvtYS5ebkyIF2/JdApSEu6kIdS2EppnROuvUzsNjTUzNkT6gk+0Ib9C/CbOqiuyZuhBUcA==",
+      "version": "9.31.1",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.31.1.tgz",
+      "integrity": "sha512-/AEGY6hmEXaggUG9XJ5by6a1BLLpwbDfc6YN2NQ/66X1EZ+nPQKuYLNM/Z0BTOVClQvp+p7Uq3tc2oaNaePSDw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4862,28 +5126,28 @@
       "license": "MIT"
     },
     "node_modules/@wdio/runner": {
-      "version": "9.30.1",
-      "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-9.30.1.tgz",
-      "integrity": "sha512-mZIqnpUupSFUpw4TH+aMU7ecyi2dZuSwJ0vQHC7oYCL4gCOlUgZ8+JRe2ZGvQdp/9GfaUSr7H8/sB86znkggdw==",
+      "version": "9.31.1",
+      "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-9.31.1.tgz",
+      "integrity": "sha512-DNTaaHQ+HHQWJ/PZm4Icvuclbxk0T3ftZ5LBvVkHOAnuFlfCM/5UYZQZSWfP5PX2tRmDGAvjJbKMOzkY/AIgXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.11.28",
-        "@wdio/config": "9.30.1",
-        "@wdio/dot-reporter": "9.30.1",
-        "@wdio/globals": "9.29.1",
+        "@wdio/config": "9.31.1",
+        "@wdio/dot-reporter": "9.31.1",
+        "@wdio/globals": "9.31.1",
         "@wdio/logger": "9.29.1",
-        "@wdio/types": "9.30.1",
-        "@wdio/utils": "9.30.1",
+        "@wdio/types": "9.31.1",
+        "@wdio/utils": "9.31.1",
         "deepmerge-ts": "^7.0.3",
-        "webdriver": "9.30.1",
-        "webdriverio": "9.30.1"
+        "webdriver": "9.31.1",
+        "webdriverio": "9.31.1"
       },
       "engines": {
         "node": ">=18.20.0"
       },
       "peerDependencies": {
-        "expect-webdriverio": "^5.6.5",
+        "expect-webdriverio": "^6.0.5",
         "webdriverio": "^9.0.0"
       },
       "peerDependenciesMeta": {
@@ -4903,6 +5167,19 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@wdio/runner/node_modules/@wdio/types": {
+      "version": "9.31.1",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.31.1.tgz",
+      "integrity": "sha512-JscpbRC8L98iv2LxgfzLpKZR+dbAq2Ag11K1HGbKj7LmunozuQXW5hYhOtqYFihWhvghLWe25Kjc+OjJWD6/XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
       }
     },
     "node_modules/@wdio/runner/node_modules/undici-types": {
@@ -4960,15 +5237,15 @@
       "license": "MIT"
     },
     "node_modules/@wdio/utils": {
-      "version": "9.30.1",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.30.1.tgz",
-      "integrity": "sha512-V+JE4G6ZO9ubdjDfHDHgp/2EWs5WCXk4IT2c2ZMoWy2qALqq4wqaeZ0ce05c3z0+N+8+xMS/Q9donDiIY1yk5A==",
+      "version": "9.31.1",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.31.1.tgz",
+      "integrity": "sha512-nFkvS40MSyru38Q+KQiGHPIcshkt9JGbuOwELH0AG73QqTT24yrqdbBljQc7LcL14ptYupb85cirUlwNAKvbGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@puppeteer/browsers": "^2.2.0",
         "@wdio/logger": "9.29.1",
-        "@wdio/types": "9.30.1",
+        "@wdio/types": "9.31.1",
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^7.0.3",
         "edgedriver": "^6.1.2",
@@ -4985,10 +5262,40 @@
         "node": ">=18.20.0"
       }
     },
+    "node_modules/@wdio/utils/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@wdio/utils/node_modules/@wdio/types": {
+      "version": "9.31.1",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.31.1.tgz",
+      "integrity": "sha512-JscpbRC8L98iv2LxgfzLpKZR+dbAq2Ag11K1HGbKj7LmunozuQXW5hYhOtqYFihWhvghLWe25Kjc+OjJWD6/XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/utils/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@wdio/xvfb": {
-      "version": "9.30.1",
-      "resolved": "https://registry.npmjs.org/@wdio/xvfb/-/xvfb-9.30.1.tgz",
-      "integrity": "sha512-ZvGUg+udJWsVmE8yC26pMMCYmvblBEItRxZ6MW/Ucf710dJUs14sY23LM9m33v/uqCYim5EsSNSxV0SaKTbveQ==",
+      "version": "9.31.1",
+      "resolved": "https://registry.npmjs.org/@wdio/xvfb/-/xvfb-9.31.1.tgz",
+      "integrity": "sha512-DPEo5xmrg+FHdQRI8EJOfw8XkJwRtUUpW5smIG/zkuXhSeIde1n8ksPs82dbX+WRJggTtn4i0tjMP2toGjpSaQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9090,13 +9397,13 @@
       }
     },
     "node_modules/expect-webdriverio": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-5.7.0.tgz",
-      "integrity": "sha512-jLOTrJoPBC3Wtd83ryHMbRcEajMGtAnn6OWtSnoJoDLt16nHvxVdjcI4Bc0n+1KAOr8DvQtlJ55f0M48kJtEpw==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-6.0.5.tgz",
+      "integrity": "sha512-YIIA6ier0PWRt8ifMgfbFZvfv4yADLvpOJIA9OWbUlFy72/RIB81TqaFsQZ7zHCgVxftRNbVXMd+zaL59+qyfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/snapshot": "^4.1.7",
+        "@vitest/snapshot": "^4.1.10",
         "deep-eql": "^5.0.2",
         "expect": "^30.4.1",
         "jest-matcher-utils": "^30.4.1"
@@ -9860,9 +10167,9 @@
       "license": "MIT"
     },
     "node_modules/happy-dom": {
-      "version": "20.11.2",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.2.tgz",
-      "integrity": "sha512-7MB+bJLkxu3SowAfBJbjW+c55kNz5tkR45gu2qzrxznezhLeN5YIlJbwUgSzlGc+qWoZ8Ykg71H5ezz69xixrw==",
+      "version": "20.11.6",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.6.tgz",
+      "integrity": "sha512-Hldbg8AdAa5a5oDcZpjqnGitp7JB0hqWmfv/8qr+kft4vzSD8BHsbdRfzYvL/0QcbKcURC/yyoygbeDQarPvYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12885,9 +13192,9 @@
       }
     },
     "node_modules/obsidian-launcher": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/obsidian-launcher/-/obsidian-launcher-3.1.3.tgz",
-      "integrity": "sha512-5G/SucctjUB2FJx09UD69/SKfACUrD6+N+nE1zBVtcQpDfo76gb6Z1RArvo1H6zXaqQLKk/ckI0WeXh9Q2D3kw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/obsidian-launcher/-/obsidian-launcher-3.2.0.tgz",
+      "integrity": "sha512-JSsGnXD+uMPy426xkV+st7iVhe1vyxKD3RsQTwiE3FZqGioC+NSnIzKZHqnlPN/AAy/ai94VuBVndc49jLcVlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15699,16 +16006,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
-      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.25",
-        "rolldown": "~1.2.1",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -15725,7 +16032,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.4.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -15864,19 +16171,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
-      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.10",
-        "@vitest/mocker": "4.1.10",
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/runner": "4.1.10",
-        "@vitest/snapshot": "4.1.10",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -15904,12 +16211,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.10",
-        "@vitest/browser-preview": "4.1.10",
-        "@vitest/browser-webdriverio": "4.1.10",
-        "@vitest/coverage-istanbul": "4.1.10",
-        "@vitest/coverage-v8": "4.1.10",
-        "@vitest/ui": "4.1.10",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -15953,17 +16260,45 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/@vitest/snapshot": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
-      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+    "node_modules/vitest/node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -16154,9 +16489,9 @@
       }
     },
     "node_modules/wdio-obsidian-reporter": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/wdio-obsidian-reporter/-/wdio-obsidian-reporter-3.1.3.tgz",
-      "integrity": "sha512-2pIFHbfPRNdfHZqdrnMBWBUShBJmoN2ZJuLdIo5pv9P4xxttlZcXCdS9rMO5kKibToCBgA6bU7r8G3LE31iYYg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/wdio-obsidian-reporter/-/wdio-obsidian-reporter-3.2.0.tgz",
+      "integrity": "sha512-rOPTRc0YTriXUks7rG2mfPQ/uFPLwV96xPGEYa/v0tcb9EUNZPLGJrWByZ9NSGG0YAPsp+Y8EKjC/N9/8znOiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16168,14 +16503,14 @@
       }
     },
     "node_modules/wdio-obsidian-service": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/wdio-obsidian-service/-/wdio-obsidian-service-3.1.3.tgz",
-      "integrity": "sha512-QOcSqD0ygI5IXPBbMdCXGjuDA329kVBorvSw4Jz2Q12MPxLisJB6waJztOk5RQi0PeFS0UtD//m8wkKazIsrOQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/wdio-obsidian-service/-/wdio-obsidian-service-3.2.0.tgz",
+      "integrity": "sha512-9ilKBh0lCXsM6wXID8FANM/HTkqzgPGPAo7HSgyBUSUpqsxoTFN2bDm9eVGp6lCpFJ8ynKxcY7Ar+dNDBM6jcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",
-        "obsidian-launcher": "3.1.3",
+        "obsidian-launcher": "3.2.0",
         "semver": "^7.7.3",
         "tar": "^7.5.3"
       },
@@ -16205,19 +16540,19 @@
       "license": "Apache-2.0"
     },
     "node_modules/webdriver": {
-      "version": "9.30.1",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.30.1.tgz",
-      "integrity": "sha512-qvtOsFiS0v3rrDPp+saWI8WQdOotT7nsPIFaML0T/uRUwr4QPjaFNbY+ZQwfzv07BQdpVGwiUEeLws5piVlEgA==",
+      "version": "9.31.1",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.31.1.tgz",
+      "integrity": "sha512-MLvpE/7ao4tAO1bRdYnv0sjXuLBBrNA9wULIJtnwl5BQpZyetkzDSbNMg1LI2dZr5k877WdrSMdBkOgwi/VEAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0",
         "@types/ws": "^8.5.3",
-        "@wdio/config": "9.30.1",
+        "@wdio/config": "9.31.1",
         "@wdio/logger": "9.29.1",
-        "@wdio/protocols": "9.30.1",
-        "@wdio/types": "9.30.1",
-        "@wdio/utils": "9.30.1",
+        "@wdio/protocols": "9.31.1",
+        "@wdio/types": "9.31.1",
+        "@wdio/utils": "9.31.1",
         "deepmerge-ts": "^7.0.3",
         "https-proxy-agent": "^7.0.6",
         "undici": "^6.27.0",
@@ -16235,6 +16570,19 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/webdriver/node_modules/@wdio/types": {
+      "version": "9.31.1",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.31.1.tgz",
+      "integrity": "sha512-JscpbRC8L98iv2LxgfzLpKZR+dbAq2Ag11K1HGbKj7LmunozuQXW5hYhOtqYFihWhvghLWe25Kjc+OjJWD6/XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
       }
     },
     "node_modules/webdriver/node_modules/undici": {
@@ -16255,20 +16603,20 @@
       "license": "MIT"
     },
     "node_modules/webdriverio": {
-      "version": "9.30.1",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.30.1.tgz",
-      "integrity": "sha512-HvoMHVPj1Ky04h0kEELKilWuzAi0Ctpmfw5V7LStQmOzbXkzfxxMutSB3SezJAYCWCnZ6zsEw7TdDWubWGY7qA==",
+      "version": "9.31.1",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.31.1.tgz",
+      "integrity": "sha512-ofHM+SyJ/vKtI7l4YtxdyU9/8bFKHO29QwY5uLL9NgPfM2AzFWGvh4Aog/IK5+CqiqIVWpjKY5kUMFWLM5Vx4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.11.30",
         "@types/sinonjs__fake-timers": "^8.1.5",
-        "@wdio/config": "9.30.1",
+        "@wdio/config": "9.31.1",
         "@wdio/logger": "9.29.1",
-        "@wdio/protocols": "9.30.1",
+        "@wdio/protocols": "9.31.1",
         "@wdio/repl": "9.16.2",
-        "@wdio/types": "9.30.1",
-        "@wdio/utils": "9.30.1",
+        "@wdio/types": "9.31.1",
+        "@wdio/utils": "9.31.1",
         "archiver": "^7.0.1",
         "aria-query": "^5.3.0",
         "cheerio": "^1.0.0-rc.12",
@@ -16285,13 +16633,13 @@
         "rgb2hex": "0.2.5",
         "serialize-error": "^12.0.0",
         "urlpattern-polyfill": "^10.0.0",
-        "webdriver": "9.30.1"
+        "webdriver": "9.31.1"
       },
       "engines": {
         "node": ">=18.20.0"
       },
       "peerDependencies": {
-        "puppeteer-core": ">=22.x || <=24.x"
+        "puppeteer-core": ">=22.x <=24.x"
       },
       "peerDependenciesMeta": {
         "puppeteer-core": {
@@ -16307,6 +16655,19 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/webdriverio/node_modules/@wdio/types": {
+      "version": "9.31.1",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.31.1.tgz",
+      "integrity": "sha512-JscpbRC8L98iv2LxgfzLpKZR+dbAq2Ag11K1HGbKj7LmunozuQXW5hYhOtqYFihWhvghLWe25Kjc+OjJWD6/XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
       }
     },
     "node_modules/webdriverio/node_modules/undici-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "obsidian-journal",
       "version": "3.1.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@inlang/paraglide-js": "^2.23.2",
@@ -58,6 +59,7 @@
         "husky": "^9.1.7",
         "mocha": "^11.8.0",
         "nano-staged": "^1.0.2",
+        "patch-package": "^8.0.1",
         "prettier": "^3.9.6",
         "tslib": "^2.8.1",
         "tsx": "^4.23.12",
@@ -5305,6 +5307,13 @@
         "node": ">=18.20.0"
       }
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/@zip.js/zip.js": {
       "version": "2.8.50",
       "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.50.tgz",
@@ -9723,6 +9732,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/flat": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -9785,6 +9804,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/fs.realpath": {
@@ -10831,6 +10865,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-document.all": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
@@ -11216,6 +11266,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/isarray": {
@@ -11754,6 +11817,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -11815,6 +11898,29 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -11935,6 +12041,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kysely": {
@@ -12615,6 +12731,33 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -13262,6 +13405,23 @@
         "wrappy": "1"
       }
     },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -13531,6 +13691,95 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/patch-package/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/patch-package/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/path-browserify": {
@@ -15527,6 +15776,16 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -15835,6 +16094,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/unplugin": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "coverage": "vitest run --coverage",
     "bench": "vitest bench",
     "check:types": "vue-tsc -b",
-    "prepare": "husky"
+    "prepare": "husky",
+    "postinstall": "patch-package"
   },
   "repository": {
     "type": "git",
@@ -86,6 +87,7 @@
     "husky": "^9.1.7",
     "mocha": "^11.8.0",
     "nano-staged": "^1.0.2",
+    "patch-package": "^8.0.1",
     "prettier": "^3.9.6",
     "tslib": "^2.8.1",
     "tsx": "^4.23.12",

--- a/patches/expect-webdriverio+6.0.5.patch
+++ b/patches/expect-webdriverio+6.0.5.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/expect-webdriverio/src/matchers/modifiers/some.d.ts b/node_modules/expect-webdriverio/src/matchers/modifiers/some.d.ts
+new file mode 100644
+index 0000000..619ace4
+--- /dev/null
++++ b/node_modules/expect-webdriverio/src/matchers/modifiers/some.d.ts
+@@ -0,0 +1,9 @@
++declare const SOME_SYMBOL: unique symbol;
++export declare class SomeElementsWrapper<T> {
++    readonly elements: T;
++    readonly [SOME_SYMBOL] = true;
++    constructor(elements: T);
++}
++export declare function some<T>(elements: T): SomeElementsWrapper<T>;
++export declare function isSomeWrapper(value: unknown): value is SomeElementsWrapper<unknown>;
++export {};


### PR DESCRIPTION
Unblocks #265, which fails `build` with 60 `@typescript-eslint/no-unsafe-call` errors across `e2e/` — in files the PR does not touch.

## Root cause

`@wdio/globals@9.31.0` moved its `expect-webdriverio` peer from `^5.6.5` to `^6.0.5`, so the bump pulls `expect-webdriverio` 5.7.0 → 6.0.5.

Every published 6.x ships:

```ts
// types/expect-webdriverio.d.ts:25
type WdioSome<T> = import('../src/matchers/modifiers/some.js').SomeElementsWrapper<T>
```

while its `.npmignore` re-includes only `lib/**/*.js` and `types/**/*.d.ts` — `src/` never reaches the tarball. Verified against every published 6.x tarball (6.0.0 through 6.0.5): `package/src/` has zero entries in all of them, and each one's `types/expect-webdriverio.d.ts` carries the import. 5.7.0 does not contain the line at all.

The dangling import makes `WdioSome` an error type, which propagates `MaybeSome` → matcher signatures → `ExpectWebdriverIO.Expect` → `@wdio/globals`' global `expect`. `skipLibCheck` swallows it, so `check:types` stays green and only the typed lint rule notices.

## Why not the alternatives

- **Pin back** — `@wdio/globals@9.31.x` peers `^6.0.5`, and every published 6.x carries the same dangling import. There is no version in range that works.
- **Disable the rule for `e2e/`** — drops `no-unsafe-call` across the entire e2e layer to route around one missing file.

## The fix

Carry the missing declaration as a `patch-package` patch, generated by compiling upstream's own `src/matchers/modifiers/some.ts` with `tsc --declaration`. Types-only; no shipped file is modified. Delete the patch once upstream ships `src/` or inlines the type — the version in its filename makes that visible.

Applying cleanly to a *mismatched* version was checked too (exit 0 with a warning against 5.7.0), so this can merge before or after #265 without breaking `main`.

## Verification

Clean `rm -rf node_modules && npm ci` on this branch, then every step of the `build` job:

| Step | Result |
| --- | --- |
| `npm ci` (postinstall) | `expect-webdriverio@6.0.5 ✔` |
| `check:i18n` | no violations (11 locales) |
| `check:types` | clean |
| `npm test` | 4101 passed (388 files) |
| `check:lint` | **0 errors**, 10 warnings (all pre-existing on `main`) |
| `build:api` + `git diff --exit-code` | API types unchanged |
| `check:api` | passes |
| `npm run build` | built |

Upstream has no issue filed for this yet — checked `webdriverio/expect-webdriverio` and `webdriverio/webdriverio`, open and closed, issues and PRs.
