### PR TITLE
test: build the testContainer harness and split the journals modules

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -10,6 +10,7 @@ words:
   - haspopup
   - iconed
   - inlang
+  - Initializable
   - invertibility
   - Keymap
   - labelledby

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -190,6 +190,11 @@ Don't test module wiring, barrel shapes, or the fakes/mocks themselves — the
 compiler and the tooling already guarantee those, and a test for a fake tests
 test infrastructure rather than behavior.
 
+`src/testing.ts` is the exception the rule implies rather than contradicts: its guards and options
+have behavior that can fail — a seed silently repaired, a leak undetected, an override applied
+after the service resolved — and a defect there makes every test in the repo lie. Test those; its
+wiring stays untested like any other module's.
+
 The e2e layer — what it covers, how it's structured, and why the mock-based
 unit suite can't reach it — is documented separately in
 [`docs/e2e-testing-strategy.md`](e2e-testing-strategy.md).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -227,10 +227,23 @@ export default [
   },
   {
     // Plugin sources are what the locale-freeze guard protects; test and e2e modules are
-    // imported by a runner that has already picked a locale.
+    // imported by a runner that has already picked a locale. Container.override is defined
+    // and tested under src/infrastructure/di/**, so that directory is exempt from the
+    // override-ban selector below.
     files: ["src/**/*.ts"],
+    ignores: ["src/infrastructure/di/**"],
     rules: {
-      "no-restricted-syntax": ["error", noRawError, noStrayDefineModal, noEagerMessage],
+      "no-restricted-syntax": [
+        "error",
+        noRawError,
+        noStrayDefineModal,
+        noEagerMessage,
+        {
+          selector: "CallExpression[callee.property.name='override'][callee.object.type!='ThisExpression']",
+          message:
+            "Container.override exists for the test host boundary. Production wiring registers once, in a module.",
+        },
+      ],
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -396,9 +396,12 @@ export default [
     },
   },
   {
+    // Modal definitions are what `noStrayDefineModal` exists to allow here, so this array drops it
+    // — but flat-config rule values replace rather than merge, so every other selector has to be
+    // repeated or it silently stops applying to these files.
     files: ["**/ui/modals.ts", "src/infrastructure/host/modals/**/*.ts"],
     rules: {
-      "no-restricted-syntax": ["error", noRawError, noEagerMessage],
+      "no-restricted-syntax": ["error", noRawError, noEagerMessage, noProductionOverride],
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -60,6 +60,15 @@ const noEagerMessage = {
     "`m.*()` at module scope resolves to the base locale because `initLocale()` runs in `onload()`. Wrap it in a factory called at use time.",
 };
 
+// `Container.override` exists for the test host boundary (src/testing.ts) and is defined and
+// tested under src/infrastructure/di/**; production wiring registers once, in a module. ESLint
+// selectors can't see types, so this also matches any other object's `.override(...)` method —
+// accepted, since none exists in this codebase today.
+const noProductionOverride = {
+  selector: "CallExpression[callee.property.name='override'][callee.object.type!='ThisExpression']",
+  message: "Container.override exists for the test host boundary. Production wiring registers once, in a module.",
+};
+
 export default [
   {
     ignores: [
@@ -233,17 +242,22 @@ export default [
     files: ["src/**/*.ts"],
     ignores: ["src/infrastructure/di/**"],
     rules: {
-      "no-restricted-syntax": [
-        "error",
-        noRawError,
-        noStrayDefineModal,
-        noEagerMessage,
-        {
-          selector: "CallExpression[callee.property.name='override'][callee.object.type!='ThisExpression']",
-          message:
-            "Container.override exists for the test host boundary. Production wiring registers once, in a module.",
-        },
-      ],
+      "no-restricted-syntax": ["error", noRawError, noStrayDefineModal, noEagerMessage, noProductionOverride],
+    },
+  },
+  {
+    // `.vue` files get the override ban too — nothing stops a component importing a
+    // `Container` and calling `.override(...)` — but not `noEagerMessage`: a `<script setup>`
+    // body reads as module scope in the AST but executes per component instance, so the rule
+    // would be a guaranteed false positive here (see the exemption note above `noEagerMessage`).
+    // `noRawError`/`noStrayDefineModal` are already enforced for `.vue` through the base rules
+    // block above (it carries no `files` filter); repeating them here just keeps this block's
+    // `no-restricted-syntax` array from silently dropping that enforcement, since flat config
+    // rule values replace rather than merge.
+    files: ["src/**/*.vue"],
+    ignores: ["src/infrastructure/di/**"],
+    rules: {
+      "no-restricted-syntax": ["error", noRawError, noStrayDefineModal, noProductionOverride],
     },
   },
   {

--- a/src/calendar/testing.test.ts
+++ b/src/calendar/testing.test.ts
@@ -1,0 +1,27 @@
+import { moment } from "obsidian";
+import { describe, expect, it } from "vitest";
+
+import { CUSTOM_LOCALE } from "./calendar";
+import { installTestCalendar, testCalendar } from "./testing";
+
+describe("ambient test calendar", () => {
+  it("starts every test on the Monday/ISO grid without an explicit install", () => {
+    expect(moment.localeData(CUSTOM_LOCALE).firstDayOfWeek()).toBe(1);
+  });
+
+  it("lets a test replace the ambient grid", () => {
+    installTestCalendar({ dow: 0, doy: 6 });
+
+    expect(moment.localeData(CUSTOM_LOCALE).firstDayOfWeek()).toBe(0);
+  });
+
+  it("restores the ambient grid for the next test", () => {
+    expect(moment.localeData(CUSTOM_LOCALE).firstDayOfWeek()).toBe(1);
+  });
+
+  it("returns the same calendar instance a replacement installed", () => {
+    const { calendar } = installTestCalendar({ dow: 0, doy: 6 });
+
+    expect(testCalendar()).toBe(calendar);
+  });
+});

--- a/src/calendar/testing.ts
+++ b/src/calendar/testing.ts
@@ -7,41 +7,26 @@ import type { AnchorString } from "./types";
 
 let installed: Calendar | undefined;
 
-export function installTestCalendar(week?: Partial<WeekConfig>): { teardown: () => void; calendar: Calendar } {
-  const priorLocale = moment.locale();
-  const priorWeek = moment.locales().includes(CUSTOM_LOCALE)
-    ? {
-        dow: moment.localeData(CUSTOM_LOCALE).firstDayOfWeek(),
-        doy: moment.localeData(CUSTOM_LOCALE).firstDayOfYear(),
-      }
-    : { dow: 1, doy: 4 };
-  const calendar = new Calendar();
-  calendar.applyWeekConfig({ dow: week?.dow ?? 1, doy: week?.doy ?? 4 }, { propagateToGlobal: false });
-  installed = calendar;
+const DEFAULT_TEST_WEEK: WeekConfig = { dow: 1, doy: 4 };
 
-  return {
-    calendar,
-    teardown: () => {
-      installed = undefined;
-      moment.updateLocale(CUSTOM_LOCALE, { week: priorWeek });
-      moment.locale(priorLocale);
-    },
-  };
+export function installTestCalendar(week?: Partial<WeekConfig>): { teardown: () => void; calendar: Calendar } {
+  // Reuse the installed instance: the Calendar constructor re-seeds CUSTOM_LOCALE from the system
+  // locale, so a second `new Calendar()` inside one test discards the first's grid.
+  const calendar = installed ?? new Calendar();
+  calendar.applyWeekConfig(
+    { dow: week?.dow ?? DEFAULT_TEST_WEEK.dow, doy: week?.doy ?? DEFAULT_TEST_WEEK.doy },
+    { propagateToGlobal: false },
+  );
+  installed = calendar;
+  return { calendar, teardown: resetCalendarLocale };
 }
 
-// moment's locale registry is process-global, so when test files share a worker's module registry
-// the custom locale outlives the file that defined it and the next file silently inherits its week
-// grid. Putting the custom locale back on the machine locale's week between files restores the
-// starting point a file gets when it is the first one to touch the calendar.
+// Puts the week grid back to the value every test starts on. The global afterEach calls this, so a
+// test that changed the grid cannot hand it to the next test in the same worker — which the previous
+// afterAll-only reset allowed.
 export function resetCalendarLocale(): void {
-  installed = undefined;
   if (!moment.locales().includes(CUSTOM_LOCALE)) return;
-  const currentLocale = moment.locale();
-  const machine = moment.localeData(currentLocale);
-  moment.updateLocale(CUSTOM_LOCALE, {
-    week: { dow: machine.firstDayOfWeek(), doy: machine.firstDayOfYear() },
-  });
-  moment.locale(currentLocale);
+  installed?.applyWeekConfig(DEFAULT_TEST_WEEK, { propagateToGlobal: false });
 }
 
 // Component tests must resolve this instance rather than constructing their own: the Calendar

--- a/src/calendar/testing.ts
+++ b/src/calendar/testing.ts
@@ -21,9 +21,9 @@ export function installTestCalendar(week?: Partial<WeekConfig>): { teardown: () 
   return { calendar, teardown: resetCalendarLocale };
 }
 
-// Puts the week grid back to the value every test starts on. The global afterEach calls this, so a
-// test that changed the grid cannot hand it to the next test in the same worker — which the previous
-// afterAll-only reset allowed.
+// Puts the week grid back to the value every test starts on, for a caller holding the `teardown`
+// handle installTestCalendar returns — nothing else reaches it. A test that changed the grid cannot
+// hand it to the next one regardless: the global beforeEach re-pins the grid before every test.
 export function resetCalendarLocale(): void {
   if (!moment.locales().includes(CUSTOM_LOCALE)) return;
   installed?.applyWeekConfig(DEFAULT_TEST_WEEK, { propagateToGlobal: false });

--- a/src/infrastructure/di/container.test.ts
+++ b/src/infrastructure/di/container.test.ts
@@ -510,4 +510,48 @@ describe("override", () => {
     expect(() => c.override(token)).toThrow(CannotOverrideError);
     expect(() => c.override(token)).toThrow(expect.objectContaining({ reason: "scoped" }));
   });
+
+  it("keeps the overridden binding eager", async () => {
+    const c = new Container();
+    const token = createToken<string>("greeting");
+    c.register(token).useValue("original").eager();
+
+    const built: string[] = [];
+    c.override(token).useFactory(() => {
+      built.push("replacement");
+      return "replaced";
+    });
+    await c.autoLoad();
+
+    expect(built).toEqual(["replacement"]);
+  });
+
+  it("keeps the overridden binding's lifetime", () => {
+    const c = new Container();
+    const token = createToken<object>("transient");
+    c.register(token)
+      .useFactory(() => ({}))
+      .lifetime(Lifetime.Transient);
+
+    c.override(token).useFactory(() => ({}));
+
+    expect(c.resolve(token)).not.toBe(c.resolve(token));
+  });
+
+  it("lets the override widen a lazy binding to eager", async () => {
+    const c = new Container();
+    const token = createToken<string>("greeting");
+    c.register(token).useValue("original");
+
+    const built: string[] = [];
+    c.override(token)
+      .useFactory(() => {
+        built.push("replacement");
+        return "replaced";
+      })
+      .eager();
+    await c.autoLoad();
+
+    expect(built).toEqual(["replacement"]);
+  });
 });

--- a/src/infrastructure/di/container.ts
+++ b/src/infrastructure/di/container.ts
@@ -74,9 +74,13 @@ export class Container implements Resolver {
     // resolve would silently keep the old instance. Refusing is safe: overrides run before
     // autoLoad(), which is when eager bindings first resolve.
     if (stored.slot.has) throw new CannotOverrideError(token, "resolved");
-    return new RegistrationBuilder<T>((entry) => {
-      stored.entry = entry;
-    });
+    const { lifetime, eager } = stored.entry;
+    return new RegistrationBuilder<T>(
+      (entry) => {
+        stored.entry = entry;
+      },
+      { lifetime, eager },
+    );
   }
 
   resolve<T>(token: TokenLike<T>): T;

--- a/src/infrastructure/di/registration.ts
+++ b/src/infrastructure/di/registration.ts
@@ -10,7 +10,7 @@ export interface RegistrationEntry<T> {
 
 export type OnRegistrationChange<T> = (entry: RegistrationEntry<T>) => void;
 
-export interface RegistrationDefaults {
+interface RegistrationDefaults {
   readonly lifetime: Lifetime;
   readonly eager: boolean;
 }

--- a/src/infrastructure/di/registration.ts
+++ b/src/infrastructure/di/registration.ts
@@ -10,35 +10,46 @@ export interface RegistrationEntry<T> {
 
 export type OnRegistrationChange<T> = (entry: RegistrationEntry<T>) => void;
 
+export interface RegistrationDefaults {
+  readonly lifetime: Lifetime;
+  readonly eager: boolean;
+}
+
+const REGISTER_DEFAULTS: RegistrationDefaults = { lifetime: Lifetime.Container, eager: false };
+
 export class RegistrationBuilder<T> {
   readonly #onChange: OnRegistrationChange<T>;
+  readonly #defaults: RegistrationDefaults;
 
-  constructor(onChange: OnRegistrationChange<T>) {
+  constructor(onChange: OnRegistrationChange<T>, defaults: RegistrationDefaults = REGISTER_DEFAULTS) {
     this.#onChange = onChange;
+    this.#defaults = defaults;
   }
 
   useClass(ctor: Class<T>): RegistrationOptions<T> {
-    return new RegistrationOptions<T>(() => new ctor(), this.#onChange);
+    return new RegistrationOptions<T>(() => new ctor(), this.#onChange, this.#defaults);
   }
 
   useFactory(factory: () => T): RegistrationOptions<T> {
-    return new RegistrationOptions<T>(factory, this.#onChange);
+    return new RegistrationOptions<T>(factory, this.#onChange, this.#defaults);
   }
 
   useValue(value: T): RegistrationOptions<T> {
-    return new RegistrationOptions<T>(() => value, this.#onChange);
+    return new RegistrationOptions<T>(() => value, this.#onChange, this.#defaults);
   }
 }
 
 export class RegistrationOptions<T> {
   readonly #factory: () => T;
   readonly #onChange: OnRegistrationChange<T>;
-  #lifetime: Lifetime = Lifetime.Container;
-  #eager = false;
+  #lifetime: Lifetime;
+  #eager: boolean;
 
-  constructor(factory: () => T, onChange: OnRegistrationChange<T>) {
+  constructor(factory: () => T, onChange: OnRegistrationChange<T>, defaults: RegistrationDefaults = REGISTER_DEFAULTS) {
     this.#factory = factory;
     this.#onChange = onChange;
+    this.#lifetime = defaults.lifetime;
+    this.#eager = defaults.eager;
     this.#notify();
   }
 

--- a/src/infrastructure/host/internal/testing.test.ts
+++ b/src/infrastructure/host/internal/testing.test.ts
@@ -41,3 +41,23 @@ describe("createFakeHost vault consistency", () => {
     expect(seen).toEqual([]);
   });
 });
+
+describe("createFakeHost metadata staging", () => {
+  it("keeps metadata staged through emitMetadata when a frontmatter write lands", async () => {
+    const host = createFakeHost();
+    const position = { start: { line: 0, col: 0, offset: 0 }, end: { line: 0, col: 0, offset: 0 } };
+    const file = host.putFile("daily/2026-05-19.md");
+    host.emitMetadata("daily/2026-05-19.md", {
+      tags: [{ tag: "#journal", position }],
+      frontmatter: { journal: "daily" },
+    });
+
+    await host.app.fileManager.processFrontMatter(file, (fm: Record<string, unknown>) => {
+      fm["journal-date"] = "2026-05-19";
+    });
+
+    const cached = host.app.metadataCache.getFileCache(file);
+    expect(cached?.tags).toEqual([{ tag: "#journal", position }]);
+    expect(cached?.frontmatter).toEqual({ journal: "daily", "journal-date": "2026-05-19" });
+  });
+});

--- a/src/infrastructure/host/internal/testing.test.ts
+++ b/src/infrastructure/host/internal/testing.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { createFakeHost } from "./testing";
+
+describe("createFakeHost vault consistency", () => {
+  it("exposes a seeded note's frontmatter through the metadata cache", () => {
+    const host = createFakeHost();
+    const file = host.putFile("daily/2026-05-19.md", "", { journal: "daily" });
+
+    expect(host.app.metadataCache.getFileCache(file)?.frontmatter).toEqual({ journal: "daily" });
+  });
+
+  it("reflects a frontmatter write in the metadata cache", async () => {
+    const host = createFakeHost();
+    const file = host.putFile("daily/2026-05-19.md", "", { journal: "daily" });
+
+    await host.app.fileManager.processFrontMatter(file, (fm: Record<string, unknown>) => {
+      fm["journal-date"] = "2026-05-19";
+    });
+
+    expect(host.app.metadataCache.getFileCache(file)?.frontmatter).toEqual({
+      journal: "daily",
+      "journal-date": "2026-05-19",
+    });
+  });
+
+  it("reports no frontmatter for a note seeded without any", () => {
+    const host = createFakeHost();
+    const file = host.putFile("notes/plain.md", "body");
+
+    expect(host.app.metadataCache.getFileCache(file)?.frontmatter).toBeUndefined();
+  });
+
+  it("does not emit a vault event when a note is seeded", () => {
+    const host = createFakeHost();
+    const seen: unknown[] = [];
+    host.app.vault.on("create", (f) => seen.push(f));
+
+    host.putFile("daily/2026-05-19.md");
+
+    expect(seen).toEqual([]);
+  });
+});

--- a/src/infrastructure/host/internal/testing.ts
+++ b/src/infrastructure/host/internal/testing.ts
@@ -161,8 +161,16 @@ function parentPath(path: string): string {
 // on write is what keeps a seeded note and a service-written note equally visible to the index.
 // Nothing here emits: events stay explicit through emitVault/emitMetadata.
 function entryFor(content: string, frontmatter: Record<string, unknown>): FakeFileSystemEntry {
-  const hasFrontmatter = Object.keys(frontmatter).length > 0;
-  return { content, frontmatter, metadata: hasFrontmatter ? { frontmatter } : {} };
+  return { content, frontmatter, metadata: metadataWithFrontmatter({}, frontmatter) };
+}
+
+// A frontmatter write must leave the rest of a staged CachedMetadata — tags, links, headings put
+// there by emitMetadata — untouched, so it patches the frontmatter field rather than rebuilding.
+function metadataWithFrontmatter(metadata: CachedMetadata, frontmatter: Record<string, unknown>): CachedMetadata {
+  const next: CachedMetadata = { ...metadata };
+  if (Object.keys(frontmatter).length > 0) next.frontmatter = frontmatter;
+  else delete next.frontmatter;
+  return next;
 }
 
 export function createFakeHost(): FakeHost {
@@ -342,7 +350,11 @@ export function createFakeHost(): FakeHost {
       if (!existing) throw new Error(`missing: ${file.path}`);
       const next = { ...existing.frontmatter };
       mutate(next);
-      files.set(file.path, entryFor(existing.content, next));
+      files.set(file.path, {
+        ...existing,
+        frontmatter: next,
+        metadata: metadataWithFrontmatter(existing.metadata, next),
+      });
     },
     async trashFile(file: TFile): Promise<void> {
       detachChild(file);
@@ -546,7 +558,11 @@ export function createFakeHost(): FakeHost {
     emitMetadata(path, cached): void {
       if (cached) {
         const existing = files.get(path);
-        if (existing) files.set(path, { ...existing, metadata: cached });
+        // The entry's own `frontmatter` is what a later processFrontMatter mutates, so staged
+        // frontmatter has to reach it or the next write drops what this call staged.
+        if (existing) {
+          files.set(path, { ...existing, frontmatter: cached.frontmatter ?? existing.frontmatter, metadata: cached });
+        }
       }
       metadata.emit("changed", fileObjects.get(path), "", cached ?? {});
     },

--- a/src/infrastructure/host/internal/testing.ts
+++ b/src/infrastructure/host/internal/testing.ts
@@ -157,6 +157,14 @@ function parentPath(path: string): string {
   return index === -1 ? "" : path.slice(0, index);
 }
 
+// getFileCache reads `metadata`, every write path sets `frontmatter`. Deriving one from the other
+// on write is what keeps a seeded note and a service-written note equally visible to the index.
+// Nothing here emits: events stay explicit through emitVault/emitMetadata.
+function entryFor(content: string, frontmatter: Record<string, unknown>): FakeFileSystemEntry {
+  const hasFrontmatter = Object.keys(frontmatter).length > 0;
+  return { content, frontmatter, metadata: hasFrontmatter ? { frontmatter } : {} };
+}
+
 export function createFakeHost(): FakeHost {
   const files = new Map<string, FakeFileSystemEntry>();
   const folders = new Set<string>([""]);
@@ -248,7 +256,7 @@ export function createFakeHost(): FakeHost {
     async create(path: string, content: string): Promise<TFile> {
       if (fileObjects.has(path)) throw new Error(`exists: ${path}`);
       ensureFolderChain(parentPath(path));
-      files.set(path, { content, frontmatter: {}, metadata: {} });
+      files.set(path, entryFor(content, {}));
       const file = makeFile(path);
       setParent(file);
       fileObjects.set(path, file);
@@ -334,7 +342,7 @@ export function createFakeHost(): FakeHost {
       if (!existing) throw new Error(`missing: ${file.path}`);
       const next = { ...existing.frontmatter };
       mutate(next);
-      files.set(file.path, { ...existing, frontmatter: next });
+      files.set(file.path, entryFor(existing.content, next));
     },
     async trashFile(file: TFile): Promise<void> {
       detachChild(file);
@@ -515,7 +523,7 @@ export function createFakeHost(): FakeHost {
     promptedDeletions,
     putFile(path, content = "", frontmatter = {}): TFile {
       ensureFolderChain(parentPath(path));
-      files.set(path, { content, frontmatter, metadata: {} });
+      files.set(path, entryFor(content, frontmatter));
       const file = makeFile(path);
       setParent(file);
       fileObjects.set(path, file);

--- a/src/journals/cycle.test.ts
+++ b/src/journals/cycle.test.ts
@@ -1,468 +1,615 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
-import { CalendarDate } from "@/calendar";
 import type { AnchorString } from "@/calendar";
-import { installTestCalendar } from "@/calendar/testing";
-import { Container } from "@/infrastructure/di";
+import { date } from "@/calendar/testing";
 import type { VaultPath } from "@/infrastructure/host";
-import { expectOk } from "@/infrastructure/result/testing";
+import { testContainer } from "@/testing";
 
 import { CycleService } from "./cycle";
 import { JournalsIndex } from "./journals-index";
-import { JournalsRepository } from "./repository";
-import { customJournal, fakeRepo, fixedJournal, unwrap } from "./testing";
-
-function buildContainer(journals: Parameters<typeof fakeRepo>[0]): Container {
-  const c = new Container();
-  c.register(JournalsRepository).useValue(fakeRepo(journals));
-  c.register(JournalsIndex).useClass(JournalsIndex);
-  c.register(CycleService).useClass(CycleService);
-  return c;
-}
-
-function unwrapResult<T, E>(r: Parameters<typeof expectOk<T, E>>[0]): T {
-  expectOk(r);
-  return r.value;
-}
+import { journalsCoreModule } from "./module";
+import { customJournal, fixedJournal, unwrap } from "./testing";
 
 describe("CycleService", () => {
-  let teardown: () => void;
-
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-
-  afterEach(() => {
-    teardown();
-  });
-
   describe("anchorOf", () => {
     describe("fixed daily", () => {
-      it("returns the date itself as the anchor", () => {
-        const c = buildContainer({ daily: fixedJournal("daily", { type: "day" }) });
-        const cycle = c.resolve(CycleService);
-        const result = cycle.anchorOf("daily", unwrapResult(CalendarDate.parse("2022-03-15")));
+      it("returns the date itself as the anchor", async () => {
+        const { resolve } = await testContainer({
+          modules: [journalsCoreModule],
+          data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+        });
+
+        const result = resolve(CycleService).anchorOf("daily", date("2022-03-15"));
+
         expect(result.isSome() && result.value).toBe("2022-03-15");
       });
 
-      it("returns None for an unknown journal", () => {
-        const c = buildContainer({});
-        const cycle = c.resolve(CycleService);
-        expect(cycle.anchorOf("missing", unwrapResult(CalendarDate.parse("2022-03-15"))).isNone()).toBe(true);
+      it("returns None for an unknown journal", async () => {
+        const { resolve } = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
+
+        expect(resolve(CycleService).anchorOf("missing", date("2022-03-15")).isNone()).toBe(true);
       });
     });
 
     describe("fixed weekly", () => {
-      it("returns a year-2020 anchor for a date the week-year considers 2020", () => {
-        const c = buildContainer({ weekly: fixedJournal("weekly", { type: "week" }) });
-        const cycle = c.resolve(CycleService);
+      it("returns a year-2020 anchor for a date the week-year considers 2020", async () => {
+        const { resolve } = await testContainer({
+          modules: [journalsCoreModule],
+          data: { journals: { weekly: fixedJournal("weekly", { type: "week" }) } },
+        });
+
         // Week containing Wed 2020-12-30 starts Mon 2020-12-28, ends Sun 2021-01-03.
         // With dow=1, the anchor is the week's first day = Mon 2020-12-28.
-        const result = cycle.anchorOf("weekly", unwrapResult(CalendarDate.parse("2020-12-30")));
+        const result = resolve(CycleService).anchorOf("weekly", date("2020-12-30"));
+
         expect(result.isSome() && result.value).toBe("2020-12-28");
       });
 
-      it("returns a year-2021 anchor for a date the week-year considers 2021", () => {
-        const c = buildContainer({ weekly: fixedJournal("weekly", { type: "week" }) });
-        const cycle = c.resolve(CycleService);
+      it("returns a year-2021 anchor for a date the week-year considers 2021", async () => {
+        const { resolve } = await testContainer({
+          modules: [journalsCoreModule],
+          data: { journals: { weekly: fixedJournal("weekly", { type: "week" }) } },
+        });
+
         // Week containing Thu 2021-01-07 starts Mon 2021-01-04, ends Sun 2021-01-10.
         // With dow=1, the anchor is the week's first day = Mon 2021-01-04. A mid-week input
         // keeps this distinct from an identity function.
-        const result = cycle.anchorOf("weekly", unwrapResult(CalendarDate.parse("2021-01-07")));
+        const result = resolve(CycleService).anchorOf("weekly", date("2021-01-07"));
+
         expect(result.isSome() && result.value).toBe("2021-01-04");
       });
     });
 
     describe("custom monthly", () => {
-      it("lands on the configured anchor for dates inside the first step", () => {
-        const c = buildContainer({ s: customJournal("s", "month", 1, "2024-01-15") });
-        const cycle = c.resolve(CycleService);
-        const result = cycle.anchorOf("s", unwrapResult(CalendarDate.parse("2024-01-20")));
+      it("lands on the configured anchor for dates inside the first step", async () => {
+        const { resolve } = await testContainer({
+          modules: [journalsCoreModule],
+          data: { journals: { s: customJournal("s", "month", 1, "2024-01-15") } },
+        });
+
+        const result = resolve(CycleService).anchorOf("s", date("2024-01-20"));
+
         expect(result.isSome() && result.value).toBe("2024-01-15");
       });
 
-      it("steps forward to the next anchor for a date past the first interval end", () => {
-        const c = buildContainer({ s: customJournal("s", "month", 1, "2024-01-15") });
-        const cycle = c.resolve(CycleService);
-        const result = cycle.anchorOf("s", unwrapResult(CalendarDate.parse("2024-02-20")));
+      it("steps forward to the next anchor for a date past the first interval end", async () => {
+        const { resolve } = await testContainer({
+          modules: [journalsCoreModule],
+          data: { journals: { s: customJournal("s", "month", 1, "2024-01-15") } },
+        });
+
+        const result = resolve(CycleService).anchorOf("s", date("2024-02-20"));
+
         expect(result.isSome() && result.value).toBe("2024-02-15");
       });
 
-      it("clamps a day-30 anchor to the last day of a shorter month", () => {
+      it("clamps a day-30 anchor to the last day of a shorter month", async () => {
+        const { resolve } = await testContainer({
+          modules: [journalsCoreModule],
+          data: { journals: { s: customJournal("s", "month", 1, "2024-01-30") } },
+        });
+
         // Feb 2024 has 29 days, so the 30th clamps to the 29th; 2024-02-28 still belongs to the
         // preceding interval [2024-01-30, 2024-02-28].
-        const c = buildContainer({ s: customJournal("s", "month", 1, "2024-01-30") });
-        const cycle = c.resolve(CycleService);
-        const result = cycle.anchorOf("s", unwrapResult(CalendarDate.parse("2024-02-28")));
+        const result = resolve(CycleService).anchorOf("s", date("2024-02-28"));
+
         expect(result.isSome() && result.value).toBe("2024-01-30");
       });
 
-      it("keeps a month-end anchor on month ends across a short month", () => {
+      it("keeps a month-end anchor on month ends across a short month", async () => {
+        const { resolve } = await testContainer({
+          modules: [journalsCoreModule],
+          data: { journals: { s: customJournal("s", "month", 1, "2025-01-31") } },
+        });
+
         // The grid from 2025-01-31 is 01-31, 02-28, 03-31, 04-30, 05-31 — 2025-05-15 falls inside
         // the interval opened on 2025-04-30.
-        const c = buildContainer({ s: customJournal("s", "month", 1, "2025-01-31") });
-        const cycle = c.resolve(CycleService);
-        const result = cycle.anchorOf("s", unwrapResult(CalendarDate.parse("2025-05-15")));
+        const result = resolve(CycleService).anchorOf("s", date("2025-05-15"));
+
         expect(result.isSome() && result.value).toBe("2025-04-30");
       });
     });
   });
 
   describe("representativeOf", () => {
-    it("returns the week's representative day for a weekly journal", () => {
-      const c = buildContainer({ weekly: fixedJournal("weekly", { type: "week" }) });
+    it("returns the week's representative day for a weekly journal", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { weekly: fixedJournal("weekly", { type: "week" }) } },
+      });
 
-      const result = c.resolve(CycleService).representativeOf("weekly", "2025-03-10" as AnchorString);
+      const result = resolve(CycleService).representativeOf("weekly", "2025-03-10" as AnchorString);
 
       expect(unwrap(result).toAnchor()).toBe("2025-03-13");
     });
 
-    it("returns the anchor itself for a monthly journal", () => {
-      const c = buildContainer({ monthly: fixedJournal("monthly", { type: "month" }) });
+    it("returns the anchor itself for a monthly journal", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { monthly: fixedJournal("monthly", { type: "month" }) } },
+      });
 
-      const result = c.resolve(CycleService).representativeOf("monthly", "2025-03-01" as AnchorString);
+      const result = resolve(CycleService).representativeOf("monthly", "2025-03-01" as AnchorString);
 
       expect(unwrap(result).toAnchor()).toBe("2025-03-01");
     });
 
-    it("returns the interval start for a custom journal", () => {
-      const c = buildContainer({ sprints: customJournal("sprints", "week", 2, "2024-01-01") });
+    it("returns the interval start for a custom journal", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { sprints: customJournal("sprints", "week", 2, "2024-01-01") } },
+      });
 
-      const result = c.resolve(CycleService).representativeOf("sprints", "2024-01-01" as AnchorString);
+      const result = resolve(CycleService).representativeOf("sprints", "2024-01-01" as AnchorString);
 
       expect(unwrap(result).toAnchor()).toBe("2024-01-01");
     });
 
-    it("returns none for an unknown journal", () => {
-      const c = buildContainer({});
+    it("returns none for an unknown journal", async () => {
+      const { resolve } = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
 
-      expect(
-        c
-          .resolve(CycleService)
-          .representativeOf("missing", "2025-03-10" as AnchorString)
-          .isNone(),
-      ).toBe(true);
+      const result = resolve(CycleService).representativeOf("missing", "2025-03-10" as AnchorString);
+
+      expect(result.isNone()).toBe(true);
     });
   });
 
   describe("nextAnchor", () => {
-    it("advances to the following week anchor for fixed weekly", () => {
-      const c = buildContainer({ w: fixedJournal("w", { type: "week" }) });
-      const cycle = c.resolve(CycleService);
-      const next = cycle.nextAnchor("w", "2024-03-04" as AnchorString);
-      const result = next.isSome() && next.value;
+    it("advances to the following week anchor for fixed weekly", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { w: fixedJournal("w", { type: "week" }) } },
+      });
+
       // With the test calendar (dow=1), the anchor of a week is its first day (Monday).
       // next() of the week containing 2024-03-04 (Mon): next week = Mon 2024-03-11.
-      expect(result).toBe("2024-03-11");
+      const next = resolve(CycleService).nextAnchor("w", "2024-03-04" as AnchorString);
+
+      expect(next.isSome() && next.value).toBe("2024-03-11");
     });
 
-    it("returns next anchor for custom monthly", () => {
-      const c = buildContainer({ s: customJournal("s", "month", 1, "2024-01-15") });
-      const cycle = c.resolve(CycleService);
-      const next = cycle.nextAnchor("s", "2024-01-15" as AnchorString);
+    it("returns next anchor for custom monthly", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { s: customJournal("s", "month", 1, "2024-01-15") } },
+      });
+
+      const next = resolve(CycleService).nextAnchor("s", "2024-01-15" as AnchorString);
+
       expect(next.isSome() && next.value).toBe("2024-02-15");
     });
 
-    it("returns None for an unknown journal", () => {
-      const c = buildContainer({});
-      const cycle = c.resolve(CycleService);
-      expect(cycle.nextAnchor("missing", "2024-01-01" as AnchorString).isNone()).toBe(true);
+    it("returns None for an unknown journal", async () => {
+      const { resolve } = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
+
+      expect(
+        resolve(CycleService)
+          .nextAnchor("missing", "2024-01-01" as AnchorString)
+          .isNone(),
+      ).toBe(true);
     });
 
     describe("custom monthly anchored to a month end", () => {
-      it("clamps to the last day of a month too short for the configured day", () => {
-        const c = buildContainer({ s: customJournal("s", "month", 1, "2025-01-31") });
-        const cycle = c.resolve(CycleService);
-        const next = cycle.nextAnchor("s", "2025-01-31" as AnchorString);
+      it("clamps to the last day of a month too short for the configured day", async () => {
+        const { resolve } = await testContainer({
+          modules: [journalsCoreModule],
+          data: { journals: { s: customJournal("s", "month", 1, "2025-01-31") } },
+        });
+
+        const next = resolve(CycleService).nextAnchor("s", "2025-01-31" as AnchorString);
+
         expect(next.isSome() && next.value).toBe("2025-02-28");
       });
 
-      it("returns to the month end after passing through a short month", () => {
-        const c = buildContainer({ s: customJournal("s", "month", 1, "2025-01-31") });
-        const cycle = c.resolve(CycleService);
-        const next = cycle.nextAnchor("s", "2025-02-28" as AnchorString);
+      it("returns to the month end after passing through a short month", async () => {
+        const { resolve } = await testContainer({
+          modules: [journalsCoreModule],
+          data: { journals: { s: customJournal("s", "month", 1, "2025-01-31") } },
+        });
+
+        const next = resolve(CycleService).nextAnchor("s", "2025-02-28" as AnchorString);
+
         expect(next.isSome() && next.value).toBe("2025-03-31");
       });
 
-      it("resumes the configured phase from an anchor left off-grid by an extension", () => {
-        const c = buildContainer({ s: customJournal("s", "month", 1, "2025-01-31") });
-        const index = c.resolve(JournalsIndex);
-        index.register({
+      it("resumes the configured phase from an anchor left off-grid by an extension", async () => {
+        const { resolve } = await testContainer({
+          modules: [journalsCoreModule],
+          data: { journals: { s: customJournal("s", "month", 1, "2025-01-31") } },
+        });
+        resolve(JournalsIndex).register({
           journalName: "s",
           anchor: "2025-02-28" as AnchorString,
           path: "S/feb.md" as VaultPath,
           endDate: "2025-03-04" as AnchorString, // extended past its computed end of 2025-03-30
         });
-        const cycle = c.resolve(CycleService);
-        const next = cycle.nextAnchor("s", "2025-03-05" as AnchorString);
+
+        const next = resolve(CycleService).nextAnchor("s", "2025-03-05" as AnchorString);
+
         expect(next.isSome() && next.value).toBe("2025-04-30");
       });
     });
 
     describe("custom monthly anchored mid-month", () => {
-      it("restores the configured day in the month after a clamped one", () => {
-        const c = buildContainer({ s: customJournal("s", "month", 1, "2024-01-30") });
-        const cycle = c.resolve(CycleService);
-        const next = cycle.nextAnchor("s", "2024-02-29" as AnchorString);
+      it("restores the configured day in the month after a clamped one", async () => {
+        const { resolve } = await testContainer({
+          modules: [journalsCoreModule],
+          data: { journals: { s: customJournal("s", "month", 1, "2024-01-30") } },
+        });
+
+        const next = resolve(CycleService).nextAnchor("s", "2024-02-29" as AnchorString);
+
         expect(next.isSome() && next.value).toBe("2024-03-30");
       });
     });
 
     describe("custom quarterly anchored to a month end", () => {
-      it("returns to the month end after a quarter landing on a 30-day month", () => {
-        const c = buildContainer({ s: customJournal("s", "quarter", 1, "2025-01-31") });
-        const cycle = c.resolve(CycleService);
-        const next = cycle.nextAnchor("s", "2025-04-30" as AnchorString);
+      it("returns to the month end after a quarter landing on a 30-day month", async () => {
+        const { resolve } = await testContainer({
+          modules: [journalsCoreModule],
+          data: { journals: { s: customJournal("s", "quarter", 1, "2025-01-31") } },
+        });
+
+        const next = resolve(CycleService).nextAnchor("s", "2025-04-30" as AnchorString);
+
         expect(next.isSome() && next.value).toBe("2025-07-31");
       });
     });
 
     describe("custom yearly anchored to a leap day", () => {
-      it("returns to the leap day in a year that has one", () => {
-        const c = buildContainer({ s: customJournal("s", "year", 1, "2024-02-29") });
-        const cycle = c.resolve(CycleService);
-        const next = cycle.nextAnchor("s", "2027-02-28" as AnchorString);
+      it("returns to the leap day in a year that has one", async () => {
+        const { resolve } = await testContainer({
+          modules: [journalsCoreModule],
+          data: { journals: { s: customJournal("s", "year", 1, "2024-02-29") } },
+        });
+
+        const next = resolve(CycleService).nextAnchor("s", "2027-02-28" as AnchorString);
+
         expect(next.isSome() && next.value).toBe("2028-02-29");
       });
     });
   });
 
   describe("previousAnchor", () => {
-    it("retreats to the prior week anchor for fixed weekly", () => {
-      const c = buildContainer({ w: fixedJournal("w", { type: "week" }) });
-      const cycle = c.resolve(CycleService);
-      const previous = cycle.previousAnchor("w", "2024-03-04" as AnchorString);
+    it("retreats to the prior week anchor for fixed weekly", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { w: fixedJournal("w", { type: "week" }) } },
+      });
+
       // With the test calendar (dow=1), 2024-03-04 is the anchor of the week Mon 2024-03-04 –
       // Sun 2024-03-10; the prior week's anchor is its first day = Mon 2024-02-26.
+      const previous = resolve(CycleService).previousAnchor("w", "2024-03-04" as AnchorString);
+
       expect(previous.isSome() && previous.value).toBe("2024-02-26");
     });
 
-    it("returns previous anchor for custom monthly", () => {
-      const c = buildContainer({ s: customJournal("s", "month", 1, "2024-01-15") });
-      const cycle = c.resolve(CycleService);
-      const previous = cycle.previousAnchor("s", "2024-02-15" as AnchorString);
+    it("returns previous anchor for custom monthly", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { s: customJournal("s", "month", 1, "2024-01-15") } },
+      });
+
+      const previous = resolve(CycleService).previousAnchor("s", "2024-02-15" as AnchorString);
+
       expect(previous.isSome() && previous.value).toBe("2024-01-15");
     });
 
-    it("steps a month-end anchor back onto the previous month's last day", () => {
-      const c = buildContainer({ s: customJournal("s", "month", 1, "2025-01-31") });
-      const cycle = c.resolve(CycleService);
-      const previous = cycle.previousAnchor("s", "2025-03-31" as AnchorString);
+    it("steps a month-end anchor back onto the previous month's last day", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { s: customJournal("s", "month", 1, "2025-01-31") } },
+      });
+
+      const previous = resolve(CycleService).previousAnchor("s", "2025-03-31" as AnchorString);
+
       expect(previous.isSome() && previous.value).toBe("2025-02-28");
     });
 
-    it("steps a quarterly month-end anchor back onto the previous quarter's last day", () => {
-      const c = buildContainer({ s: customJournal("s", "quarter", 1, "2025-01-31") });
-      const cycle = c.resolve(CycleService);
-      const previous = cycle.previousAnchor("s", "2025-04-30" as AnchorString);
+    it("steps a quarterly month-end anchor back onto the previous quarter's last day", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { s: customJournal("s", "quarter", 1, "2025-01-31") } },
+      });
+
+      const previous = resolve(CycleService).previousAnchor("s", "2025-04-30" as AnchorString);
+
       expect(previous.isSome() && previous.value).toBe("2025-01-31");
     });
   });
 
   describe("startOf and endOf", () => {
-    it("returns the anchor's period start/end for fixed weekly", () => {
-      const c = buildContainer({ w: fixedJournal("w", { type: "week" }) });
-      const cycle = c.resolve(CycleService);
-      const anchor = unwrap(cycle.anchorOf("w", unwrapResult(CalendarDate.parse("2024-03-06"))));
-      // Adjust expected start/end to match the test calendar's dow=1 doy=4 — week containing
-      // 2024-03-06 (Wednesday) starts Mon 2024-03-04 and ends Sun 2024-03-10.
+    it("returns the anchor's period start/end for fixed weekly", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { w: fixedJournal("w", { type: "week" }) } },
+      });
+      const cycle = resolve(CycleService);
+      const anchor = unwrap(cycle.anchorOf("w", date("2024-03-06")));
+
+      // The test calendar's dow=1 doy=4 puts the week containing 2024-03-06 (Wednesday) at
+      // Mon 2024-03-04 through Sun 2024-03-10.
       const start = cycle.startOf("w", anchor);
       const end = cycle.endOf("w", anchor);
+
       expect(start.isSome() && start.value.toAnchor()).toBe("2024-03-04");
       expect(end.isSome() && end.value.toAnchor()).toBe("2024-03-10");
     });
 
-    it("returns the anchor and computed end for custom monthly", () => {
-      const c = buildContainer({ s: customJournal("s", "month", 1, "2024-01-15") });
-      const cycle = c.resolve(CycleService);
+    it("returns the configured anchor's interval bounds for custom monthly", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { s: customJournal("s", "month", 1, "2024-01-15") } },
+      });
+      const cycle = resolve(CycleService);
+
       const start = cycle.startOf("s", "2024-01-15" as AnchorString);
       const end = cycle.endOf("s", "2024-01-15" as AnchorString);
+
       expect(start.isSome() && start.value.toAnchor()).toBe("2024-01-15");
-      expect(end.isSome() && end.value.toAnchor()).toBe("2024-02-14"); // Feb 15 - 1 day
+      expect(end.isSome() && end.value.toAnchor()).toBe("2024-02-14"); // the day before the next anchor
     });
 
-    it("returns the stored endDate for custom anchor with extension", () => {
-      const c = buildContainer({ s: customJournal("s", "week", 1, "2024-01-01") });
-      const index = c.resolve(JournalsIndex);
-      index.register({
+    it("returns the stored endDate for custom anchor with extension", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { s: customJournal("s", "week", 1, "2024-01-01") } },
+      });
+      resolve(JournalsIndex).register({
         journalName: "s",
         anchor: "2024-01-01" as AnchorString,
         path: "S/1.md" as VaultPath,
         endDate: "2024-01-14" as AnchorString,
       });
-      const cycle = c.resolve(CycleService);
-      const end = cycle.endOf("s", "2024-01-01" as AnchorString);
+
+      const end = resolve(CycleService).endOf("s", "2024-01-01" as AnchorString);
+
       expect(end.isSome() && end.value.toAnchor()).toBe("2024-01-14");
     });
 
-    it("returns None for unknown journal", () => {
-      const c = buildContainer({});
-      const cycle = c.resolve(CycleService);
+    it("returns None for unknown journal", async () => {
+      const { resolve } = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
+      const cycle = resolve(CycleService);
+
       expect(cycle.startOf("missing", "2024-01-01" as AnchorString).isNone()).toBe(true);
       expect(cycle.endOf("missing", "2024-01-01" as AnchorString).isNone()).toBe(true);
     });
   });
 
   describe("custom variant extension awareness", () => {
-    it("nextAnchor after an extended interval starts at endDate + 1 day", () => {
-      const c = buildContainer({ s: customJournal("s", "week", 1, "2024-01-01") });
-      const index = c.resolve(JournalsIndex);
-      index.register({
+    it("nextAnchor after an extended interval starts at endDate + 1 day", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { s: customJournal("s", "week", 1, "2024-01-01") } },
+      });
+      resolve(JournalsIndex).register({
         journalName: "s",
         anchor: "2024-01-01" as AnchorString,
         path: "S/1.md" as VaultPath,
         endDate: "2024-01-14" as AnchorString, // extended through Jan 14 instead of Jan 7
       });
-      const cycle = c.resolve(CycleService);
-      const next = cycle.nextAnchor("s", "2024-01-01" as AnchorString);
+
+      const next = resolve(CycleService).nextAnchor("s", "2024-01-01" as AnchorString);
+
       expect(next.isSome() && next.value).toBe("2024-01-15");
     });
 
-    it("anchorOf maps a date inside an extended interval to that interval's anchor", () => {
-      const c = buildContainer({ s: customJournal("s", "week", 1, "2024-01-01") });
-      const index = c.resolve(JournalsIndex);
-      index.register({
+    it("anchorOf maps a date inside an extended interval to that interval's anchor", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { s: customJournal("s", "week", 1, "2024-01-01") } },
+      });
+      resolve(JournalsIndex).register({
         journalName: "s",
         anchor: "2024-01-01" as AnchorString,
         path: "S/1.md" as VaultPath,
         endDate: "2024-01-14" as AnchorString, // extended through Jan 14 instead of Jan 7
       });
-      const cycle = c.resolve(CycleService);
+
       // 2024-01-10 lies in the extended first interval [2024-01-01, 2024-01-14], not a
       // phantom computed week starting 2024-01-08.
-      const anchor = cycle.anchorOf("s", unwrapResult(CalendarDate.parse("2024-01-10")));
+      const anchor = resolve(CycleService).anchorOf("s", date("2024-01-10"));
+
       expect(anchor.isSome() && anchor.value).toBe("2024-01-01");
     });
 
-    it("anchorOf steps past an extended interval to the next computed anchor", () => {
-      const c = buildContainer({ s: customJournal("s", "week", 1, "2024-01-01") });
-      const index = c.resolve(JournalsIndex);
-      index.register({
+    it("anchorOf steps past an extended interval to the next computed anchor", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { s: customJournal("s", "week", 1, "2024-01-01") } },
+      });
+      resolve(JournalsIndex).register({
         journalName: "s",
         anchor: "2024-01-01" as AnchorString,
         path: "S/1.md" as VaultPath,
         endDate: "2024-01-14" as AnchorString,
       });
-      const cycle = c.resolve(CycleService);
+
       // The interval after the extension starts 2024-01-15; 2024-01-20 falls inside it.
-      const anchor = cycle.anchorOf("s", unwrapResult(CalendarDate.parse("2024-01-20")));
+      const anchor = resolve(CycleService).anchorOf("s", date("2024-01-20"));
+
       expect(anchor.isSome() && anchor.value).toBe("2024-01-15");
     });
 
-    it("anchorOf maps a date inside an extended interval that precedes the configured anchor", () => {
-      const c = buildContainer({ s: customJournal("s", "week", 1, "2024-01-15") });
-      const index = c.resolve(JournalsIndex);
-      index.register({
+    it("anchorOf maps a date inside an extended interval that precedes the configured anchor", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { s: customJournal("s", "week", 1, "2024-01-15") } },
+      });
+      resolve(JournalsIndex).register({
         journalName: "s",
         anchor: "2023-12-18" as AnchorString,
         path: "S/prev.md" as VaultPath,
         endDate: "2024-01-14" as AnchorString, // extended right up to the day before the anchor
       });
-      const cycle = c.resolve(CycleService);
+
       // 2024-01-05 lies in the stored interval [2023-12-18, 2024-01-14], reached by walking
       // backward from the configured anchor 2024-01-15.
-      const anchor = cycle.anchorOf("s", unwrapResult(CalendarDate.parse("2024-01-05")));
+      const anchor = resolve(CycleService).anchorOf("s", date("2024-01-05"));
+
       expect(anchor.isSome() && anchor.value).toBe("2023-12-18");
     });
   });
 
   describe("offsets", () => {
-    it("returns +day-from-start, -day-to-end for a date inside a weekly anchor", () => {
-      const c = buildContainer({ w: fixedJournal("w", { type: "week" }) });
-      const cycle = c.resolve(CycleService);
+    it("returns +day-from-start, -day-to-end for a date inside a weekly anchor", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { w: fixedJournal("w", { type: "week" }) } },
+      });
+
       // 2024-03-06 (Wed) of the Mon 2024-03-04 — Sun 2024-03-10 week.
       // From start Mon: day 3 (Mon=1, Tue=2, Wed=3). To end Sun: -5 (Wed is 4 days before Sun,
       // negated and decremented by 1 so offsets are 1-based from both ends, never 0).
-      const off = cycle.offsets("w", unwrapResult(CalendarDate.parse("2024-03-06")));
+      const off = resolve(CycleService).offsets("w", date("2024-03-06"));
+
       expect(off.isSome() && off.value).toEqual([3, -5]);
     });
 
-    it("returns None for unknown journal", () => {
-      const c = buildContainer({});
-      const cycle = c.resolve(CycleService);
-      expect(cycle.offsets("missing", unwrapResult(CalendarDate.parse("2024-01-01"))).isNone()).toBe(true);
+    it("returns None for unknown journal", async () => {
+      const { resolve } = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
+
+      expect(resolve(CycleService).offsets("missing", date("2024-01-01")).isNone()).toBe(true);
     });
   });
 
   describe("intervalsInRange", () => {
-    it("projects every scheduled interval overlapping the range when no notes exist", () => {
-      const c = buildContainer({ s: customJournal("s", "week", 1, "2024-01-01") });
-      const cycle = c.resolve(CycleService);
-      const result = cycle.intervalsInRange("s", "2024-01-05" as AnchorString, "2024-01-20" as AnchorString);
+    it("projects every scheduled interval overlapping the range when no notes exist", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { s: customJournal("s", "week", 1, "2024-01-01") } },
+      });
+
+      const result = resolve(CycleService).intervalsInRange(
+        "s",
+        "2024-01-05" as AnchorString,
+        "2024-01-20" as AnchorString,
+      );
+
       expect([...result]).toEqual(["2024-01-01", "2024-01-08", "2024-01-15"]);
     });
   });
 
   describe("countRepeats", () => {
-    it("counts intervals between two anchors for fixed weekly", () => {
-      const c = buildContainer({ w: fixedJournal("w", { type: "week" }) });
-      const cycle = c.resolve(CycleService);
+    it("counts intervals between two anchors for fixed weekly", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { w: fixedJournal("w", { type: "week" }) } },
+      });
+
       // 2024-01-01 (Mon) and 2024-01-22 (Mon) are 3 weeks apart.
-      const result = cycle.countRepeats("w", "2024-01-01" as AnchorString, "2024-01-22" as AnchorString);
+      const result = resolve(CycleService).countRepeats(
+        "w",
+        "2024-01-01" as AnchorString,
+        "2024-01-22" as AnchorString,
+      );
+
       expect(result.isSome() && result.value).toBe(3);
     });
 
-    it("returns None when the from anchor does not parse", () => {
-      const c = buildContainer({ w: fixedJournal("w", { type: "week" }) });
-      const cycle = c.resolve(CycleService);
-      expect(cycle.countRepeats("w", "" as AnchorString, "2024-01-22" as AnchorString).isNone()).toBe(true);
+    it("returns None when the from anchor does not parse", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { w: fixedJournal("w", { type: "week" }) } },
+      });
+
+      const result = resolve(CycleService).countRepeats("w", "" as AnchorString, "2024-01-22" as AnchorString);
+
+      expect(result.isNone()).toBe(true);
     });
 
-    it("returns None when the to anchor does not parse", () => {
-      const c = buildContainer({ w: fixedJournal("w", { type: "week" }) });
-      const cycle = c.resolve(CycleService);
-      expect(cycle.countRepeats("w", "2024-01-01" as AnchorString, "nonsense" as AnchorString).isNone()).toBe(true);
+    it("returns None when the to anchor does not parse", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { w: fixedJournal("w", { type: "week" }) } },
+      });
+
+      const result = resolve(CycleService).countRepeats("w", "2024-01-01" as AnchorString, "nonsense" as AnchorString);
+
+      expect(result.isNone()).toBe(true);
     });
 
-    it("counts whole weeks from a mid-week start date", () => {
-      const c = buildContainer({ w: fixedJournal("w", { type: "week" }) });
-      const cycle = c.resolve(CycleService);
+    it("counts whole weeks from a mid-week start date", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { w: fixedJournal("w", { type: "week" }) } },
+      });
+
       // Wed 2024-01-03 sits in the week anchored Mon 2024-01-01; the week anchored
       // 2024-01-15 is two weeks on, however far into its week the start date falls.
-      const result = cycle.countRepeats("w", "2024-01-03" as AnchorString, "2024-01-15" as AnchorString);
+      const result = resolve(CycleService).countRepeats(
+        "w",
+        "2024-01-03" as AnchorString,
+        "2024-01-15" as AnchorString,
+      );
+
       expect(result.isSome() && result.value).toBe(2);
     });
 
-    it("counts whole months from a mid-month start date", () => {
-      const c = buildContainer({ m: fixedJournal("m", { type: "month" }) });
-      const cycle = c.resolve(CycleService);
-      const result = cycle.countRepeats("m", "2024-06-15" as AnchorString, "2024-08-01" as AnchorString);
+    it("counts whole months from a mid-month start date", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { m: fixedJournal("m", { type: "month" }) } },
+      });
+
+      const result = resolve(CycleService).countRepeats(
+        "m",
+        "2024-06-15" as AnchorString,
+        "2024-08-01" as AnchorString,
+      );
+
       expect(result.isSome() && result.value).toBe(2);
     });
 
-    it("returns equal magnitude regardless of direction", () => {
-      const c = buildContainer({ w: fixedJournal("w", { type: "week" }) });
-      const cycle = c.resolve(CycleService);
+    it("returns equal magnitude regardless of direction", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { w: fixedJournal("w", { type: "week" }) } },
+      });
+      const cycle = resolve(CycleService);
+
       const forward = unwrap(cycle.countRepeats("w", "2024-01-01" as AnchorString, "2024-01-22" as AnchorString));
       const backward = unwrap(cycle.countRepeats("w", "2024-01-22" as AnchorString, "2024-01-01" as AnchorString));
+
       expect(Math.abs(forward)).toBe(Math.abs(backward));
     });
 
-    it("counts whole intervals from an off-anchor start for a custom cycle", () => {
+    it("counts whole intervals from an off-anchor start for a custom cycle", async () => {
       // Cycle anchored 2026-06-01, stepping every 7 days: 06-01, 06-08, 06-15, 06-22, ...
       // A `from` of 2026-06-03 sits mid-interval; it must snap to 2026-06-01 before counting,
       // so the walk to 2026-06-22 crosses exactly 3 interval boundaries, not 2.
-      const c = buildContainer({ s: customJournal("s", "day", 7, "2026-06-01") });
-      const cycle = c.resolve(CycleService);
-      const result = cycle.countRepeats("s", "2026-06-03" as AnchorString, "2026-06-22" as AnchorString);
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { s: customJournal("s", "day", 7, "2026-06-01") } },
+      });
+
+      const result = resolve(CycleService).countRepeats(
+        "s",
+        "2026-06-03" as AnchorString,
+        "2026-06-22" as AnchorString,
+      );
+
       expect(result.isSome() && result.value).toBe(3);
     });
 
     describe("custom interval extended past its default end", () => {
-      it("counts the same number of intervals as stepping through nextAnchor", () => {
+      it("counts the same number of intervals as stepping through nextAnchor", async () => {
         // The first interval is extended a full week past its default end of 01-07, so the
         // index-aware grid is 01-01, 01-15, 01-22, 01-29, 02-05 — 4 steps, not the 5 a raw
         // 7-day stepping (ignoring the extension) would produce.
-        const c = buildContainer({ s: customJournal("s", "week", 1, "2024-01-01") });
-        const index = c.resolve(JournalsIndex);
-        index.register({
+        const { resolve } = await testContainer({
+          modules: [journalsCoreModule],
+          data: { journals: { s: customJournal("s", "week", 1, "2024-01-01") } },
+        });
+        resolve(JournalsIndex).register({
           journalName: "s",
           anchor: "2024-01-01" as AnchorString,
           path: "S/1.md" as VaultPath,
           endDate: "2024-01-14" as AnchorString,
         });
-        const cycle = c.resolve(CycleService);
+        const cycle = resolve(CycleService);
         const to = "2024-02-05" as AnchorString;
+
         let current = "2024-01-01" as AnchorString;
         let steps = 0;
         // Capped so a stalled nextAnchor fails the test below rather than hanging the run.
@@ -471,26 +618,30 @@ describe("CycleService", () => {
           current = unwrap(cycle.nextAnchor("s", current));
           steps++;
         }
+
         expect(current).toBe(to);
         expect(steps).toBe(4);
         const result = cycle.countRepeats("s", "2024-01-01" as AnchorString, to);
         expect(result.isSome() && result.value).toBe(steps);
       });
 
-      it("counts the same number of intervals as stepping through previousAnchor", () => {
+      it("counts the same number of intervals as stepping through previousAnchor", async () => {
         // Mirror of the forward case: stepping backward from 2024-02-05 through the
         // index-aware grid is 02-05, 01-29, 01-22, 01-15, 01-01 — 4 steps, not the 5 a raw
         // 7-day stepping (ignoring the extension) would produce.
-        const c = buildContainer({ s: customJournal("s", "week", 1, "2024-01-01") });
-        const index = c.resolve(JournalsIndex);
-        index.register({
+        const { resolve } = await testContainer({
+          modules: [journalsCoreModule],
+          data: { journals: { s: customJournal("s", "week", 1, "2024-01-01") } },
+        });
+        resolve(JournalsIndex).register({
           journalName: "s",
           anchor: "2024-01-01" as AnchorString,
           path: "S/1.md" as VaultPath,
           endDate: "2024-01-14" as AnchorString,
         });
-        const cycle = c.resolve(CycleService);
+        const cycle = resolve(CycleService);
         const to = "2024-01-01" as AnchorString;
+
         let current = "2024-02-05" as AnchorString;
         let steps = 0;
         // Capped so a stalled previousAnchor fails the test below rather than hanging the run.
@@ -499,6 +650,7 @@ describe("CycleService", () => {
           current = unwrap(cycle.previousAnchor("s", current));
           steps++;
         }
+
         expect(current).toBe(to);
         expect(steps).toBe(4);
         const result = cycle.countRepeats("s", "2024-02-05" as AnchorString, to);
@@ -508,102 +660,154 @@ describe("CycleService", () => {
   });
 
   describe("anchorAtOffset", () => {
-    it("advances a custom anchor forward by the given number of intervals", () => {
-      const c = buildContainer({ s: customJournal("s", "week", 1, "2024-01-01") });
-      const cycle = c.resolve(CycleService);
-      const result = cycle.anchorAtOffset("s", "2024-01-01" as AnchorString, 3);
+    it("advances a custom anchor forward by the given number of intervals", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { s: customJournal("s", "week", 1, "2024-01-01") } },
+      });
+
+      const result = resolve(CycleService).anchorAtOffset("s", "2024-01-01" as AnchorString, 3);
+
       expect(result.isSome() && result.value).toBe("2024-01-22");
     });
 
-    it("steps a custom anchor backward for a negative offset", () => {
-      const c = buildContainer({ s: customJournal("s", "week", 1, "2024-01-01") });
-      const cycle = c.resolve(CycleService);
-      const result = cycle.anchorAtOffset("s", "2024-01-22" as AnchorString, -3);
+    it("steps a custom anchor backward for a negative offset", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { s: customJournal("s", "week", 1, "2024-01-01") } },
+      });
+
+      const result = resolve(CycleService).anchorAtOffset("s", "2024-01-22" as AnchorString, -3);
+
       expect(result.isSome() && result.value).toBe("2024-01-01");
     });
 
-    it("returns the same anchor for a zero offset", () => {
-      const c = buildContainer({ s: customJournal("s", "week", 1, "2024-01-01") });
-      const cycle = c.resolve(CycleService);
-      const result = cycle.anchorAtOffset("s", "2024-01-08" as AnchorString, 0);
+    it("returns the same anchor for a zero offset", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { s: customJournal("s", "week", 1, "2024-01-01") } },
+      });
+
+      const result = resolve(CycleService).anchorAtOffset("s", "2024-01-08" as AnchorString, 0);
+
       expect(result.isSome() && result.value).toBe("2024-01-08");
     });
 
-    it("inverts countRepeats for a fixed cycle", () => {
-      const c = buildContainer({ d: fixedJournal("d", { type: "day" }) });
-      const cycle = c.resolve(CycleService);
-      const result = cycle.anchorAtOffset("d", "2024-01-01" as AnchorString, 3);
+    it("inverts countRepeats for a fixed cycle", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { d: fixedJournal("d", { type: "day" }) } },
+      });
+
+      const result = resolve(CycleService).anchorAtOffset("d", "2024-01-01" as AnchorString, 3);
+
       expect(result.isSome() && result.value).toBe("2024-01-04");
     });
 
-    it("keeps a month-end anchor's phase across many intervals", () => {
-      const c = buildContainer({ s: customJournal("s", "month", 2, "2024-01-31") });
-      const cycle = c.resolve(CycleService);
-      const result = cycle.anchorAtOffset("s", "2024-01-31" as AnchorString, 7);
+    it("keeps a month-end anchor's phase across many intervals", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { s: customJournal("s", "month", 2, "2024-01-31") } },
+      });
+
+      const result = resolve(CycleService).anchorAtOffset("s", "2024-01-31" as AnchorString, 7);
+
       expect(result.isSome() && result.value).toBe("2025-03-31");
     });
 
-    it("returns an off-grid custom anchor unchanged for a zero offset", () => {
-      const c = buildContainer({ s: customJournal("s", "month", 2, "2024-01-31") });
-      const cycle = c.resolve(CycleService);
-      const result = cycle.anchorAtOffset("s", "2024-01-01" as AnchorString, 0);
+    it("returns an off-grid custom anchor unchanged for a zero offset", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { s: customJournal("s", "month", 2, "2024-01-31") } },
+      });
+
+      const result = resolve(CycleService).anchorAtOffset("s", "2024-01-01" as AnchorString, 0);
+
       expect(result.isSome() && result.value).toBe("2024-01-01");
     });
 
-    it("snaps an off-grid start onto the fixed cycle before stepping", () => {
-      const c = buildContainer({ q: fixedJournal("q", { type: "quarter" }) });
-      const cycle = c.resolve(CycleService);
-      const result = cycle.anchorAtOffset("q", "2024-02-15" as AnchorString, 5);
+    it("snaps an off-grid start onto the fixed cycle before stepping", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { q: fixedJournal("q", { type: "quarter" }) } },
+      });
+
+      const result = resolve(CycleService).anchorAtOffset("q", "2024-02-15" as AnchorString, 5);
+
       expect(result.isSome() && result.value).toBe("2025-04-01");
     });
 
-    it("returns None for an unknown journal", () => {
-      const c = buildContainer({});
-      const cycle = c.resolve(CycleService);
-      expect(cycle.anchorAtOffset("missing", "2024-01-01" as AnchorString, 2).isNone()).toBe(true);
+    it("returns None for an unknown journal", async () => {
+      const { resolve } = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
+
+      const result = resolve(CycleService).anchorAtOffset("missing", "2024-01-01" as AnchorString, 2);
+
+      expect(result.isNone()).toBe(true);
     });
   });
 
   describe("isCanonicalAnchor", () => {
-    it("accepts any date for a fixed daily journal", () => {
-      const c = buildContainer({ daily: fixedJournal("daily", { type: "day" }) });
-      const cycle = c.resolve(CycleService);
-      const result = cycle.isCanonicalAnchor("daily", "2024-06-15" as AnchorString);
+    it("accepts any date for a fixed daily journal", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+      });
+
+      const result = resolve(CycleService).isCanonicalAnchor("daily", "2024-06-15" as AnchorString);
+
       expect(result.isSome() && result.value).toBe(true);
     });
 
-    it("rejects a non-first-of-month date for a fixed monthly journal", () => {
-      const c = buildContainer({ m: fixedJournal("m", { type: "month" }) });
-      const cycle = c.resolve(CycleService);
-      const result = cycle.isCanonicalAnchor("m", "2024-06-15" as AnchorString);
+    it("rejects a non-first-of-month date for a fixed monthly journal", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { m: fixedJournal("m", { type: "month" }) } },
+      });
+
+      const result = resolve(CycleService).isCanonicalAnchor("m", "2024-06-15" as AnchorString);
+
       expect(result.isSome() && result.value).toBe(false);
     });
 
-    it("accepts the first-of-month date for a fixed monthly journal", () => {
-      const c = buildContainer({ m: fixedJournal("m", { type: "month" }) });
-      const cycle = c.resolve(CycleService);
-      const result = cycle.isCanonicalAnchor("m", "2024-06-01" as AnchorString);
+    it("accepts the first-of-month date for a fixed monthly journal", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { m: fixedJournal("m", { type: "month" }) } },
+      });
+
+      const result = resolve(CycleService).isCanonicalAnchor("m", "2024-06-01" as AnchorString);
+
       expect(result.isSome() && result.value).toBe(true);
     });
 
-    it("rejects an off-grid date for a custom interval journal", () => {
-      const c = buildContainer({ s: customJournal("s", "month", 1, "2024-01-15") });
-      const cycle = c.resolve(CycleService);
-      const result = cycle.isCanonicalAnchor("s", "2024-02-20" as AnchorString);
+    it("rejects an off-grid date for a custom interval journal", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { s: customJournal("s", "month", 1, "2024-01-15") } },
+      });
+
+      const result = resolve(CycleService).isCanonicalAnchor("s", "2024-02-20" as AnchorString);
+
       expect(result.isSome() && result.value).toBe(false);
     });
 
-    it("accepts an on-grid date for a custom interval journal", () => {
-      const c = buildContainer({ s: customJournal("s", "month", 1, "2024-01-15") });
-      const cycle = c.resolve(CycleService);
-      const result = cycle.isCanonicalAnchor("s", "2024-02-15" as AnchorString);
+    it("accepts an on-grid date for a custom interval journal", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { s: customJournal("s", "month", 1, "2024-01-15") } },
+      });
+
+      const result = resolve(CycleService).isCanonicalAnchor("s", "2024-02-15" as AnchorString);
+
       expect(result.isSome() && result.value).toBe(true);
     });
 
-    it("returns None for an unknown journal", () => {
-      const c = buildContainer({});
-      const cycle = c.resolve(CycleService);
-      expect(cycle.isCanonicalAnchor("missing", "2024-06-01" as AnchorString).isNone()).toBe(true);
+    it("returns None for an unknown journal", async () => {
+      const { resolve } = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
+
+      const result = resolve(CycleService).isCanonicalAnchor("missing", "2024-06-01" as AnchorString);
+
+      expect(result.isNone()).toBe(true);
     });
   });
 });

--- a/src/journals/cycle.test.ts
+++ b/src/journals/cycle.test.ts
@@ -31,10 +31,10 @@ describe("CycleService", () => {
     });
 
     describe("fixed weekly", () => {
-      let h: TestHarness;
+      let harness: TestHarness;
 
       beforeEach(async () => {
-        h = await testContainer({
+        harness = await testContainer({
           modules: [journalsCoreModule],
           data: { journals: { weekly: fixedJournal("weekly", { type: "week" }) } },
         });
@@ -43,7 +43,7 @@ describe("CycleService", () => {
       it("returns a year-2020 anchor for a date the week-year considers 2020", () => {
         // Week containing Wed 2020-12-30 starts Mon 2020-12-28, ends Sun 2021-01-03.
         // With dow=1, the anchor is the week's first day = Mon 2020-12-28.
-        const result = h.resolve(CycleService).anchorOf("weekly", date("2020-12-30"));
+        const result = harness.resolve(CycleService).anchorOf("weekly", date("2020-12-30"));
 
         expect(result.isSome() && result.value).toBe("2020-12-28");
       });
@@ -52,7 +52,7 @@ describe("CycleService", () => {
         // Week containing Thu 2021-01-07 starts Mon 2021-01-04, ends Sun 2021-01-10.
         // With dow=1, the anchor is the week's first day = Mon 2021-01-04. A mid-week input
         // keeps this distinct from an identity function.
-        const result = h.resolve(CycleService).anchorOf("weekly", date("2021-01-07"));
+        const result = harness.resolve(CycleService).anchorOf("weekly", date("2021-01-07"));
 
         expect(result.isSome() && result.value).toBe("2021-01-04");
       });
@@ -184,36 +184,36 @@ describe("CycleService", () => {
     });
 
     describe("custom monthly anchored to a month end", () => {
-      let h: TestHarness;
+      let harness: TestHarness;
 
       beforeEach(async () => {
-        h = await testContainer({
+        harness = await testContainer({
           modules: [journalsCoreModule],
           data: { journals: { s: customJournal("s", "month", 1, "2025-01-31") } },
         });
       });
 
       it("clamps to the last day of a month too short for the configured day", () => {
-        const next = h.resolve(CycleService).nextAnchor("s", anchor("2025-01-31"));
+        const next = harness.resolve(CycleService).nextAnchor("s", anchor("2025-01-31"));
 
         expect(next.isSome() && next.value).toBe("2025-02-28");
       });
 
       it("returns to the month end after passing through a short month", () => {
-        const next = h.resolve(CycleService).nextAnchor("s", anchor("2025-02-28"));
+        const next = harness.resolve(CycleService).nextAnchor("s", anchor("2025-02-28"));
 
         expect(next.isSome() && next.value).toBe("2025-03-31");
       });
 
       it("resumes the configured phase from an anchor left off-grid by an extension", () => {
-        h.resolve(JournalsIndex).register({
+        harness.resolve(JournalsIndex).register({
           journalName: "s",
           anchor: anchor("2025-02-28"),
           path: "S/feb.md" as VaultPath,
           endDate: anchor("2025-03-04"), // extended past its computed end of 2025-03-30
         });
 
-        const next = h.resolve(CycleService).nextAnchor("s", anchor("2025-03-05"));
+        const next = harness.resolve(CycleService).nextAnchor("s", anchor("2025-03-05"));
 
         expect(next.isSome() && next.value).toBe("2025-04-30");
       });
@@ -565,14 +565,14 @@ describe("CycleService", () => {
       // The first interval is extended a full week past its default end of 01-07, so the
       // index-aware grid is 01-01, 01-15, 01-22, 01-29, 02-05 — 4 steps, not the 5 a raw
       // 7-day stepping (ignoring the extension) would produce.
-      let h: TestHarness;
+      let harness: TestHarness;
 
       beforeEach(async () => {
-        h = await testContainer({
+        harness = await testContainer({
           modules: [journalsCoreModule],
           data: { journals: { s: customJournal("s", "week", 1, "2024-01-01") } },
         });
-        h.resolve(JournalsIndex).register({
+        harness.resolve(JournalsIndex).register({
           journalName: "s",
           anchor: anchor("2024-01-01"),
           path: "S/1.md" as VaultPath,
@@ -581,7 +581,7 @@ describe("CycleService", () => {
       });
 
       it("counts the same number of intervals as stepping through nextAnchor", () => {
-        const cycle = h.resolve(CycleService);
+        const cycle = harness.resolve(CycleService);
         const to = anchor("2024-02-05");
 
         let current = anchor("2024-01-01");
@@ -602,7 +602,7 @@ describe("CycleService", () => {
       it("counts the same number of intervals as stepping through previousAnchor", () => {
         // Mirror of the forward case: stepping backward through the same grid is
         // 02-05, 01-29, 01-22, 01-15, 01-01.
-        const cycle = h.resolve(CycleService);
+        const cycle = harness.resolve(CycleService);
         const to = anchor("2024-01-01");
 
         let current = anchor("2024-02-05");

--- a/src/journals/cycle.test.ts
+++ b/src/journals/cycle.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import type { AnchorString } from "@/calendar";
-import { date } from "@/calendar/testing";
+import { anchor, date } from "@/calendar/testing";
 import type { VaultPath } from "@/infrastructure/host";
 import { testContainer, type TestHarness } from "@/testing";
 
@@ -117,7 +116,7 @@ describe("CycleService", () => {
         data: { journals: { weekly: fixedJournal("weekly", { type: "week" }) } },
       });
 
-      const result = resolve(CycleService).representativeOf("weekly", "2025-03-10" as AnchorString);
+      const result = resolve(CycleService).representativeOf("weekly", anchor("2025-03-10"));
 
       expect(unwrap(result).toAnchor()).toBe("2025-03-13");
     });
@@ -128,7 +127,7 @@ describe("CycleService", () => {
         data: { journals: { monthly: fixedJournal("monthly", { type: "month" }) } },
       });
 
-      const result = resolve(CycleService).representativeOf("monthly", "2025-03-01" as AnchorString);
+      const result = resolve(CycleService).representativeOf("monthly", anchor("2025-03-01"));
 
       expect(unwrap(result).toAnchor()).toBe("2025-03-01");
     });
@@ -139,7 +138,7 @@ describe("CycleService", () => {
         data: { journals: { sprints: customJournal("sprints", "week", 2, "2024-01-01") } },
       });
 
-      const result = resolve(CycleService).representativeOf("sprints", "2024-01-01" as AnchorString);
+      const result = resolve(CycleService).representativeOf("sprints", anchor("2024-01-01"));
 
       expect(unwrap(result).toAnchor()).toBe("2024-01-01");
     });
@@ -147,7 +146,7 @@ describe("CycleService", () => {
     it("returns none for an unknown journal", async () => {
       const { resolve } = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
 
-      const result = resolve(CycleService).representativeOf("missing", "2025-03-10" as AnchorString);
+      const result = resolve(CycleService).representativeOf("missing", anchor("2025-03-10"));
 
       expect(result.isNone()).toBe(true);
     });
@@ -162,7 +161,7 @@ describe("CycleService", () => {
 
       // With the test calendar (dow=1), the anchor of a week is its first day (Monday).
       // next() of the week containing 2024-03-04 (Mon): next week = Mon 2024-03-11.
-      const next = resolve(CycleService).nextAnchor("w", "2024-03-04" as AnchorString);
+      const next = resolve(CycleService).nextAnchor("w", anchor("2024-03-04"));
 
       expect(next.isSome() && next.value).toBe("2024-03-11");
     });
@@ -173,7 +172,7 @@ describe("CycleService", () => {
         data: { journals: { s: customJournal("s", "month", 1, "2024-01-15") } },
       });
 
-      const next = resolve(CycleService).nextAnchor("s", "2024-01-15" as AnchorString);
+      const next = resolve(CycleService).nextAnchor("s", anchor("2024-01-15"));
 
       expect(next.isSome() && next.value).toBe("2024-02-15");
     });
@@ -181,11 +180,7 @@ describe("CycleService", () => {
     it("returns None for an unknown journal", async () => {
       const { resolve } = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
 
-      expect(
-        resolve(CycleService)
-          .nextAnchor("missing", "2024-01-01" as AnchorString)
-          .isNone(),
-      ).toBe(true);
+      expect(resolve(CycleService).nextAnchor("missing", anchor("2024-01-01")).isNone()).toBe(true);
     });
 
     describe("custom monthly anchored to a month end", () => {
@@ -199,13 +194,13 @@ describe("CycleService", () => {
       });
 
       it("clamps to the last day of a month too short for the configured day", () => {
-        const next = h.resolve(CycleService).nextAnchor("s", "2025-01-31" as AnchorString);
+        const next = h.resolve(CycleService).nextAnchor("s", anchor("2025-01-31"));
 
         expect(next.isSome() && next.value).toBe("2025-02-28");
       });
 
       it("returns to the month end after passing through a short month", () => {
-        const next = h.resolve(CycleService).nextAnchor("s", "2025-02-28" as AnchorString);
+        const next = h.resolve(CycleService).nextAnchor("s", anchor("2025-02-28"));
 
         expect(next.isSome() && next.value).toBe("2025-03-31");
       });
@@ -213,12 +208,12 @@ describe("CycleService", () => {
       it("resumes the configured phase from an anchor left off-grid by an extension", () => {
         h.resolve(JournalsIndex).register({
           journalName: "s",
-          anchor: "2025-02-28" as AnchorString,
+          anchor: anchor("2025-02-28"),
           path: "S/feb.md" as VaultPath,
-          endDate: "2025-03-04" as AnchorString, // extended past its computed end of 2025-03-30
+          endDate: anchor("2025-03-04"), // extended past its computed end of 2025-03-30
         });
 
-        const next = h.resolve(CycleService).nextAnchor("s", "2025-03-05" as AnchorString);
+        const next = h.resolve(CycleService).nextAnchor("s", anchor("2025-03-05"));
 
         expect(next.isSome() && next.value).toBe("2025-04-30");
       });
@@ -231,7 +226,7 @@ describe("CycleService", () => {
           data: { journals: { s: customJournal("s", "month", 1, "2024-01-30") } },
         });
 
-        const next = resolve(CycleService).nextAnchor("s", "2024-02-29" as AnchorString);
+        const next = resolve(CycleService).nextAnchor("s", anchor("2024-02-29"));
 
         expect(next.isSome() && next.value).toBe("2024-03-30");
       });
@@ -244,7 +239,7 @@ describe("CycleService", () => {
           data: { journals: { s: customJournal("s", "quarter", 1, "2025-01-31") } },
         });
 
-        const next = resolve(CycleService).nextAnchor("s", "2025-04-30" as AnchorString);
+        const next = resolve(CycleService).nextAnchor("s", anchor("2025-04-30"));
 
         expect(next.isSome() && next.value).toBe("2025-07-31");
       });
@@ -257,7 +252,7 @@ describe("CycleService", () => {
           data: { journals: { s: customJournal("s", "year", 1, "2024-02-29") } },
         });
 
-        const next = resolve(CycleService).nextAnchor("s", "2027-02-28" as AnchorString);
+        const next = resolve(CycleService).nextAnchor("s", anchor("2027-02-28"));
 
         expect(next.isSome() && next.value).toBe("2028-02-29");
       });
@@ -273,7 +268,7 @@ describe("CycleService", () => {
 
       // With the test calendar (dow=1), 2024-03-04 is the anchor of the week Mon 2024-03-04 –
       // Sun 2024-03-10; the prior week's anchor is its first day = Mon 2024-02-26.
-      const previous = resolve(CycleService).previousAnchor("w", "2024-03-04" as AnchorString);
+      const previous = resolve(CycleService).previousAnchor("w", anchor("2024-03-04"));
 
       expect(previous.isSome() && previous.value).toBe("2024-02-26");
     });
@@ -284,7 +279,7 @@ describe("CycleService", () => {
         data: { journals: { s: customJournal("s", "month", 1, "2024-01-15") } },
       });
 
-      const previous = resolve(CycleService).previousAnchor("s", "2024-02-15" as AnchorString);
+      const previous = resolve(CycleService).previousAnchor("s", anchor("2024-02-15"));
 
       expect(previous.isSome() && previous.value).toBe("2024-01-15");
     });
@@ -295,7 +290,7 @@ describe("CycleService", () => {
         data: { journals: { s: customJournal("s", "month", 1, "2025-01-31") } },
       });
 
-      const previous = resolve(CycleService).previousAnchor("s", "2025-03-31" as AnchorString);
+      const previous = resolve(CycleService).previousAnchor("s", anchor("2025-03-31"));
 
       expect(previous.isSome() && previous.value).toBe("2025-02-28");
     });
@@ -306,7 +301,7 @@ describe("CycleService", () => {
         data: { journals: { s: customJournal("s", "quarter", 1, "2025-01-31") } },
       });
 
-      const previous = resolve(CycleService).previousAnchor("s", "2025-04-30" as AnchorString);
+      const previous = resolve(CycleService).previousAnchor("s", anchor("2025-04-30"));
 
       expect(previous.isSome() && previous.value).toBe("2025-01-31");
     });
@@ -319,12 +314,12 @@ describe("CycleService", () => {
         data: { journals: { w: fixedJournal("w", { type: "week" }) } },
       });
       const cycle = resolve(CycleService);
-      const anchor = unwrap(cycle.anchorOf("w", date("2024-03-06")));
+      const weekAnchor = unwrap(cycle.anchorOf("w", date("2024-03-06")));
 
       // The test calendar's dow=1 doy=4 puts the week containing 2024-03-06 (Wednesday) at
       // Mon 2024-03-04 through Sun 2024-03-10.
-      const start = cycle.startOf("w", anchor);
-      const end = cycle.endOf("w", anchor);
+      const start = cycle.startOf("w", weekAnchor);
+      const end = cycle.endOf("w", weekAnchor);
 
       expect(start.isSome() && start.value.toAnchor()).toBe("2024-03-04");
       expect(end.isSome() && end.value.toAnchor()).toBe("2024-03-10");
@@ -337,8 +332,8 @@ describe("CycleService", () => {
       });
       const cycle = resolve(CycleService);
 
-      const start = cycle.startOf("s", "2024-01-15" as AnchorString);
-      const end = cycle.endOf("s", "2024-01-15" as AnchorString);
+      const start = cycle.startOf("s", anchor("2024-01-15"));
+      const end = cycle.endOf("s", anchor("2024-01-15"));
 
       expect(start.isSome() && start.value.toAnchor()).toBe("2024-01-15");
       expect(end.isSome() && end.value.toAnchor()).toBe("2024-02-14"); // the day before the next anchor
@@ -351,12 +346,12 @@ describe("CycleService", () => {
       });
       resolve(JournalsIndex).register({
         journalName: "s",
-        anchor: "2024-01-01" as AnchorString,
+        anchor: anchor("2024-01-01"),
         path: "S/1.md" as VaultPath,
-        endDate: "2024-01-14" as AnchorString,
+        endDate: anchor("2024-01-14"),
       });
 
-      const end = resolve(CycleService).endOf("s", "2024-01-01" as AnchorString);
+      const end = resolve(CycleService).endOf("s", anchor("2024-01-01"));
 
       expect(end.isSome() && end.value.toAnchor()).toBe("2024-01-14");
     });
@@ -365,8 +360,8 @@ describe("CycleService", () => {
       const { resolve } = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
       const cycle = resolve(CycleService);
 
-      expect(cycle.startOf("missing", "2024-01-01" as AnchorString).isNone()).toBe(true);
-      expect(cycle.endOf("missing", "2024-01-01" as AnchorString).isNone()).toBe(true);
+      expect(cycle.startOf("missing", anchor("2024-01-01")).isNone()).toBe(true);
+      expect(cycle.endOf("missing", anchor("2024-01-01")).isNone()).toBe(true);
     });
   });
 
@@ -378,12 +373,12 @@ describe("CycleService", () => {
       });
       resolve(JournalsIndex).register({
         journalName: "s",
-        anchor: "2024-01-01" as AnchorString,
+        anchor: anchor("2024-01-01"),
         path: "S/1.md" as VaultPath,
-        endDate: "2024-01-14" as AnchorString, // extended through Jan 14 instead of Jan 7
+        endDate: anchor("2024-01-14"), // extended through Jan 14 instead of Jan 7
       });
 
-      const next = resolve(CycleService).nextAnchor("s", "2024-01-01" as AnchorString);
+      const next = resolve(CycleService).nextAnchor("s", anchor("2024-01-01"));
 
       expect(next.isSome() && next.value).toBe("2024-01-15");
     });
@@ -395,16 +390,16 @@ describe("CycleService", () => {
       });
       resolve(JournalsIndex).register({
         journalName: "s",
-        anchor: "2024-01-01" as AnchorString,
+        anchor: anchor("2024-01-01"),
         path: "S/1.md" as VaultPath,
-        endDate: "2024-01-14" as AnchorString, // extended through Jan 14 instead of Jan 7
+        endDate: anchor("2024-01-14"), // extended through Jan 14 instead of Jan 7
       });
 
       // 2024-01-10 lies in the extended first interval [2024-01-01, 2024-01-14], not a
       // phantom computed week starting 2024-01-08.
-      const anchor = resolve(CycleService).anchorOf("s", date("2024-01-10"));
+      const result = resolve(CycleService).anchorOf("s", date("2024-01-10"));
 
-      expect(anchor.isSome() && anchor.value).toBe("2024-01-01");
+      expect(result.isSome() && result.value).toBe("2024-01-01");
     });
 
     it("anchorOf steps past an extended interval to the next computed anchor", async () => {
@@ -414,15 +409,15 @@ describe("CycleService", () => {
       });
       resolve(JournalsIndex).register({
         journalName: "s",
-        anchor: "2024-01-01" as AnchorString,
+        anchor: anchor("2024-01-01"),
         path: "S/1.md" as VaultPath,
-        endDate: "2024-01-14" as AnchorString,
+        endDate: anchor("2024-01-14"),
       });
 
       // The interval after the extension starts 2024-01-15; 2024-01-20 falls inside it.
-      const anchor = resolve(CycleService).anchorOf("s", date("2024-01-20"));
+      const result = resolve(CycleService).anchorOf("s", date("2024-01-20"));
 
-      expect(anchor.isSome() && anchor.value).toBe("2024-01-15");
+      expect(result.isSome() && result.value).toBe("2024-01-15");
     });
 
     it("anchorOf maps a date inside an extended interval that precedes the configured anchor", async () => {
@@ -432,16 +427,16 @@ describe("CycleService", () => {
       });
       resolve(JournalsIndex).register({
         journalName: "s",
-        anchor: "2023-12-18" as AnchorString,
+        anchor: anchor("2023-12-18"),
         path: "S/prev.md" as VaultPath,
-        endDate: "2024-01-14" as AnchorString, // extended right up to the day before the anchor
+        endDate: anchor("2024-01-14"), // extended right up to the day before the anchor
       });
 
       // 2024-01-05 lies in the stored interval [2023-12-18, 2024-01-14], reached by walking
       // backward from the configured anchor 2024-01-15.
-      const anchor = resolve(CycleService).anchorOf("s", date("2024-01-05"));
+      const result = resolve(CycleService).anchorOf("s", date("2024-01-05"));
 
-      expect(anchor.isSome() && anchor.value).toBe("2023-12-18");
+      expect(result.isSome() && result.value).toBe("2023-12-18");
     });
   });
 
@@ -474,11 +469,7 @@ describe("CycleService", () => {
         data: { journals: { s: customJournal("s", "week", 1, "2024-01-01") } },
       });
 
-      const result = resolve(CycleService).intervalsInRange(
-        "s",
-        "2024-01-05" as AnchorString,
-        "2024-01-20" as AnchorString,
-      );
+      const result = resolve(CycleService).intervalsInRange("s", anchor("2024-01-05"), anchor("2024-01-20"));
 
       expect([...result]).toEqual(["2024-01-01", "2024-01-08", "2024-01-15"]);
     });
@@ -492,11 +483,7 @@ describe("CycleService", () => {
       });
 
       // 2024-01-01 (Mon) and 2024-01-22 (Mon) are 3 weeks apart.
-      const result = resolve(CycleService).countRepeats(
-        "w",
-        "2024-01-01" as AnchorString,
-        "2024-01-22" as AnchorString,
-      );
+      const result = resolve(CycleService).countRepeats("w", anchor("2024-01-01"), anchor("2024-01-22"));
 
       expect(result.isSome() && result.value).toBe(3);
     });
@@ -507,7 +494,7 @@ describe("CycleService", () => {
         data: { journals: { w: fixedJournal("w", { type: "week" }) } },
       });
 
-      const result = resolve(CycleService).countRepeats("w", "" as AnchorString, "2024-01-22" as AnchorString);
+      const result = resolve(CycleService).countRepeats("w", anchor(""), anchor("2024-01-22"));
 
       expect(result.isNone()).toBe(true);
     });
@@ -518,7 +505,7 @@ describe("CycleService", () => {
         data: { journals: { w: fixedJournal("w", { type: "week" }) } },
       });
 
-      const result = resolve(CycleService).countRepeats("w", "2024-01-01" as AnchorString, "nonsense" as AnchorString);
+      const result = resolve(CycleService).countRepeats("w", anchor("2024-01-01"), anchor("nonsense"));
 
       expect(result.isNone()).toBe(true);
     });
@@ -531,11 +518,7 @@ describe("CycleService", () => {
 
       // Wed 2024-01-03 sits in the week anchored Mon 2024-01-01; the week anchored
       // 2024-01-15 is two weeks on, however far into its week the start date falls.
-      const result = resolve(CycleService).countRepeats(
-        "w",
-        "2024-01-03" as AnchorString,
-        "2024-01-15" as AnchorString,
-      );
+      const result = resolve(CycleService).countRepeats("w", anchor("2024-01-03"), anchor("2024-01-15"));
 
       expect(result.isSome() && result.value).toBe(2);
     });
@@ -546,11 +529,7 @@ describe("CycleService", () => {
         data: { journals: { m: fixedJournal("m", { type: "month" }) } },
       });
 
-      const result = resolve(CycleService).countRepeats(
-        "m",
-        "2024-06-15" as AnchorString,
-        "2024-08-01" as AnchorString,
-      );
+      const result = resolve(CycleService).countRepeats("m", anchor("2024-06-15"), anchor("2024-08-01"));
 
       expect(result.isSome() && result.value).toBe(2);
     });
@@ -562,8 +541,8 @@ describe("CycleService", () => {
       });
       const cycle = resolve(CycleService);
 
-      const forward = unwrap(cycle.countRepeats("w", "2024-01-01" as AnchorString, "2024-01-22" as AnchorString));
-      const backward = unwrap(cycle.countRepeats("w", "2024-01-22" as AnchorString, "2024-01-01" as AnchorString));
+      const forward = unwrap(cycle.countRepeats("w", anchor("2024-01-01"), anchor("2024-01-22")));
+      const backward = unwrap(cycle.countRepeats("w", anchor("2024-01-22"), anchor("2024-01-01")));
 
       expect(Math.abs(forward)).toBe(Math.abs(backward));
     });
@@ -577,11 +556,7 @@ describe("CycleService", () => {
         data: { journals: { s: customJournal("s", "day", 7, "2026-06-01") } },
       });
 
-      const result = resolve(CycleService).countRepeats(
-        "s",
-        "2026-06-03" as AnchorString,
-        "2026-06-22" as AnchorString,
-      );
+      const result = resolve(CycleService).countRepeats("s", anchor("2026-06-03"), anchor("2026-06-22"));
 
       expect(result.isSome() && result.value).toBe(3);
     });
@@ -599,17 +574,17 @@ describe("CycleService", () => {
         });
         h.resolve(JournalsIndex).register({
           journalName: "s",
-          anchor: "2024-01-01" as AnchorString,
+          anchor: anchor("2024-01-01"),
           path: "S/1.md" as VaultPath,
-          endDate: "2024-01-14" as AnchorString,
+          endDate: anchor("2024-01-14"),
         });
       });
 
       it("counts the same number of intervals as stepping through nextAnchor", () => {
         const cycle = h.resolve(CycleService);
-        const to = "2024-02-05" as AnchorString;
+        const to = anchor("2024-02-05");
 
-        let current = "2024-01-01" as AnchorString;
+        let current = anchor("2024-01-01");
         let steps = 0;
         // Capped so a stalled nextAnchor fails the test below rather than hanging the run.
         const maxSteps = 8;
@@ -620,7 +595,7 @@ describe("CycleService", () => {
 
         expect(current).toBe(to);
         expect(steps).toBe(4);
-        const result = cycle.countRepeats("s", "2024-01-01" as AnchorString, to);
+        const result = cycle.countRepeats("s", anchor("2024-01-01"), to);
         expect(result.isSome() && result.value).toBe(steps);
       });
 
@@ -628,9 +603,9 @@ describe("CycleService", () => {
         // Mirror of the forward case: stepping backward through the same grid is
         // 02-05, 01-29, 01-22, 01-15, 01-01.
         const cycle = h.resolve(CycleService);
-        const to = "2024-01-01" as AnchorString;
+        const to = anchor("2024-01-01");
 
-        let current = "2024-02-05" as AnchorString;
+        let current = anchor("2024-02-05");
         let steps = 0;
         // Capped so a stalled previousAnchor fails the test below rather than hanging the run.
         const maxSteps = 8;
@@ -641,7 +616,7 @@ describe("CycleService", () => {
 
         expect(current).toBe(to);
         expect(steps).toBe(4);
-        const result = cycle.countRepeats("s", "2024-02-05" as AnchorString, to);
+        const result = cycle.countRepeats("s", anchor("2024-02-05"), to);
         expect(result.isSome() && result.value).toBe(-steps);
       });
     });
@@ -654,7 +629,7 @@ describe("CycleService", () => {
         data: { journals: { s: customJournal("s", "week", 1, "2024-01-01") } },
       });
 
-      const result = resolve(CycleService).anchorAtOffset("s", "2024-01-01" as AnchorString, 3);
+      const result = resolve(CycleService).anchorAtOffset("s", anchor("2024-01-01"), 3);
 
       expect(result.isSome() && result.value).toBe("2024-01-22");
     });
@@ -665,7 +640,7 @@ describe("CycleService", () => {
         data: { journals: { s: customJournal("s", "week", 1, "2024-01-01") } },
       });
 
-      const result = resolve(CycleService).anchorAtOffset("s", "2024-01-22" as AnchorString, -3);
+      const result = resolve(CycleService).anchorAtOffset("s", anchor("2024-01-22"), -3);
 
       expect(result.isSome() && result.value).toBe("2024-01-01");
     });
@@ -676,7 +651,7 @@ describe("CycleService", () => {
         data: { journals: { s: customJournal("s", "week", 1, "2024-01-01") } },
       });
 
-      const result = resolve(CycleService).anchorAtOffset("s", "2024-01-08" as AnchorString, 0);
+      const result = resolve(CycleService).anchorAtOffset("s", anchor("2024-01-08"), 0);
 
       expect(result.isSome() && result.value).toBe("2024-01-08");
     });
@@ -687,7 +662,7 @@ describe("CycleService", () => {
         data: { journals: { d: fixedJournal("d", { type: "day" }) } },
       });
 
-      const result = resolve(CycleService).anchorAtOffset("d", "2024-01-01" as AnchorString, 3);
+      const result = resolve(CycleService).anchorAtOffset("d", anchor("2024-01-01"), 3);
 
       expect(result.isSome() && result.value).toBe("2024-01-04");
     });
@@ -698,7 +673,7 @@ describe("CycleService", () => {
         data: { journals: { s: customJournal("s", "month", 2, "2024-01-31") } },
       });
 
-      const result = resolve(CycleService).anchorAtOffset("s", "2024-01-31" as AnchorString, 7);
+      const result = resolve(CycleService).anchorAtOffset("s", anchor("2024-01-31"), 7);
 
       expect(result.isSome() && result.value).toBe("2025-03-31");
     });
@@ -709,7 +684,7 @@ describe("CycleService", () => {
         data: { journals: { s: customJournal("s", "month", 2, "2024-01-31") } },
       });
 
-      const result = resolve(CycleService).anchorAtOffset("s", "2024-01-01" as AnchorString, 0);
+      const result = resolve(CycleService).anchorAtOffset("s", anchor("2024-01-01"), 0);
 
       expect(result.isSome() && result.value).toBe("2024-01-01");
     });
@@ -720,7 +695,7 @@ describe("CycleService", () => {
         data: { journals: { q: fixedJournal("q", { type: "quarter" }) } },
       });
 
-      const result = resolve(CycleService).anchorAtOffset("q", "2024-02-15" as AnchorString, 5);
+      const result = resolve(CycleService).anchorAtOffset("q", anchor("2024-02-15"), 5);
 
       expect(result.isSome() && result.value).toBe("2025-04-01");
     });
@@ -728,7 +703,7 @@ describe("CycleService", () => {
     it("returns None for an unknown journal", async () => {
       const { resolve } = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
 
-      const result = resolve(CycleService).anchorAtOffset("missing", "2024-01-01" as AnchorString, 2);
+      const result = resolve(CycleService).anchorAtOffset("missing", anchor("2024-01-01"), 2);
 
       expect(result.isNone()).toBe(true);
     });
@@ -741,7 +716,7 @@ describe("CycleService", () => {
         data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
       });
 
-      const result = resolve(CycleService).isCanonicalAnchor("daily", "2024-06-15" as AnchorString);
+      const result = resolve(CycleService).isCanonicalAnchor("daily", anchor("2024-06-15"));
 
       expect(result.isSome() && result.value).toBe(true);
     });
@@ -752,7 +727,7 @@ describe("CycleService", () => {
         data: { journals: { m: fixedJournal("m", { type: "month" }) } },
       });
 
-      const result = resolve(CycleService).isCanonicalAnchor("m", "2024-06-15" as AnchorString);
+      const result = resolve(CycleService).isCanonicalAnchor("m", anchor("2024-06-15"));
 
       expect(result.isSome() && result.value).toBe(false);
     });
@@ -763,7 +738,7 @@ describe("CycleService", () => {
         data: { journals: { m: fixedJournal("m", { type: "month" }) } },
       });
 
-      const result = resolve(CycleService).isCanonicalAnchor("m", "2024-06-01" as AnchorString);
+      const result = resolve(CycleService).isCanonicalAnchor("m", anchor("2024-06-01"));
 
       expect(result.isSome() && result.value).toBe(true);
     });
@@ -774,7 +749,7 @@ describe("CycleService", () => {
         data: { journals: { s: customJournal("s", "month", 1, "2024-01-15") } },
       });
 
-      const result = resolve(CycleService).isCanonicalAnchor("s", "2024-02-20" as AnchorString);
+      const result = resolve(CycleService).isCanonicalAnchor("s", anchor("2024-02-20"));
 
       expect(result.isSome() && result.value).toBe(false);
     });
@@ -785,7 +760,7 @@ describe("CycleService", () => {
         data: { journals: { s: customJournal("s", "month", 1, "2024-01-15") } },
       });
 
-      const result = resolve(CycleService).isCanonicalAnchor("s", "2024-02-15" as AnchorString);
+      const result = resolve(CycleService).isCanonicalAnchor("s", anchor("2024-02-15"));
 
       expect(result.isSome() && result.value).toBe(true);
     });
@@ -793,7 +768,7 @@ describe("CycleService", () => {
     it("returns None for an unknown journal", async () => {
       const { resolve } = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
 
-      const result = resolve(CycleService).isCanonicalAnchor("missing", "2024-06-01" as AnchorString);
+      const result = resolve(CycleService).isCanonicalAnchor("missing", anchor("2024-06-01"));
 
       expect(result.isNone()).toBe(true);
     });

--- a/src/journals/cycle.test.ts
+++ b/src/journals/cycle.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import type { AnchorString } from "@/calendar";
 import { date } from "@/calendar/testing";
 import type { VaultPath } from "@/infrastructure/host";
-import { testContainer } from "@/testing";
+import { testContainer, type TestHarness } from "@/testing";
 
 import { CycleService } from "./cycle";
 import { JournalsIndex } from "./journals-index";
@@ -32,29 +32,28 @@ describe("CycleService", () => {
     });
 
     describe("fixed weekly", () => {
-      it("returns a year-2020 anchor for a date the week-year considers 2020", async () => {
-        const { resolve } = await testContainer({
+      let h: TestHarness;
+
+      beforeEach(async () => {
+        h = await testContainer({
           modules: [journalsCoreModule],
           data: { journals: { weekly: fixedJournal("weekly", { type: "week" }) } },
         });
+      });
 
+      it("returns a year-2020 anchor for a date the week-year considers 2020", () => {
         // Week containing Wed 2020-12-30 starts Mon 2020-12-28, ends Sun 2021-01-03.
         // With dow=1, the anchor is the week's first day = Mon 2020-12-28.
-        const result = resolve(CycleService).anchorOf("weekly", date("2020-12-30"));
+        const result = h.resolve(CycleService).anchorOf("weekly", date("2020-12-30"));
 
         expect(result.isSome() && result.value).toBe("2020-12-28");
       });
 
-      it("returns a year-2021 anchor for a date the week-year considers 2021", async () => {
-        const { resolve } = await testContainer({
-          modules: [journalsCoreModule],
-          data: { journals: { weekly: fixedJournal("weekly", { type: "week" }) } },
-        });
-
+      it("returns a year-2021 anchor for a date the week-year considers 2021", () => {
         // Week containing Thu 2021-01-07 starts Mon 2021-01-04, ends Sun 2021-01-10.
         // With dow=1, the anchor is the week's first day = Mon 2021-01-04. A mid-week input
         // keeps this distinct from an identity function.
-        const result = resolve(CycleService).anchorOf("weekly", date("2021-01-07"));
+        const result = h.resolve(CycleService).anchorOf("weekly", date("2021-01-07"));
 
         expect(result.isSome() && result.value).toBe("2021-01-04");
       });
@@ -190,41 +189,36 @@ describe("CycleService", () => {
     });
 
     describe("custom monthly anchored to a month end", () => {
-      it("clamps to the last day of a month too short for the configured day", async () => {
-        const { resolve } = await testContainer({
+      let h: TestHarness;
+
+      beforeEach(async () => {
+        h = await testContainer({
           modules: [journalsCoreModule],
           data: { journals: { s: customJournal("s", "month", 1, "2025-01-31") } },
         });
+      });
 
-        const next = resolve(CycleService).nextAnchor("s", "2025-01-31" as AnchorString);
+      it("clamps to the last day of a month too short for the configured day", () => {
+        const next = h.resolve(CycleService).nextAnchor("s", "2025-01-31" as AnchorString);
 
         expect(next.isSome() && next.value).toBe("2025-02-28");
       });
 
-      it("returns to the month end after passing through a short month", async () => {
-        const { resolve } = await testContainer({
-          modules: [journalsCoreModule],
-          data: { journals: { s: customJournal("s", "month", 1, "2025-01-31") } },
-        });
-
-        const next = resolve(CycleService).nextAnchor("s", "2025-02-28" as AnchorString);
+      it("returns to the month end after passing through a short month", () => {
+        const next = h.resolve(CycleService).nextAnchor("s", "2025-02-28" as AnchorString);
 
         expect(next.isSome() && next.value).toBe("2025-03-31");
       });
 
-      it("resumes the configured phase from an anchor left off-grid by an extension", async () => {
-        const { resolve } = await testContainer({
-          modules: [journalsCoreModule],
-          data: { journals: { s: customJournal("s", "month", 1, "2025-01-31") } },
-        });
-        resolve(JournalsIndex).register({
+      it("resumes the configured phase from an anchor left off-grid by an extension", () => {
+        h.resolve(JournalsIndex).register({
           journalName: "s",
           anchor: "2025-02-28" as AnchorString,
           path: "S/feb.md" as VaultPath,
           endDate: "2025-03-04" as AnchorString, // extended past its computed end of 2025-03-30
         });
 
-        const next = resolve(CycleService).nextAnchor("s", "2025-03-05" as AnchorString);
+        const next = h.resolve(CycleService).nextAnchor("s", "2025-03-05" as AnchorString);
 
         expect(next.isSome() && next.value).toBe("2025-04-30");
       });
@@ -593,21 +587,26 @@ describe("CycleService", () => {
     });
 
     describe("custom interval extended past its default end", () => {
-      it("counts the same number of intervals as stepping through nextAnchor", async () => {
-        // The first interval is extended a full week past its default end of 01-07, so the
-        // index-aware grid is 01-01, 01-15, 01-22, 01-29, 02-05 — 4 steps, not the 5 a raw
-        // 7-day stepping (ignoring the extension) would produce.
-        const { resolve } = await testContainer({
+      // The first interval is extended a full week past its default end of 01-07, so the
+      // index-aware grid is 01-01, 01-15, 01-22, 01-29, 02-05 — 4 steps, not the 5 a raw
+      // 7-day stepping (ignoring the extension) would produce.
+      let h: TestHarness;
+
+      beforeEach(async () => {
+        h = await testContainer({
           modules: [journalsCoreModule],
           data: { journals: { s: customJournal("s", "week", 1, "2024-01-01") } },
         });
-        resolve(JournalsIndex).register({
+        h.resolve(JournalsIndex).register({
           journalName: "s",
           anchor: "2024-01-01" as AnchorString,
           path: "S/1.md" as VaultPath,
           endDate: "2024-01-14" as AnchorString,
         });
-        const cycle = resolve(CycleService);
+      });
+
+      it("counts the same number of intervals as stepping through nextAnchor", () => {
+        const cycle = h.resolve(CycleService);
         const to = "2024-02-05" as AnchorString;
 
         let current = "2024-01-01" as AnchorString;
@@ -625,21 +624,10 @@ describe("CycleService", () => {
         expect(result.isSome() && result.value).toBe(steps);
       });
 
-      it("counts the same number of intervals as stepping through previousAnchor", async () => {
-        // Mirror of the forward case: stepping backward from 2024-02-05 through the
-        // index-aware grid is 02-05, 01-29, 01-22, 01-15, 01-01 — 4 steps, not the 5 a raw
-        // 7-day stepping (ignoring the extension) would produce.
-        const { resolve } = await testContainer({
-          modules: [journalsCoreModule],
-          data: { journals: { s: customJournal("s", "week", 1, "2024-01-01") } },
-        });
-        resolve(JournalsIndex).register({
-          journalName: "s",
-          anchor: "2024-01-01" as AnchorString,
-          path: "S/1.md" as VaultPath,
-          endDate: "2024-01-14" as AnchorString,
-        });
-        const cycle = resolve(CycleService);
+      it("counts the same number of intervals as stepping through previousAnchor", () => {
+        // Mirror of the forward case: stepping backward through the same grid is
+        // 02-05, 01-29, 01-22, 01-15, 01-01.
+        const cycle = h.resolve(CycleService);
         const to = "2024-01-01" as AnchorString;
 
         let current = "2024-02-05" as AnchorString;

--- a/src/journals/index.ts
+++ b/src/journals/index.ts
@@ -13,7 +13,8 @@ export { JournalsIndex } from "./journals-index";
 
 export { useIndexVersion } from "./use-index-version";
 
-export { journalsModule, journalsCoreModule } from "./module";
+export { journalsModule, journalsCoreModule, journalsStartupModule } from "./module";
+export { journalsUiModule } from "./ui-module";
 
 export {
   JournalEditSectionToken,

--- a/src/journals/module.ts
+++ b/src/journals/module.ts
@@ -12,14 +12,9 @@ import { JournalNavigationCommands } from "./navigation-commands";
 import { journalNotesCoreModule, journalNotesStartupModule } from "./notes/module";
 import { NumberingService } from "./numbering";
 import { JournalsRepository, type JournalsEvents } from "./repository";
-import { JournalEditSectionToken, defineJournalEditSection } from "./settings/ui/journal-edit-section";
-import FrontmatterSection from "./settings/ui/sections/FrontmatterSection.vue";
-import NoteCreationSection from "./settings/ui/sections/NoteCreationSection.vue";
-import SequenceSection from "./settings/ui/sections/SequenceSection.vue";
-import TemplatesSection from "./settings/ui/sections/TemplatesSection.vue";
-import TimelineSection from "./settings/ui/sections/TimelineSection.vue";
 import { TimelineService } from "./timeline";
 import { JournalsEventsToken } from "./tokens";
+import { journalsUiModule } from "./ui-module";
 import { journalUriModule } from "./uri/module";
 import { VaultSubscriptionService } from "./vault-subscription";
 import { JournalsViewModel } from "./view-model";
@@ -42,25 +37,17 @@ export const journalsCoreModule: Module = {
   },
 };
 
+export const journalsStartupModule: Module = {
+  register(c) {
+    journalNotesStartupModule.register(c);
+    c.register(JournalNavigationCommands).useClass(JournalNavigationCommands).eager();
+  },
+};
+
 export const journalsModule: Module = {
   register(c) {
     journalsCoreModule.register(c);
-    journalNotesStartupModule.register(c);
-    c.register(JournalNavigationCommands).useClass(JournalNavigationCommands).eager();
-    c.register(JournalEditSectionToken).useValue(
-      defineJournalEditSection({ key: "note-creation", order: 20, component: NoteCreationSection }),
-    );
-    c.register(JournalEditSectionToken).useValue(
-      defineJournalEditSection({ key: "templates", order: 30, component: TemplatesSection }),
-    );
-    c.register(JournalEditSectionToken).useValue(
-      defineJournalEditSection({ key: "timeline", order: 40, component: TimelineSection }),
-    );
-    c.register(JournalEditSectionToken).useValue(
-      defineJournalEditSection({ key: "sequence", order: 50, component: SequenceSection }),
-    );
-    c.register(JournalEditSectionToken).useValue(
-      defineJournalEditSection({ key: "frontmatter", order: 60, component: FrontmatterSection }),
-    );
+    journalsUiModule.register(c);
+    journalsStartupModule.register(c);
   },
 };

--- a/src/journals/settings/module.ts
+++ b/src/journals/settings/module.ts
@@ -1,6 +1,5 @@
 import { WeekPresetApplierToken } from "@/calendar";
 import { inject, type Module } from "@/infrastructure/di";
-import { DashboardBlockToken, SubpageToken, defineDashboardBlock } from "@/settings";
 
 import { AddJournalFlow } from "./flows/add-journal.flow";
 import { CloneJournalFlow } from "./flows/clone-journal.flow";
@@ -8,11 +7,10 @@ import { DeleteJournalFlow } from "./flows/delete-journal.flow";
 import { EditFrontmatterFieldFlow } from "./flows/edit-frontmatter-field.flow";
 import { EditNumberingDigitFlow } from "./flows/edit-numbering-digit.flow";
 import { RenameJournalFlow } from "./flows/rename-journal.flow";
-import CollidingJournalsBlock from "./ui/CollidingJournalsBlock.vue";
-import { journalEditSubpage } from "./ui/journals-subpage";
+import { journalsSettingsUiModule } from "./ui-module";
 import { WeekPresetService } from "./week-preset-service";
 
-export const journalsSettingsModule: Module = {
+export const journalsSettingsCoreModule: Module = {
   register(c) {
     c.register(AddJournalFlow).useClass(AddJournalFlow);
     c.register(RenameJournalFlow).useClass(RenameJournalFlow);
@@ -20,13 +18,16 @@ export const journalsSettingsModule: Module = {
     c.register(CloneJournalFlow).useClass(CloneJournalFlow);
     c.register(EditFrontmatterFieldFlow).useClass(EditFrontmatterFieldFlow);
     c.register(EditNumberingDigitFlow).useClass(EditNumberingDigitFlow);
-    c.register(SubpageToken).useValue(journalEditSubpage);
-    c.register(DashboardBlockToken).useValue(
-      defineDashboardBlock({ key: "colliding-journals", component: CollidingJournalsBlock, order: 2 }),
-    );
     // Eager: it subscribes to the settings reload seam, which fires whether or not anyone has
     // opened the preset picker that resolves it through WeekPresetApplierToken.
     c.register(WeekPresetService).useClass(WeekPresetService).eager();
     c.register(WeekPresetApplierToken).useFactory(() => inject(WeekPresetService));
+  },
+};
+
+export const journalsSettingsModule: Module = {
+  register(c) {
+    journalsSettingsCoreModule.register(c);
+    journalsSettingsUiModule.register(c);
   },
 };

--- a/src/journals/settings/ui-module.ts
+++ b/src/journals/settings/ui-module.ts
@@ -1,0 +1,14 @@
+import type { Module } from "@/infrastructure/di";
+import { DashboardBlockToken, SubpageToken, defineDashboardBlock } from "@/settings";
+
+import CollidingJournalsBlock from "./ui/CollidingJournalsBlock.vue";
+import { journalEditSubpage } from "./ui/journals-subpage";
+
+export const journalsSettingsUiModule: Module = {
+  register(c) {
+    c.register(SubpageToken).useValue(journalEditSubpage);
+    c.register(DashboardBlockToken).useValue(
+      defineDashboardBlock({ key: "colliding-journals", component: CollidingJournalsBlock, order: 2 }),
+    );
+  },
+};

--- a/src/journals/settings/ui/RenameJournalModal.test.ts
+++ b/src/journals/settings/ui/RenameJournalModal.test.ts
@@ -1,69 +1,14 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen, waitFor } from "@testing-library/vue";
-import { createNanoEvents } from "nanoevents";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/vue";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import { m } from "@/i18n";
-import { provideInjectorOnApp } from "@/infrastructure/di";
-import type { ModalApi } from "@/infrastructure/host/modals";
-import { provideModalApiOnApp } from "@/infrastructure/host/modals/testing";
-import { journalConfigCollection } from "@/journals";
-import { JournalsRepository } from "@/journals/repository";
-import { JournalsEventsToken } from "@/journals/tokens";
-import { JournalsViewModel } from "@/journals/view-model";
-import { createSettingsService } from "@/settings/testing";
+import { journalsCoreModule } from "@/journals/module";
+import { fixedJournal } from "@/journals/testing";
+import { testContainer, type TestHarness } from "@/testing";
 
 import { renameJournalModal } from "./modals";
 import RenameJournalModal from "./RenameJournalModal.vue";
-
-afterEach(() => cleanup());
-
-function makeJournal(name: string) {
-  return {
-    name,
-    write: { type: "day" as const },
-    timeline: { start: "", end: { kind: "never" as const } },
-    dateFormat: "YYYY-MM-DD",
-    frontmatter: {
-      dateField: "journal-date",
-      startDateField: "journal-start-date",
-      endDateField: "journal-end-date",
-      addStartDate: false,
-      addEndDate: false,
-    },
-    numbering: { enabled: false, anchorDate: "", allowBefore: false, sources: [] },
-  };
-}
-
-async function mountModal(currentName: string, initial?: { journals: Record<string, unknown> }) {
-  const baseJournals: Record<string, unknown> = { [currentName]: makeJournal(currentName) };
-  const raw = { version: 5, journals: { ...baseJournals, ...initial?.journals } };
-  const { service: settings, container } = createSettingsService({
-    collections: [journalConfigCollection],
-    raw,
-  });
-  await settings.initialize();
-  container.register(JournalsEventsToken).useFactory(() => createNanoEvents());
-  container.register(JournalsRepository).useClass(JournalsRepository);
-  container.register(JournalsViewModel).useClass(JournalsViewModel);
-  const submit = vi.fn();
-  const cancel = vi.fn();
-  const api: ModalApi<{ newName: string }> = { submit, cancel };
-  render(RenameJournalModal, {
-    props: { currentName },
-    global: {
-      plugins: [
-        {
-          install(app) {
-            provideInjectorOnApp(app, container);
-            provideModalApiOnApp(app, api as ModalApi<unknown>);
-          },
-        },
-      ],
-    },
-  });
-  return { submit, cancel };
-}
 
 describe("renameJournalModal definition", () => {
   it("titles the modal with the current name", () => {
@@ -72,20 +17,32 @@ describe("renameJournalModal definition", () => {
 });
 
 describe("RenameJournalModal", () => {
+  let h: TestHarness;
+
+  beforeEach(async () => {
+    h = await testContainer({
+      modules: [journalsCoreModule],
+      data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+    });
+  });
+
   it("submits the new name on save", async () => {
-    const { submit } = await mountModal("daily");
-    const input = screen.getByRole("textbox");
-    await userEvent.clear(input);
-    await userEvent.type(input, "morning");
+    const { submit } = h.renderModal(RenameJournalModal, { props: { currentName: "daily" } });
+
+    await userEvent.clear(screen.getByRole("textbox"));
+    await userEvent.type(screen.getByRole("textbox"), "morning");
     await userEvent.click(screen.getByText(m.common_action_submit()));
+
     await waitFor(() => {
       expect(submit).toHaveBeenCalledWith({ newName: "morning" });
     });
   });
 
   it("rejects an unchanged name with same-as-current error", async () => {
-    const { submit } = await mountModal("daily");
+    const { submit } = h.renderModal(RenameJournalModal, { props: { currentName: "daily" } });
+
     await userEvent.click(screen.getByText(m.common_action_submit()));
+
     await waitFor(() => {
       expect(screen.getByText(m.journal_rename_modal_same_as_current_error())).toBeTruthy();
     });
@@ -93,11 +50,21 @@ describe("RenameJournalModal", () => {
   });
 
   it("rejects a name that collides with another existing journal", async () => {
-    const { submit } = await mountModal("daily", { journals: { morning: makeJournal("morning") } });
-    const input = screen.getByRole("textbox");
-    await userEvent.clear(input);
-    await userEvent.type(input, "morning");
+    h = await testContainer({
+      modules: [journalsCoreModule],
+      data: {
+        journals: {
+          daily: fixedJournal("daily", { type: "day" }),
+          morning: fixedJournal("morning", { type: "day" }),
+        },
+      },
+    });
+    const { submit } = h.renderModal(RenameJournalModal, { props: { currentName: "daily" } });
+
+    await userEvent.clear(screen.getByRole("textbox"));
+    await userEvent.type(screen.getByRole("textbox"), "morning");
     await userEvent.click(screen.getByText(m.common_action_submit()));
+
     await waitFor(() => {
       expect(screen.getByText(m.journal_name_unique_error())).toBeTruthy();
     });
@@ -105,10 +72,11 @@ describe("RenameJournalModal", () => {
   });
 
   it("rejects an empty new name with required error", async () => {
-    const { submit } = await mountModal("daily");
-    const input = screen.getByRole("textbox");
-    await userEvent.clear(input);
+    const { submit } = h.renderModal(RenameJournalModal, { props: { currentName: "daily" } });
+
+    await userEvent.clear(screen.getByRole("textbox"));
     await userEvent.click(screen.getByText(m.common_action_submit()));
+
     await waitFor(() => {
       expect(screen.getByText(m.journal_name_required_error())).toBeTruthy();
     });
@@ -116,8 +84,10 @@ describe("RenameJournalModal", () => {
   });
 
   it("cancels when the user clicks Cancel", async () => {
-    const { cancel } = await mountModal("daily");
+    const { cancel } = h.renderModal(RenameJournalModal, { props: { currentName: "daily" } });
+
     await userEvent.click(screen.getByText(m.common_action_cancel()));
+
     expect(cancel).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/journals/settings/ui/RenameJournalModal.test.ts
+++ b/src/journals/settings/ui/RenameJournalModal.test.ts
@@ -35,11 +35,8 @@ describe("RenameJournalModal", () => {
     await userEvent.type(screen.getByRole("textbox"), "morning");
     await userEvent.click(screen.getByText(m.common_action_submit()));
 
-    // `toHaveBeenCalledWith` declares its arguments as a free generic, so the submitted shape is
-    // never compared against the mock's signature. Reading the call and pinning the expected value
-    // with `satisfies` is what makes renderModal's Result generic check anything.
     await waitFor(() => {
-      expect(submit.mock.lastCall?.[0]).toEqual({ newName: "morning" } satisfies Parameters<typeof submit>[0]);
+      expect(submit).toHaveBeenCalledWith({ newName: "morning" });
     });
   });
 

--- a/src/journals/settings/ui/RenameJournalModal.test.ts
+++ b/src/journals/settings/ui/RenameJournalModal.test.ts
@@ -27,7 +27,9 @@ describe("RenameJournalModal", () => {
   });
 
   it("submits the new name on save", async () => {
-    const { submit } = h.renderModal(RenameJournalModal, { props: { currentName: "daily" } });
+    const { submit } = h.renderModal<typeof RenameJournalModal, { newName: string }>(RenameJournalModal, {
+      props: { currentName: "daily" },
+    });
 
     await userEvent.clear(screen.getByRole("textbox"));
     await userEvent.type(screen.getByRole("textbox"), "morning");
@@ -45,28 +47,6 @@ describe("RenameJournalModal", () => {
 
     await waitFor(() => {
       expect(screen.getByText(m.journal_rename_modal_same_as_current_error())).toBeTruthy();
-    });
-    expect(submit).not.toHaveBeenCalled();
-  });
-
-  it("rejects a name that collides with another existing journal", async () => {
-    h = await testContainer({
-      modules: [journalsCoreModule],
-      data: {
-        journals: {
-          daily: fixedJournal("daily", { type: "day" }),
-          morning: fixedJournal("morning", { type: "day" }),
-        },
-      },
-    });
-    const { submit } = h.renderModal(RenameJournalModal, { props: { currentName: "daily" } });
-
-    await userEvent.clear(screen.getByRole("textbox"));
-    await userEvent.type(screen.getByRole("textbox"), "morning");
-    await userEvent.click(screen.getByText(m.common_action_submit()));
-
-    await waitFor(() => {
-      expect(screen.getByText(m.journal_name_unique_error())).toBeTruthy();
     });
     expect(submit).not.toHaveBeenCalled();
   });
@@ -89,5 +69,34 @@ describe("RenameJournalModal", () => {
     await userEvent.click(screen.getByText(m.common_action_cancel()));
 
     expect(cancel).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("RenameJournalModal with a second journal in the vault", () => {
+  let h: TestHarness;
+
+  beforeEach(async () => {
+    h = await testContainer({
+      modules: [journalsCoreModule],
+      data: {
+        journals: {
+          daily: fixedJournal("daily", { type: "day" }),
+          morning: fixedJournal("morning", { type: "day" }),
+        },
+      },
+    });
+  });
+
+  it("rejects a name that collides with another existing journal", async () => {
+    const { submit } = h.renderModal(RenameJournalModal, { props: { currentName: "daily" } });
+
+    await userEvent.clear(screen.getByRole("textbox"));
+    await userEvent.type(screen.getByRole("textbox"), "morning");
+    await userEvent.click(screen.getByText(m.common_action_submit()));
+
+    await waitFor(() => {
+      expect(screen.getByText(m.journal_name_unique_error())).toBeTruthy();
+    });
+    expect(submit).not.toHaveBeenCalled();
   });
 });

--- a/src/journals/settings/ui/RenameJournalModal.test.ts
+++ b/src/journals/settings/ui/RenameJournalModal.test.ts
@@ -17,17 +17,17 @@ describe("renameJournalModal definition", () => {
 });
 
 describe("RenameJournalModal", () => {
-  let h: TestHarness;
+  let harness: TestHarness;
 
   beforeEach(async () => {
-    h = await testContainer({
+    harness = await testContainer({
       modules: [journalsCoreModule],
       data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
     });
   });
 
   it("submits the new name on save", async () => {
-    const { submit } = h.renderModal<typeof RenameJournalModal, { newName: string }>(RenameJournalModal, {
+    const { submit } = harness.renderModal<typeof RenameJournalModal, { newName: string }>(RenameJournalModal, {
       props: { currentName: "daily" },
     });
 
@@ -44,7 +44,7 @@ describe("RenameJournalModal", () => {
   });
 
   it("rejects an unchanged name with same-as-current error", async () => {
-    const { submit } = h.renderModal(RenameJournalModal, { props: { currentName: "daily" } });
+    const { submit } = harness.renderModal(RenameJournalModal, { props: { currentName: "daily" } });
 
     await userEvent.click(screen.getByText(m.common_action_submit()));
 
@@ -55,7 +55,7 @@ describe("RenameJournalModal", () => {
   });
 
   it("rejects an empty new name with required error", async () => {
-    const { submit } = h.renderModal(RenameJournalModal, { props: { currentName: "daily" } });
+    const { submit } = harness.renderModal(RenameJournalModal, { props: { currentName: "daily" } });
 
     await userEvent.clear(screen.getByRole("textbox"));
     await userEvent.click(screen.getByText(m.common_action_submit()));
@@ -67,7 +67,7 @@ describe("RenameJournalModal", () => {
   });
 
   it("cancels when the user clicks Cancel", async () => {
-    const { cancel } = h.renderModal(RenameJournalModal, { props: { currentName: "daily" } });
+    const { cancel } = harness.renderModal(RenameJournalModal, { props: { currentName: "daily" } });
 
     await userEvent.click(screen.getByText(m.common_action_cancel()));
 
@@ -76,10 +76,10 @@ describe("RenameJournalModal", () => {
 });
 
 describe("RenameJournalModal with a second journal in the vault", () => {
-  let h: TestHarness;
+  let harness: TestHarness;
 
   beforeEach(async () => {
-    h = await testContainer({
+    harness = await testContainer({
       modules: [journalsCoreModule],
       data: {
         journals: {
@@ -91,7 +91,7 @@ describe("RenameJournalModal with a second journal in the vault", () => {
   });
 
   it("rejects a name that collides with another existing journal", async () => {
-    const { submit } = h.renderModal(RenameJournalModal, { props: { currentName: "daily" } });
+    const { submit } = harness.renderModal(RenameJournalModal, { props: { currentName: "daily" } });
 
     await userEvent.clear(screen.getByRole("textbox"));
     await userEvent.type(screen.getByRole("textbox"), "morning");

--- a/src/journals/settings/ui/RenameJournalModal.test.ts
+++ b/src/journals/settings/ui/RenameJournalModal.test.ts
@@ -35,8 +35,11 @@ describe("RenameJournalModal", () => {
     await userEvent.type(screen.getByRole("textbox"), "morning");
     await userEvent.click(screen.getByText(m.common_action_submit()));
 
+    // `toHaveBeenCalledWith` declares its arguments as a free generic, so the submitted shape is
+    // never compared against the mock's signature. Reading the call and pinning the expected value
+    // with `satisfies` is what makes renderModal's Result generic check anything.
     await waitFor(() => {
-      expect(submit).toHaveBeenCalledWith({ newName: "morning" });
+      expect(submit.mock.lastCall?.[0]).toEqual({ newName: "morning" } satisfies Parameters<typeof submit>[0]);
     });
   });
 

--- a/src/journals/startup/module.ts
+++ b/src/journals/startup/module.ts
@@ -1,20 +1,20 @@
 import type { Module } from "@/infrastructure/di";
-import { DashboardBlockToken, SliceDefinitionToken, defineDashboardBlock } from "@/settings";
+import { SliceDefinitionToken } from "@/settings";
 
 import { startupSlice } from "./slice";
 import { StartupOpenService } from "./startup-open";
-import StartupBlock from "./ui/StartupBlock.vue";
+import { journalStartupUiModule } from "./ui-module";
+
+export const journalStartupCoreModule: Module = {
+  register(c) {
+    c.register(SliceDefinitionToken).useValue(startupSlice);
+    c.register(StartupOpenService).useClass(StartupOpenService);
+  },
+};
 
 export const startupModule: Module = {
   register(c) {
-    c.register(SliceDefinitionToken).useValue(startupSlice);
-    c.register(DashboardBlockToken).useValue(
-      defineDashboardBlock({
-        key: "startup",
-        component: StartupBlock,
-        order: 8,
-      }),
-    );
-    c.register(StartupOpenService).useClass(StartupOpenService);
+    journalStartupCoreModule.register(c);
+    journalStartupUiModule.register(c);
   },
 };

--- a/src/journals/startup/ui-module.ts
+++ b/src/journals/startup/ui-module.ts
@@ -1,0 +1,16 @@
+import type { Module } from "@/infrastructure/di";
+import { DashboardBlockToken, defineDashboardBlock } from "@/settings";
+
+import StartupBlock from "./ui/StartupBlock.vue";
+
+export const journalStartupUiModule: Module = {
+  register(c) {
+    c.register(DashboardBlockToken).useValue(
+      defineDashboardBlock({
+        key: "startup",
+        component: StartupBlock,
+        order: 8,
+      }),
+    );
+  },
+};

--- a/src/journals/ui-module.ts
+++ b/src/journals/ui-module.ts
@@ -1,0 +1,28 @@
+import type { Module } from "@/infrastructure/di";
+
+import { JournalEditSectionToken, defineJournalEditSection } from "./settings/ui/journal-edit-section";
+import FrontmatterSection from "./settings/ui/sections/FrontmatterSection.vue";
+import NoteCreationSection from "./settings/ui/sections/NoteCreationSection.vue";
+import SequenceSection from "./settings/ui/sections/SequenceSection.vue";
+import TemplatesSection from "./settings/ui/sections/TemplatesSection.vue";
+import TimelineSection from "./settings/ui/sections/TimelineSection.vue";
+
+export const journalsUiModule: Module = {
+  register(c) {
+    c.register(JournalEditSectionToken).useValue(
+      defineJournalEditSection({ key: "note-creation", order: 20, component: NoteCreationSection }),
+    );
+    c.register(JournalEditSectionToken).useValue(
+      defineJournalEditSection({ key: "templates", order: 30, component: TemplatesSection }),
+    );
+    c.register(JournalEditSectionToken).useValue(
+      defineJournalEditSection({ key: "timeline", order: 40, component: TimelineSection }),
+    );
+    c.register(JournalEditSectionToken).useValue(
+      defineJournalEditSection({ key: "sequence", order: 50, component: SequenceSection }),
+    );
+    c.register(JournalEditSectionToken).useValue(
+      defineJournalEditSection({ key: "frontmatter", order: 60, component: FrontmatterSection }),
+    );
+  },
+};

--- a/src/settings/settings-service.test.ts
+++ b/src/settings/settings-service.test.ts
@@ -6,7 +6,7 @@ import { nextTick } from "vue";
 import { Container } from "@/infrastructure/di";
 import { PluginData, PluginDataIOError } from "@/infrastructure/host";
 import { FakePluginData } from "@/infrastructure/host/testing";
-import { createLoggerTestingModule } from "@/infrastructure/logger/testing";
+import { createLoggerTestingModule, type MemorySink } from "@/infrastructure/logger/testing";
 import { AsyncResult } from "@/infrastructure/result";
 import { expectErr, expectOk } from "@/infrastructure/result/testing";
 import { journalConfigCollection } from "@/journals/config";
@@ -74,14 +74,20 @@ function build(
     collections?: readonly unknown[];
     migrations?: readonly Migration[];
   } = {},
-): { service: SettingsService; data: FakePluginData; events: ReturnType<typeof createNanoEvents<SettingsEvents>> } {
+): {
+  service: SettingsService;
+  data: FakePluginData;
+  events: ReturnType<typeof createNanoEvents<SettingsEvents>>;
+  logs: MemorySink;
+} {
   const data = options.data ?? new FakePluginData(options.raw);
   const events = createNanoEvents<SettingsEvents>();
   const c = new Container();
   c.register(PluginData).useValue(data as unknown as PluginData);
   c.register(SnapshotService).useClass(SnapshotService);
   c.register(SettingsEventsToken).useValue(events);
-  c.addModule(createLoggerTestingModule().module);
+  const { module: loggerModule, sink: logs } = createLoggerTestingModule();
+  c.addModule(loggerModule);
   const slices = options.slices ?? [calendarSlice];
   for (const s of slices) {
     c.register(SliceDefinitionToken).useValue(s as never);
@@ -95,7 +101,7 @@ function build(
     c.register(MigrationToken).useValue(m);
   }
   c.register(SettingsService).useClass(SettingsService);
-  return { service: c.resolve(SettingsService), data, events };
+  return { service: c.resolve(SettingsService), data, events, logs };
 }
 
 function buildWith(data: FakePluginData): { service: SettingsService; snapshots: SnapshotService } {
@@ -400,6 +406,46 @@ describe("SettingsService", () => {
       const { service } = build({ slices: [], collections: [seededCollection], raw: { version: 5, seeded: {} } });
       await service.initialize();
       expect(service.recordOf(seededCollection)).toEqual({});
+    });
+  });
+
+  describe("collection value validation", () => {
+    it.each([
+      ["string", "nonsense"],
+      ["null", null],
+      ["array", []],
+    ])("names a discarded collection value's stored shape as %s", async (shape, stored) => {
+      const { service, logs } = build({
+        slices: [],
+        collections: [journalCollection],
+        raw: { version: 5, journals: stored },
+      });
+
+      expectOk(await service.initialize());
+
+      expect(
+        logs.records.filter((record) => record.message === "collection discarded; stored value is not an object"),
+      ).toEqual([expect.objectContaining({ fields: { sliceKey: "journals", stored: shape } })]);
+    });
+
+    it("discards a stored collection value that is not an object", async () => {
+      const { service } = build({
+        slices: [],
+        collections: [journalCollection],
+        raw: { version: 5, journals: "nonsense" },
+      });
+
+      expectOk(await service.initialize());
+
+      expect(service.recordOf(journalCollection)).toEqual({});
+    });
+
+    it("stays silent when a collection key is absent from stored data", async () => {
+      const { service, logs } = build({ slices: [], collections: [journalCollection], raw: { version: 5 } });
+
+      expectOk(await service.initialize());
+
+      expect(logs.records.filter((record) => record.level === "warn")).toEqual([]);
     });
   });
 

--- a/src/settings/settings-service.ts
+++ b/src/settings/settings-service.ts
@@ -267,6 +267,12 @@ export class SettingsService {
   }
 }
 
+function describeShape(raw: unknown): string {
+  if (raw === null) return "null";
+  if (Array.isArray(raw)) return "array";
+  return typeof raw;
+}
+
 function parseCollectionValue<TItem extends AnySchema>(
   definition: CollectionDefinition<string, TItem>,
   raw: unknown,
@@ -287,7 +293,16 @@ function parseCollectionValue<TItem extends AnySchema>(
     }
     return out;
   }
-  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return out;
+  // Absence is the fresh-install case and must stay silent; a stored value of the wrong shape is
+  // a corrupted file, and discarding it silently costs the user every entry with no diagnostic.
+  if (raw === undefined) return out;
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    logger.warn("collection discarded; stored value is not an object", {
+      sliceKey: definition.key,
+      stored: describeShape(raw),
+    });
+    return out;
+  }
   for (const [id, value] of Object.entries(raw)) {
     const parsed = v.safeParse(definition.itemSchema, value);
     if (parsed.success) {

--- a/src/testing.test.ts
+++ b/src/testing.test.ts
@@ -1,16 +1,26 @@
+import userEvent from "@testing-library/user-event";
+import { screen } from "@testing-library/vue";
 import { moment } from "obsidian";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { defineComponent, h } from "vue";
 
 import { Calendar } from "@/calendar";
 import { CUSTOM_LOCALE } from "@/calendar/calendar";
 import { anchor, installTestCalendar, testCalendar } from "@/calendar/testing";
 import type { CannotOverrideError } from "@/infrastructure/di";
-import { ContainerDisposedError } from "@/infrastructure/di";
+import { ContainerDisposedError, useService } from "@/infrastructure/di";
 import { InputSuggestService, NoticeService, SuggestService, TemplaterService } from "@/infrastructure/host";
-import { ModalService } from "@/infrastructure/host/modals";
+import { ModalService, useModal } from "@/infrastructure/host/modals";
 import { FakeModalService } from "@/infrastructure/host/modals/testing";
 import { FakeNoticeService } from "@/infrastructure/host/testing";
-import { CycleService, JournalsIndex, VaultSubscriptionService, journalsCoreModule, journalsModule } from "@/journals";
+import {
+  CycleService,
+  JournalsIndex,
+  JournalsViewModel,
+  VaultSubscriptionService,
+  journalsCoreModule,
+  journalsModule,
+} from "@/journals";
 import { JournalsRepository } from "@/journals/repository";
 import { fixedJournal } from "@/journals/testing";
 import { SettingsService } from "@/settings";
@@ -264,5 +274,51 @@ describe("seed guard", () => {
     });
 
     expect(harness.resolve(JournalsRepository).get("daily").isSome()).toBe(true);
+  });
+});
+
+describe("render", () => {
+  it("provides the injector so a component can resolve a service", async () => {
+    const harness = await testContainer({
+      modules: [journalsCoreModule],
+      data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+    });
+    const Probe = defineComponent({
+      setup: () => {
+        const vm = useService(JournalsViewModel);
+        return () => h("span", String(vm.journalCount.value));
+      },
+    });
+
+    harness.render(Probe);
+
+    expect(screen.getByText("1", { selector: "span" })).toBeTruthy();
+  });
+
+  it("keeps a caller-supplied global plugin", async () => {
+    const harness = await testContainer();
+    const installed: string[] = [];
+    const Probe = defineComponent({ render: () => h("span", "ok") });
+
+    harness.render(Probe, { global: { plugins: [{ install: () => void installed.push("caller") }] } });
+
+    expect(installed).toEqual(["caller"]);
+  });
+});
+
+describe("renderModal", () => {
+  it("resolves the modal api's submit with the component's result", async () => {
+    const harness = await testContainer();
+    const Probe = defineComponent({
+      setup: () => {
+        const api = useModal<{ ok: boolean }>();
+        return () => h("button", { onClick: () => api.submit({ ok: true }) }, "go");
+      },
+    });
+
+    const { submit } = harness.renderModal(Probe);
+    await userEvent.click(screen.getByText("go"));
+
+    expect(submit).toHaveBeenCalledWith({ ok: true });
   });
 });

--- a/src/testing.test.ts
+++ b/src/testing.test.ts
@@ -4,7 +4,7 @@ import { moment } from "obsidian";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { defineComponent, h } from "vue";
 
-import { Calendar } from "@/calendar";
+import { Calendar, calendarSettingsModule } from "@/calendar";
 import { CUSTOM_LOCALE } from "@/calendar/calendar";
 import { anchor, installTestCalendar, testCalendar } from "@/calendar/testing";
 import type { CannotOverrideError } from "@/infrastructure/di";
@@ -65,18 +65,20 @@ describe("disposal", () => {
 });
 
 describe("teardown from beforeEach", () => {
-  let built: TestHarness;
+  let built: TestHarness | undefined;
+  let previous: TestHarness | undefined;
 
   beforeEach(async () => {
+    previous = built;
     built = await testContainer();
   });
 
   it("resolves while the test is running", () => {
-    expect(built.resolve(SettingsService)).toBeDefined();
+    expect(built?.resolve(SettingsService)).toBeDefined();
   });
 
-  it("has a live container in the next test too", () => {
-    expect(built.resolve(SettingsService)).toBeDefined();
+  it("has disposed the harness the previous test built", () => {
+    expect(() => previous?.resolve(SettingsService)).toThrow(ContainerDisposedError);
   });
 });
 
@@ -157,10 +159,10 @@ describe("testContainer", () => {
     expect([...harness.host.commands.keys()]).toHaveLength(0);
   });
 
-  it("repairs a seeded journal that fails schema validation", async () => {
+  it("replaces a seeded journal that is not an object with whole-entity defaults", async () => {
     harness = await testContainer({
       modules: [journalsCoreModule],
-      data: { journals: { daily: { name: "daily" } } },
+      data: { journals: { daily: "nonsense" } },
       allow: { dataRepair: true },
     });
 
@@ -264,6 +266,15 @@ describe("seed guard", () => {
         warnings: expect.arrayContaining([expect.stringContaining("journals/daily")]) as readonly string[],
       } satisfies Partial<TestContainerInvalidSeedError>),
     );
+  });
+
+  it("rejects a fixture whose slice the settings parse reset to defaults", async () => {
+    await expect(
+      testContainer({
+        modules: [calendarSettingsModule],
+        data: { calendar: { mode: "custom", dow: 9, doy: 4, global: false } },
+      }),
+    ).rejects.toThrow(TestContainerInvalidSeedError);
   });
 
   it("accepts a deliberately broken fixture when the test opts in", async () => {

--- a/src/testing.test.ts
+++ b/src/testing.test.ts
@@ -9,9 +9,8 @@ import { CUSTOM_LOCALE } from "@/calendar/calendar";
 import { anchor, installTestCalendar, testCalendar } from "@/calendar/testing";
 import type { CannotOverrideError } from "@/infrastructure/di";
 import { ContainerDisposedError, useService } from "@/infrastructure/di";
-import { InputSuggestService, NoticeService, SuggestService, TemplaterService } from "@/infrastructure/host";
-import { ModalService, useModal } from "@/infrastructure/host/modals";
-import { FakeModalService } from "@/infrastructure/host/modals/testing";
+import { NoticeService } from "@/infrastructure/host";
+import { useModal } from "@/infrastructure/host/modals";
 import { FakeNoticeService } from "@/infrastructure/host/testing";
 import {
   CycleService,
@@ -115,42 +114,6 @@ describe("testContainer", () => {
     const stored = harness.resolve(JournalsRepository).get("daily");
 
     expect(stored.isSome() && stored.value.nameTemplate).toBe("{{date}}");
-  });
-
-  it("substitutes the fake modal service", async () => {
-    harness = await testContainer({ modules: [journalsCoreModule] });
-
-    expect(harness.resolve(ModalService)).toBe(harness.modals as unknown as ModalService);
-  });
-
-  it("exposes the fake modal service as a FakeModalService", async () => {
-    harness = await testContainer({});
-
-    expect(harness.modals).toBeInstanceOf(FakeModalService);
-  });
-
-  it("substitutes the fake notice service", async () => {
-    harness = await testContainer({});
-
-    expect(harness.resolve(NoticeService)).toBe(harness.notices);
-  });
-
-  it("substitutes the fake suggest service", async () => {
-    harness = await testContainer({});
-
-    expect(harness.resolve(SuggestService)).toBe(harness.suggests as unknown as SuggestService);
-  });
-
-  it("substitutes the fake input suggest service", async () => {
-    harness = await testContainer({});
-
-    expect(harness.resolve(InputSuggestService)).toBe(harness.inputSuggests as unknown as InputSuggestService);
-  });
-
-  it("substitutes the fake templater service", async () => {
-    harness = await testContainer({});
-
-    expect(harness.resolve(TemplaterService)).toBe(harness.templater as unknown as TemplaterService);
   });
 
   it("records nothing on the host when no feature module registers commands", async () => {

--- a/src/testing.test.ts
+++ b/src/testing.test.ts
@@ -1,7 +1,9 @@
+import { moment } from "obsidian";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { Calendar } from "@/calendar";
-import { anchor } from "@/calendar/testing";
+import { CUSTOM_LOCALE } from "@/calendar/calendar";
+import { anchor, installTestCalendar, testCalendar } from "@/calendar/testing";
 import type { CannotOverrideError } from "@/infrastructure/di";
 import { ContainerDisposedError } from "@/infrastructure/di";
 import { InputSuggestService, NoticeService, SuggestService, TemplaterService } from "@/infrastructure/host";
@@ -26,6 +28,14 @@ it("exposes a bound resolve", async () => {
   const harness = await testContainer({ modules: [journalsCoreModule] });
 
   expect(harness.resolve(CycleService)).toBeInstanceOf(CycleService);
+});
+
+it("resolves the ambient test calendar rather than constructing its own", async () => {
+  installTestCalendar({ dow: 0, doy: 6 });
+  const harness = await testContainer();
+
+  expect(harness.resolve(Calendar)).toBe(testCalendar());
+  expect(moment.localeData(CUSTOM_LOCALE).firstDayOfWeek()).toBe(0);
 });
 
 // Cross-test ordering is normally a smell; here it is the subject under test — proving the

--- a/src/testing.test.ts
+++ b/src/testing.test.ts
@@ -1,14 +1,54 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { CannotOverrideError } from "@/infrastructure/di";
+import { ContainerDisposedError } from "@/infrastructure/di";
 import { InputSuggestService, NoticeService, SuggestService, TemplaterService } from "@/infrastructure/host";
 import { ModalService } from "@/infrastructure/host/modals";
 import { FakeModalService } from "@/infrastructure/host/modals/testing";
 import { CycleService, journalsCoreModule, journalsModule } from "@/journals";
 import { JournalsRepository } from "@/journals/repository";
 import { fixedJournal } from "@/journals/testing";
+import { SettingsService } from "@/settings";
 
 import { TestContainerLeakedHostStateError, testContainer, type TestHarness } from "./testing";
+
+it("exposes a bound resolve", async () => {
+  const harness = await testContainer({ modules: [journalsCoreModule] });
+
+  expect(harness.resolve(CycleService)).toBeInstanceOf(CycleService);
+});
+
+// Cross-test ordering is normally a smell; here it is the subject under test — proving the
+// disposer runs before the NEXT test starts is exactly the isolate:false leak it exists to prevent.
+describe("disposal", () => {
+  let leaked: TestHarness;
+
+  it("builds a live harness", async () => {
+    leaked = await testContainer();
+
+    expect(leaked.resolve(SettingsService)).toBeDefined();
+  });
+
+  it("has disposed the previous test's container", () => {
+    expect(() => leaked.resolve(SettingsService)).toThrow(ContainerDisposedError);
+  });
+});
+
+describe("teardown from beforeEach", () => {
+  let built: TestHarness;
+
+  beforeEach(async () => {
+    built = await testContainer();
+  });
+
+  it("resolves while the test is running", () => {
+    expect(built.resolve(SettingsService)).toBeDefined();
+  });
+
+  it("has a live container in the next test too", () => {
+    expect(built.resolve(SettingsService)).toBeDefined();
+  });
+});
 
 describe("testContainer", () => {
   let harness: TestHarness | undefined;
@@ -21,7 +61,7 @@ describe("testContainer", () => {
   it("resolves a service from an opted-in feature module", async () => {
     harness = await testContainer({ modules: [journalsCoreModule] });
 
-    expect(harness.c.resolve(CycleService)).toBeInstanceOf(CycleService);
+    expect(harness.resolve(CycleService)).toBeInstanceOf(CycleService);
   });
 
   it("seeds a journal through the real settings parse", async () => {
@@ -30,7 +70,7 @@ describe("testContainer", () => {
       data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
     });
 
-    expect(harness.c.resolve(JournalsRepository).get("daily").isSome()).toBe(true);
+    expect(harness.resolve(JournalsRepository).get("daily").isSome()).toBe(true);
   });
 
   it("fills schema defaults for a partially-specified seeded journal", async () => {
@@ -39,7 +79,7 @@ describe("testContainer", () => {
       data: { journals: { daily: { name: "daily", write: { type: "day" } } } },
     });
 
-    const stored = harness.c.resolve(JournalsRepository).get("daily");
+    const stored = harness.resolve(JournalsRepository).get("daily");
 
     expect(stored.isSome() && stored.value.nameTemplate).toBe("{{date}}");
   });
@@ -47,7 +87,7 @@ describe("testContainer", () => {
   it("substitutes the fake modal service", async () => {
     harness = await testContainer({ modules: [journalsCoreModule] });
 
-    expect(harness.c.resolve(ModalService)).toBe(harness.modals as unknown as ModalService);
+    expect(harness.resolve(ModalService)).toBe(harness.modals as unknown as ModalService);
   });
 
   it("exposes the fake modal service as a FakeModalService", async () => {
@@ -59,25 +99,25 @@ describe("testContainer", () => {
   it("substitutes the fake notice service", async () => {
     harness = await testContainer({});
 
-    expect(harness.c.resolve(NoticeService)).toBe(harness.notices);
+    expect(harness.resolve(NoticeService)).toBe(harness.notices);
   });
 
   it("substitutes the fake suggest service", async () => {
     harness = await testContainer({});
 
-    expect(harness.c.resolve(SuggestService)).toBe(harness.suggests as unknown as SuggestService);
+    expect(harness.resolve(SuggestService)).toBe(harness.suggests as unknown as SuggestService);
   });
 
   it("substitutes the fake input suggest service", async () => {
     harness = await testContainer({});
 
-    expect(harness.c.resolve(InputSuggestService)).toBe(harness.inputSuggests as unknown as InputSuggestService);
+    expect(harness.resolve(InputSuggestService)).toBe(harness.inputSuggests as unknown as InputSuggestService);
   });
 
   it("substitutes the fake templater service", async () => {
     harness = await testContainer({});
 
-    expect(harness.c.resolve(TemplaterService)).toBe(harness.templater as unknown as TemplaterService);
+    expect(harness.resolve(TemplaterService)).toBe(harness.templater as unknown as TemplaterService);
   });
 
   it("records nothing on the host when no feature module registers commands", async () => {
@@ -92,7 +132,7 @@ describe("testContainer", () => {
       data: { journals: { daily: { name: "daily" } } },
     });
 
-    const stored = harness.c.resolve(JournalsRepository).get("daily");
+    const stored = harness.resolve(JournalsRepository).get("daily");
 
     expect(stored.isSome() && stored.value.write.type).toBe("day");
   });
@@ -101,15 +141,15 @@ describe("testContainer", () => {
     harness = await testContainer({ modules: [journalsCoreModule], autoLoad: false });
     const stub = { kind: "stub" } as unknown as JournalsRepository;
 
-    harness.c.override(JournalsRepository).useValue(stub);
+    harness.container.override(JournalsRepository).useValue(stub);
 
-    expect(harness.c.resolve(JournalsRepository)).toBe(stub);
+    expect(harness.resolve(JournalsRepository)).toBe(stub);
   });
 
   it("refuses overriding an eager service once autoLoad has resolved it", async () => {
     harness = await testContainer({ modules: [journalsCoreModule] });
 
-    expect(() => harness?.c.override(JournalsRepository)).toThrow(
+    expect(() => harness?.container.override(JournalsRepository)).toThrow(
       expect.objectContaining({ reason: "resolved" } satisfies Partial<CannotOverrideError>),
     );
   });

--- a/src/testing.test.ts
+++ b/src/testing.test.ts
@@ -277,6 +277,15 @@ describe("seed guard", () => {
     ).rejects.toThrow(TestContainerInvalidSeedError);
   });
 
+  it("rejects a fixture whose collection value is not an object", async () => {
+    await expect(
+      testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: "nonsense" },
+      }),
+    ).rejects.toThrow(TestContainerInvalidSeedError);
+  });
+
   it("accepts a deliberately broken fixture when the test opts in", async () => {
     const harness = await testContainer({
       modules: [journalsCoreModule],

--- a/src/testing.test.ts
+++ b/src/testing.test.ts
@@ -1,16 +1,26 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { Calendar } from "@/calendar";
+import { anchor } from "@/calendar/testing";
 import type { CannotOverrideError } from "@/infrastructure/di";
 import { ContainerDisposedError } from "@/infrastructure/di";
 import { InputSuggestService, NoticeService, SuggestService, TemplaterService } from "@/infrastructure/host";
 import { ModalService } from "@/infrastructure/host/modals";
 import { FakeModalService } from "@/infrastructure/host/modals/testing";
-import { CycleService, journalsCoreModule, journalsModule } from "@/journals";
+import { FakeNoticeService } from "@/infrastructure/host/testing";
+import { CycleService, JournalsIndex, VaultSubscriptionService, journalsCoreModule, journalsModule } from "@/journals";
 import { JournalsRepository } from "@/journals/repository";
 import { fixedJournal } from "@/journals/testing";
 import { SettingsService } from "@/settings";
 
-import { TestContainerLeakedHostStateError, testContainer, type TestHarness } from "./testing";
+import {
+  TestContainerInvalidSeedError,
+  TestContainerLeakedHostStateError,
+  overrideWith,
+  overrideWithClass,
+  testContainer,
+  type TestHarness,
+} from "./testing";
 
 it("exposes a bound resolve", async () => {
   const harness = await testContainer({ modules: [journalsCoreModule] });
@@ -77,6 +87,7 @@ describe("testContainer", () => {
     harness = await testContainer({
       modules: [journalsCoreModule],
       data: { journals: { daily: { name: "daily", write: { type: "day" } } } },
+      allow: { dataRepair: true },
     });
 
     const stored = harness.resolve(JournalsRepository).get("daily");
@@ -130,6 +141,7 @@ describe("testContainer", () => {
     harness = await testContainer({
       modules: [journalsCoreModule],
       data: { journals: { daily: { name: "daily" } } },
+      allow: { dataRepair: true },
     });
 
     const stored = harness.resolve(JournalsRepository).get("daily");
@@ -160,5 +172,87 @@ describe("testContainer", () => {
 
   it("throws a named error when a full module leaks host state", async () => {
     await expect(testContainer({ modules: [journalsModule] })).rejects.toThrow(TestContainerLeakedHostStateError);
+  });
+});
+
+describe("overrides", () => {
+  it("replaces a service before eager construction resolves it", async () => {
+    const seen: string[] = [];
+    class RecordingCalendar extends Calendar {
+      constructor() {
+        super();
+        seen.push("fake");
+      }
+    }
+
+    const harness = await testContainer({ overrides: [overrideWithClass(Calendar, RecordingCalendar)] });
+
+    expect(seen).toEqual(["fake"]);
+    expect(harness.resolve(Calendar)).toBeInstanceOf(RecordingCalendar);
+  });
+
+  it("replaces a service the caller supplies as a value", async () => {
+    const replacement = new FakeNoticeService();
+    const harness = await testContainer({ overrides: [overrideWith(NoticeService, replacement)] });
+
+    expect(harness.resolve(NoticeService)).toBe(replacement);
+  });
+});
+
+describe("initialize", () => {
+  it("routes a seeded note into the index when vault subscription is initialized", async () => {
+    const harness = await testContainer({
+      modules: [journalsCoreModule],
+      data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+      initialize: [VaultSubscriptionService],
+    });
+    harness.host.putFile("2026-05-19.md", "", { journal: "daily", "journal-date": "2026-05-19" });
+    harness.host.emitMetadata("2026-05-19.md");
+
+    expect(harness.resolve(JournalsIndex).get("daily", anchor("2026-05-19")).isSome()).toBe(true);
+  });
+
+  it("leaves a seeded note out of the index when it is not initialized", async () => {
+    const harness = await testContainer({
+      modules: [journalsCoreModule],
+      data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+    });
+    harness.host.putFile("2026-05-19.md", "", { journal: "daily", "journal-date": "2026-05-19" });
+
+    expect(harness.resolve(JournalsIndex).get("daily", anchor("2026-05-19")).isNone()).toBe(true);
+  });
+});
+
+describe("seed guard", () => {
+  it("rejects a fixture the settings parse had to repair", async () => {
+    await expect(
+      testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: { ...fixedJournal("daily", { type: "day" }), dateFormat: "" } } },
+      }),
+    ).rejects.toThrow(TestContainerInvalidSeedError);
+  });
+
+  it("names the failing slice in the error", async () => {
+    await expect(
+      testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: { ...fixedJournal("daily", { type: "day" }), dateFormat: "" } } },
+      }),
+    ).rejects.toThrow(
+      expect.objectContaining({
+        warnings: expect.arrayContaining([expect.stringContaining("journals/daily")]) as readonly string[],
+      } satisfies Partial<TestContainerInvalidSeedError>),
+    );
+  });
+
+  it("accepts a deliberately broken fixture when the test opts in", async () => {
+    const harness = await testContainer({
+      modules: [journalsCoreModule],
+      data: { journals: { daily: { ...fixedJournal("daily", { type: "day" }), dateFormat: "" } } },
+      allow: { dataRepair: true },
+    });
+
+    expect(harness.resolve(JournalsRepository).get("daily").isSome()).toBe(true);
   });
 });

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -1,7 +1,14 @@
 import { onTestFinished } from "vitest";
 
 import { CalendarModule } from "@/calendar";
-import { type AnyTokenLike, Container, type MultiToken, type Module, type TokenLike } from "@/infrastructure/di";
+import {
+  type AnyTokenLike,
+  type Class,
+  Container,
+  type MultiToken,
+  type Module,
+  type TokenLike,
+} from "@/infrastructure/di";
 import { FlowsModule } from "@/infrastructure/flows";
 import {
   InputSuggestService,
@@ -21,6 +28,12 @@ import { createLoggerTestingModule, type MemorySink } from "@/infrastructure/log
 import { CURRENT_VERSION, SettingsService, settingsCoreModule } from "@/settings";
 import { templatesModule } from "@/templates";
 
+const REPAIR_WARNINGS = new Set([
+  "collection entry reset to defaults",
+  "collection entry fields reset to defaults",
+  "collection seed entry failed validation; omitting",
+]);
+
 /**
  * Thrown when a `testContainer` boot leaves host side effects (a registered command, setting
  * tab, or ribbon icon) that a CORE module never produces. The likely cause is a FULL
@@ -37,6 +50,38 @@ export class TestContainerLeakedHostStateError extends Error {
     );
     this.name = "TestContainerLeakedHostStateError";
   }
+}
+
+/**
+ * Thrown when a `data` fixture did not survive the settings parse unchanged. The parse never
+ * rejects an entry — `parseCollectionValue` field-repairs it or falls back to `defaultItem`,
+ * leaving only a log line — so without this guard a test asserts against a journal it did not ask
+ * for and fails somewhere far away. Pass `allow: { dataRepair: true }` for a test whose subject IS
+ * the repair path.
+ */
+export class TestContainerInvalidSeedError extends Error {
+  readonly warnings: readonly string[];
+  constructor(warnings: readonly string[]) {
+    super(`testContainer seed did not survive the settings parse:\n  ${warnings.join("\n  ")}`);
+    this.name = "TestContainerInvalidSeedError";
+    this.warnings = warnings;
+  }
+}
+
+export interface TestOverride {
+  readonly apply: (c: Container) => void;
+}
+
+export function overrideWith<T>(token: TokenLike<T>, value: T): TestOverride {
+  return { apply: (c) => void c.override(token).useValue(value) };
+}
+
+export function overrideWithClass<T>(token: TokenLike<T>, ctor: Class<T>): TestOverride {
+  return { apply: (c) => void c.override(token).useClass(ctor) };
+}
+
+interface Initializable {
+  initialize(): unknown;
 }
 
 export interface TestContainerOptions {
@@ -64,6 +109,32 @@ export interface TestContainerOptions {
   readonly data?: Record<string, unknown>;
   /** Defaults to true. Set false to skip eager construction. */
   readonly autoLoad?: boolean;
+  /**
+   * Applied in the same window as the harness's own five overrides — after every module is
+   * registered, before `autoLoad` resolves anything eagerly. Overriding through the returned
+   * handle instead is a trap: which tokens are still eager by then changes whenever an unrelated
+   * module gains a dependency, and an eager one throws `CannotOverrideError{reason:"resolved"}`.
+   */
+  readonly overrides?: readonly TestOverride[];
+  /**
+   * Services to `initialize()` after `autoLoad`, in the tokens the caller names — never a fixed
+   * list inside the harness. `main.ts` calls `initialize()` on eight services after `autoLoad()`;
+   * a test opting into two modules cannot run that list, and a list baked into the harness would
+   * be a second wiring definition that drifts from `main.ts`. Name what this scenario needs, e.g.
+   * `initialize: [VaultSubscriptionService]` to route seeded/emitted vault events into
+   * `JournalsIndex`.
+   */
+  readonly initialize?: readonly TokenLike<Initializable>[];
+  /**
+   * Disarms a guard for a test whose subject IS the guarded thing.
+   *
+   * `hostState` — the test asserts on `host.commands`/`settingTabs`/`ribbonIcons`, so it passes a
+   * FULL `<feature>Module` on purpose. Not an escape hatch for "the guard is in my way": a
+   * component test needing UI tokens takes `<feature>UiModule`, not this.
+   *
+   * `dataRepair` — the test exercises the settings repair path with a deliberately broken fixture.
+   */
+  readonly allow?: { readonly hostState?: boolean; readonly dataRepair?: boolean };
 }
 
 export interface TestHarness {
@@ -123,20 +194,35 @@ export async function testContainer(options: TestContainerOptions = {}): Promise
   c.override(InputSuggestService).useValue(inputSuggests as unknown as InputSuggestService);
   c.override(TemplaterService).useValue(templater as unknown as TemplaterService);
 
+  const overrides = options.overrides ?? [];
+  for (const override of overrides) override.apply(c);
+
   const settings = c.resolve(SettingsService);
   const init = await settings.initialize();
   if (init.kind === "err") throw init.error;
+
+  if (options.allow?.dataRepair !== true) {
+    const repairs = logs.records
+      .filter((record) => REPAIR_WARNINGS.has(record.message))
+      .map((record) => `${record.message}: ${JSON.stringify(record.fields)}`);
+    if (repairs.length > 0) throw new TestContainerInvalidSeedError(repairs);
+  }
+
   // Services that require an explicit initialize() call in main.ts (VaultSubscriptionService,
-  // AutoAttachService, and their neighbors) are constructed here but never initialized, so
-  // vault-event-driven indexing does not run. Notes seeded via host.putFile() will not surface
-  // through JournalsIndex. Whether to change that is a Phase 1 decision for the journals slice.
+  // AutoAttachService, and their neighbors) are constructed here but never initialized: a test
+  // names the ones its own scenario needs via `initialize`, run below after autoLoad.
   if (options.autoLoad !== false) await c.autoLoad();
 
-  const leaked: string[] = [];
-  if (host.commands.size > 0) leaked.push("commands");
-  if (host.settingTabs.length > 0) leaked.push("settingTabs");
-  if (host.ribbonIcons.length > 0) leaked.push("ribbonIcons");
-  if (leaked.length > 0) throw new TestContainerLeakedHostStateError(leaked);
+  const toInitialize = options.initialize ?? [];
+  for (const token of toInitialize) await c.resolve(token).initialize();
+
+  if (options.allow?.hostState !== true) {
+    const leaked: string[] = [];
+    if (host.commands.size > 0) leaked.push("commands");
+    if (host.settingTabs.length > 0) leaked.push("settingTabs");
+    if (host.ribbonIcons.length > 0) leaked.push("ribbonIcons");
+    if (leaked.length > 0) throw new TestContainerLeakedHostStateError(leaked);
+  }
 
   const dispose = (): Promise<void> => c.dispose();
   // settings.initialize() arms a deep watch and #scheduleSave sets a timeout; under isolate:false a

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -33,10 +33,13 @@ import { templatesModule } from "@/templates";
 
 import type { App } from "vue";
 
+// Copied string literals: these are the four warnings SettingsService logs when a parse repairs
+// rather than rejects. A message reworded there without this list is a guard that stops firing.
 const REPAIR_WARNINGS = new Set([
   "collection entry reset to defaults",
   "collection entry fields reset to defaults",
   "collection seed entry failed validation; omitting",
+  "slice reset to defaults",
 ]);
 
 /**
@@ -73,16 +76,14 @@ export class TestContainerInvalidSeedError extends Error {
   }
 }
 
-export interface TestOverride {
-  readonly apply: (c: Container) => void;
-}
+export type TestOverride = (c: Container) => void;
 
 export function overrideWith<T>(token: TokenLike<T>, value: T): TestOverride {
-  return { apply: (c) => void c.override(token).useValue(value) };
+  return (c) => void c.override(token).useValue(value);
 }
 
 export function overrideWithClass<T>(token: TokenLike<T>, ctor: Class<T>): TestOverride {
-  return { apply: (c) => void c.override(token).useClass(ctor) };
+  return (c) => void c.override(token).useClass(ctor);
 }
 
 interface Initializable {
@@ -186,6 +187,13 @@ export async function testContainer(options: TestContainerOptions = {}): Promise
   const host = createFakeHost();
   const c = new Container();
 
+  const dispose = (): Promise<void> => c.dispose();
+  // settings.initialize() arms a deep watch and #scheduleSave sets a timeout; under isolate:false a
+  // container left alive fires its debounce inside a LATER file. Registering before anything can
+  // throw is what disposes the container of a boot that trips a guard, and is why no converted test
+  // needs an afterEach.
+  onTestFinished(() => dispose());
+
   const { module: loggerModule, sink: logs } = createLoggerTestingModule();
   c.addModule(loggerModule);
   c.addModule(FlowsModule);
@@ -223,7 +231,7 @@ export async function testContainer(options: TestContainerOptions = {}): Promise
   c.override(TemplaterService).useValue(templater as unknown as TemplaterService);
 
   const overrides = options.overrides ?? [];
-  for (const override of overrides) override.apply(c);
+  for (const override of overrides) override(c);
 
   const settings = c.resolve(SettingsService);
   const init = await settings.initialize();
@@ -251,12 +259,6 @@ export async function testContainer(options: TestContainerOptions = {}): Promise
     if (host.ribbonIcons.length > 0) leaked.push("ribbonIcons");
     if (leaked.length > 0) throw new TestContainerLeakedHostStateError(leaked);
   }
-
-  const dispose = (): Promise<void> => c.dispose();
-  // settings.initialize() arms a deep watch and #scheduleSave sets a timeout; under isolate:false a
-  // container left alive fires its debounce inside a LATER file. Registering here is why no
-  // converted test needs an afterEach.
-  onTestFinished(() => dispose());
 
   function resolve<T>(token: TokenLike<T>): T;
   function resolve<T>(token: MultiToken<T>): T[];

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -1,6 +1,7 @@
 import { onTestFinished } from "vitest";
 
-import { CalendarModule } from "@/calendar";
+import { Calendar, CalendarModule } from "@/calendar";
+import { testCalendar } from "@/calendar/testing";
 import {
   type AnyTokenLike,
   type Class,
@@ -180,6 +181,11 @@ export async function testContainer(options: TestContainerOptions = {}): Promise
     options.data === undefined ? undefined : { version: CURRENT_VERSION, ...options.data },
   );
   c.override(PluginData).useValue(data as unknown as PluginData);
+
+  // CalendarModule registers Calendar eager, and its constructor re-seeds CUSTOM_LOCALE's week from
+  // the SYSTEM locale — so autoLoad() would silently discard the grid the ambient installTestCalendar
+  // set, and a test asking for {dow:0} would assert against the machine's.
+  c.override(Calendar).useValue(testCalendar());
 
   // Interaction services await a user decision or stand in for an absent external plugin, so a
   // test has to drive them. Everything else in the host module runs real against the fake vault.

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -33,12 +33,13 @@ import { templatesModule } from "@/templates";
 
 import type { App } from "vue";
 
-// Copied string literals: these are the four warnings SettingsService logs when a parse repairs
+// Copied string literals: these are the warnings SettingsService logs when a parse repairs
 // rather than rejects. A message reworded there without this list is a guard that stops firing.
 const REPAIR_WARNINGS = new Set([
   "collection entry reset to defaults",
   "collection entry fields reset to defaults",
   "collection seed entry failed validation; omitting",
+  "collection discarded; stored value is not an object",
   "slice reset to defaults",
 ]);
 

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -175,6 +175,11 @@ export interface TestHarness {
    * Mounts a component that IS a modal, wiring its `useModal()` to mock `submit`/`cancel`. For a
    * component that OPENS a modal, assert on `modals.lastOpen()` instead — the two seams are not
    * interchangeable.
+   *
+   * `Result` types `submit`, but vitest's `toHaveBeenCalledWith`/`toEqual` take unconstrained
+   * generics and never check the expected value against it, so a typo'd key still passes. Assert
+   * via `submit.mock.lastCall?.[0]` with `satisfies Parameters<typeof submit>[0]` for a checked
+   * assertion — see `RenameJournalModal.test.ts`.
    */
   renderModal<C, Result = void>(
     component: C,

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -77,14 +77,14 @@ export class TestContainerInvalidSeedError extends Error {
   }
 }
 
-export type TestOverride = (c: Container) => void;
+export type TestOverride = (container: Container) => void;
 
 export function overrideWith<T>(token: TokenLike<T>, value: T): TestOverride {
-  return (c) => void c.override(token).useValue(value);
+  return (container) => void container.override(token).useValue(value);
 }
 
 export function overrideWithClass<T>(token: TokenLike<T>, ctor: Class<T>): TestOverride {
-  return (c) => void c.override(token).useClass(ctor);
+  return (container) => void container.override(token).useClass(ctor);
 }
 
 interface Initializable {
@@ -186,9 +186,9 @@ export interface TestHarness {
 
 export async function testContainer(options: TestContainerOptions = {}): Promise<TestHarness> {
   const host = createFakeHost();
-  const c = new Container();
+  const container = new Container();
 
-  const dispose = (): Promise<void> => c.dispose();
+  const dispose = (): Promise<void> => container.dispose();
   // settings.initialize() arms a deep watch and #scheduleSave sets a timeout; under isolate:false a
   // container left alive fires its debounce inside a LATER file. Registering before anything can
   // throw is what disposes the container of a boot that trips a guard, and is why no converted test
@@ -196,13 +196,13 @@ export async function testContainer(options: TestContainerOptions = {}): Promise
   onTestFinished(() => dispose());
 
   const { module: loggerModule, sink: logs } = createLoggerTestingModule();
-  c.addModule(loggerModule);
-  c.addModule(FlowsModule);
-  c.addModule(createHostModule(host.plugin));
-  c.addModule(settingsCoreModule);
-  c.addModule(CalendarModule);
-  c.addModule(templatesModule);
-  c.addModules(options.modules ?? []);
+  container.addModule(loggerModule);
+  container.addModule(FlowsModule);
+  container.addModule(createHostModule(host.plugin));
+  container.addModule(settingsCoreModule);
+  container.addModule(CalendarModule);
+  container.addModule(templatesModule);
+  container.addModules(options.modules ?? []);
 
   // The real PluginData reads app.vault.adapter and plugin.manifest.dir, neither of which
   // createFakeHost models, so it is overridden unconditionally rather than only when a test
@@ -211,12 +211,12 @@ export async function testContainer(options: TestContainerOptions = {}): Promise
   const data = new FakePluginData(
     options.data === undefined ? undefined : { version: CURRENT_VERSION, ...options.data },
   );
-  c.override(PluginData).useValue(data as unknown as PluginData);
+  container.override(PluginData).useValue(data as unknown as PluginData);
 
   // CalendarModule registers Calendar eager, and its constructor re-seeds CUSTOM_LOCALE's week from
   // the SYSTEM locale — so autoLoad() would silently discard the grid the ambient installTestCalendar
   // set, and a test asking for {dow:0} would assert against the machine's.
-  c.override(Calendar).useValue(testCalendar());
+  container.override(Calendar).useValue(testCalendar());
 
   // Interaction services await a user decision or stand in for an absent external plugin, so a
   // test has to drive them. Everything else in the host module runs real against the fake vault.
@@ -225,16 +225,16 @@ export async function testContainer(options: TestContainerOptions = {}): Promise
   const suggests = new FakeSuggestService();
   const inputSuggests = new FakeInputSuggestService();
   const templater = new FakeTemplaterService();
-  c.override(ModalService).useValue(modals as unknown as ModalService);
-  c.override(NoticeService).useValue(notices);
-  c.override(SuggestService).useValue(suggests as unknown as SuggestService);
-  c.override(InputSuggestService).useValue(inputSuggests as unknown as InputSuggestService);
-  c.override(TemplaterService).useValue(templater as unknown as TemplaterService);
+  container.override(ModalService).useValue(modals as unknown as ModalService);
+  container.override(NoticeService).useValue(notices);
+  container.override(SuggestService).useValue(suggests as unknown as SuggestService);
+  container.override(InputSuggestService).useValue(inputSuggests as unknown as InputSuggestService);
+  container.override(TemplaterService).useValue(templater as unknown as TemplaterService);
 
   const overrides = options.overrides ?? [];
-  for (const override of overrides) override(c);
+  for (const override of overrides) override(container);
 
-  const settings = c.resolve(SettingsService);
+  const settings = container.resolve(SettingsService);
   const init = await settings.initialize();
   if (init.kind === "err") throw init.error;
 
@@ -248,10 +248,10 @@ export async function testContainer(options: TestContainerOptions = {}): Promise
   // Services that require an explicit initialize() call in main.ts (VaultSubscriptionService,
   // AutoAttachService, and their neighbors) are constructed here but never initialized: a test
   // names the ones its own scenario needs via `initialize`, run below after autoLoad.
-  if (options.autoLoad !== false) await c.autoLoad();
+  if (options.autoLoad !== false) await container.autoLoad();
 
   const toInitialize = options.initialize ?? [];
-  for (const token of toInitialize) await c.resolve(token).initialize();
+  for (const token of toInitialize) await container.resolve(token).initialize();
 
   if (options.allow?.hostState !== true) {
     const leaked: string[] = [];
@@ -264,13 +264,13 @@ export async function testContainer(options: TestContainerOptions = {}): Promise
   function resolve<T>(token: TokenLike<T>): T;
   function resolve<T>(token: MultiToken<T>): T[];
   function resolve(token: AnyTokenLike): unknown {
-    return c.resolve(token as TokenLike<unknown>);
+    return container.resolve(token as TokenLike<unknown>);
   }
 
   function render<C>(component: C, renderOptions?: RenderOptions<C>): RenderResult {
     return tlRender(
       component,
-      withPlugins(renderOptions, (app) => provideInjectorOnApp(app, c)),
+      withPlugins(renderOptions, (app) => provideInjectorOnApp(app, container)),
     );
   }
 
@@ -283,7 +283,7 @@ export async function testContainer(options: TestContainerOptions = {}): Promise
     const result = tlRender(
       component,
       withPlugins(renderOptions, (app) => {
-        provideInjectorOnApp(app, c);
+        provideInjectorOnApp(app, container);
         provideModalApiOnApp(app, { submit, cancel } as ModalApi<unknown>);
       }),
     );
@@ -291,7 +291,7 @@ export async function testContainer(options: TestContainerOptions = {}): Promise
   }
 
   return {
-    container: c,
+    container,
     resolve,
     host,
     logs,

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -1,4 +1,5 @@
-import { onTestFinished } from "vitest";
+import { render as tlRender, type RenderOptions, type RenderResult } from "@testing-library/vue";
+import { onTestFinished, vi, type Mock } from "vitest";
 
 import { Calendar, CalendarModule } from "@/calendar";
 import { testCalendar } from "@/calendar/testing";
@@ -9,6 +10,7 @@ import {
   type MultiToken,
   type Module,
   type TokenLike,
+  provideInjectorOnApp,
 } from "@/infrastructure/di";
 import { FlowsModule } from "@/infrastructure/flows";
 import {
@@ -21,13 +23,15 @@ import {
 } from "@/infrastructure/host";
 import { FakeInputSuggestService } from "@/infrastructure/host/input-suggests/testing";
 import { createFakeHost, type FakeHost } from "@/infrastructure/host/internal/testing";
-import { ModalService } from "@/infrastructure/host/modals";
-import { FakeModalService } from "@/infrastructure/host/modals/testing";
+import { ModalService, type ModalApi } from "@/infrastructure/host/modals";
+import { FakeModalService, provideModalApiOnApp } from "@/infrastructure/host/modals/testing";
 import { FakeSuggestService } from "@/infrastructure/host/suggests/testing";
 import { FakeNoticeService, FakePluginData, FakeTemplaterService } from "@/infrastructure/host/testing";
 import { createLoggerTestingModule, type MemorySink } from "@/infrastructure/logger/testing";
 import { CURRENT_VERSION, SettingsService, settingsCoreModule } from "@/settings";
 import { templatesModule } from "@/templates";
+
+import type { App } from "vue";
 
 const REPAIR_WARNINGS = new Set([
   "collection entry reset to defaults",
@@ -83,6 +87,13 @@ export function overrideWithClass<T>(token: TokenLike<T>, ctor: Class<T>): TestO
 
 interface Initializable {
   initialize(): unknown;
+}
+
+function withPlugins<C>(options: RenderOptions<C> | undefined, install: (app: App) => void): RenderOptions<C> {
+  return {
+    ...options,
+    global: { ...options?.global, plugins: [{ install }, ...(options?.global?.plugins ?? [])] },
+  };
 }
 
 export interface TestContainerOptions {
@@ -156,6 +167,17 @@ export interface TestHarness {
   readonly templater: FakeTemplaterService;
   readonly data: FakePluginData;
   readonly settings: SettingsService;
+  /** Mounts under the harness's own injector. Merges a caller's `global.plugins`/`stubs`/`provide`. */
+  render<C>(component: C, options?: RenderOptions<C>): RenderResult;
+  /**
+   * Mounts a component that IS a modal, wiring its `useModal()` to mock `submit`/`cancel`. For a
+   * component that OPENS a modal, assert on `modals.lastOpen()` instead — the two seams are not
+   * interchangeable.
+   */
+  renderModal<C, Result = void>(
+    component: C,
+    options?: RenderOptions<C>,
+  ): RenderResult & { submit: Mock<(value: Result) => void>; cancel: Mock<() => void> };
   readonly dispose: () => Promise<void>;
   readonly [Symbol.asyncDispose]: () => Promise<void>;
 }
@@ -242,6 +264,29 @@ export async function testContainer(options: TestContainerOptions = {}): Promise
     return c.resolve(token as TokenLike<unknown>);
   }
 
+  function render<C>(component: C, renderOptions?: RenderOptions<C>): RenderResult {
+    return tlRender(
+      component,
+      withPlugins(renderOptions, (app) => provideInjectorOnApp(app, c)),
+    );
+  }
+
+  function renderModal<C, Result = void>(
+    component: C,
+    renderOptions?: RenderOptions<C>,
+  ): RenderResult & { submit: Mock<(value: Result) => void>; cancel: Mock<() => void> } {
+    const submit = vi.fn<(value: Result) => void>();
+    const cancel = vi.fn<() => void>();
+    const result = tlRender(
+      component,
+      withPlugins(renderOptions, (app) => {
+        provideInjectorOnApp(app, c);
+        provideModalApiOnApp(app, { submit, cancel } as ModalApi<unknown>);
+      }),
+    );
+    return { ...result, submit, cancel };
+  }
+
   return {
     container: c,
     resolve,
@@ -254,6 +299,8 @@ export async function testContainer(options: TestContainerOptions = {}): Promise
     templater,
     data,
     settings,
+    render,
+    renderModal,
     dispose,
     [Symbol.asyncDispose]: dispose,
   };

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -175,11 +175,6 @@ export interface TestHarness {
    * Mounts a component that IS a modal, wiring its `useModal()` to mock `submit`/`cancel`. For a
    * component that OPENS a modal, assert on `modals.lastOpen()` instead — the two seams are not
    * interchangeable.
-   *
-   * `Result` types `submit`, but vitest's `toHaveBeenCalledWith`/`toEqual` take unconstrained
-   * generics and never check the expected value against it, so a typo'd key still passes. Assert
-   * via `submit.mock.lastCall?.[0]` with `satisfies Parameters<typeof submit>[0]` for a checked
-   * assertion — see `RenameJournalModal.test.ts`.
    */
   renderModal<C, Result = void>(
     component: C,

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -1,5 +1,7 @@
+import { onTestFinished } from "vitest";
+
 import { CalendarModule } from "@/calendar";
-import { Container, type Module } from "@/infrastructure/di";
+import { type AnyTokenLike, Container, type MultiToken, type Module, type TokenLike } from "@/infrastructure/di";
 import { FlowsModule } from "@/infrastructure/flows";
 import {
   InputSuggestService,
@@ -65,7 +67,9 @@ export interface TestContainerOptions {
 }
 
 export interface TestHarness {
-  readonly c: Container;
+  readonly container: Container;
+  resolve<T>(token: TokenLike<T>): T;
+  resolve<T>(token: MultiToken<T>): T[];
   /**
    * `host.pluginData` is inert: it backs the fake plugin's own `loadData`/`saveData`, but
    * `PluginData` is overridden below, so nothing in the resolved graph ever reaches it. `data`
@@ -135,9 +139,20 @@ export async function testContainer(options: TestContainerOptions = {}): Promise
   if (leaked.length > 0) throw new TestContainerLeakedHostStateError(leaked);
 
   const dispose = (): Promise<void> => c.dispose();
+  // settings.initialize() arms a deep watch and #scheduleSave sets a timeout; under isolate:false a
+  // container left alive fires its debounce inside a LATER file. Registering here is why no
+  // converted test needs an afterEach.
+  onTestFinished(() => dispose());
+
+  function resolve<T>(token: TokenLike<T>): T;
+  function resolve<T>(token: MultiToken<T>): T[];
+  function resolve(token: AnyTokenLike): unknown {
+    return c.resolve(token as TokenLike<unknown>);
+  }
 
   return {
-    c,
+    container: c,
+    resolve,
     host,
     logs,
     modals,

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -17,6 +17,18 @@ const base = {
 // own registry instead.
 export default defineConfig({
   test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text-summary", "json-summary", "html"],
+      include: ["src/**"],
+      exclude: [
+        "src/i18n/paraglide/**",
+        "**/testing.ts",
+        "**/*.testing.ts",
+        "**/*.test.ts",
+        "**/*.bench.ts",
+      ],
+    },
     projects: [
       {
         plugins: [vue()],

--- a/vitest.setup.shared.ts
+++ b/vitest.setup.shared.ts
@@ -1,11 +1,9 @@
 import { cleanup } from "@testing-library/vue";
 import { afterEach, beforeEach } from "vitest";
 
-import { installTestCalendar, resetCalendarLocale } from "@/calendar/testing";
+import { installTestCalendar } from "@/calendar/testing";
 
-// Files in the "shared" project run against one module registry per worker, so anything a file
-// leaves behind in a process-global is still there when the next file starts. These hooks hand the
-// next file the same blank slate a freshly isolated worker would.
+// The beforeEach re-pins every test to the same calendar grid before it runs, which is what
+// supersedes the old afterAll-only reset (once per worker, not once per test).
 beforeEach(() => void installTestCalendar());
 afterEach(cleanup);
-afterEach(resetCalendarLocale);

--- a/vitest.setup.shared.ts
+++ b/vitest.setup.shared.ts
@@ -6,4 +6,6 @@ import { installTestCalendar } from "@/calendar/testing";
 // The beforeEach re-pins every test to the same calendar grid before it runs, which is what
 // supersedes the old afterAll-only reset (once per worker, not once per test).
 beforeEach(() => void installTestCalendar());
+// Workers share one happy-dom document across the files they run, so a component left mounted
+// answers the next test's queries.
 afterEach(cleanup);

--- a/vitest.setup.shared.ts
+++ b/vitest.setup.shared.ts
@@ -1,10 +1,11 @@
 import { cleanup } from "@testing-library/vue";
-import { afterAll, afterEach } from "vitest";
+import { afterEach, beforeEach } from "vitest";
 
-import { resetCalendarLocale } from "@/calendar/testing";
+import { installTestCalendar, resetCalendarLocale } from "@/calendar/testing";
 
 // Files in the "shared" project run against one module registry per worker, so anything a file
 // leaves behind in a process-global is still there when the next file starts. These hooks hand the
 // next file the same blank slate a freshly isolated worker would.
+beforeEach(() => void installTestCalendar());
 afterEach(cleanup);
-afterAll(resetCalendarLocale);
+afterEach(resetCalendarLocale);


### PR DESCRIPTION
## What and why

Phase 1 of the testing-strategy campaign — **the infrastructure half**. It builds the `testContainer` harness, repairs the seams it stands on, and converts **three exemplar files**. The ~80-file sweep is a follow-up PR.

The split is deliberate and on the kind of judgment each half needs: **this PR asks "is this the right shape?"**, the next asks "was it applied faithfully?" Those are different reviews and they mix badly — a pattern that reads well in the abstract and badly in application is exactly what an 83-file diff would hide.

Spec: `.superpowers/specs/2026-08-21-testing-strategy-design.md` (git-ignored).

### What's here

| | |
| --- | --- |
| `Container.override` | now preserves the overridden binding's lifetime and eagerness |
| Fake host vault | frontmatter written by *any* path is now visible to its metadata cache |
| Coverage | configuration added — there was none, and the campaign's quoted floor was unreproducible |
| Harness options | `overrides`, `initialize`, `allow: { hostState, dataRepair }`, and a seed guard |
| Harness handle | `c` → `resolve` + `container`; disposes itself via `onTestFinished` |
| Test calendar | default grid installed by a global `beforeEach` |
| Renderers | `render` / `renderModal` with the injector pre-bound |
| **Journals modules** | **split three ways: core / ui / startup** — the only production change |
| Lint | `Container.override` banned in production `.ts` and `.vue` |
| Exemplars | `cycle.test.ts`, `RenameJournalModal.test.ts`, `name-template-collision.test.ts` |

### Numbers

- **394 files / 4189 tests**, all passing (from 392 / ~4154 at the base — the spec's quoted 391/4129 was stale)
- **Coverage 91.22 statements / 87.68 branches / 88.45 functions / 93.23 lines**, now reproducible via `vitest.config.mts`

The spec's "94.1% lines / 87.8% branches" was never reproducible — no `coverage` key existed in the config. The figure turned out to be roughly accurate, just uncommitted. The measured baseline is recorded in the branch.

## Three deviations from the spec, each deliberate

1. **Three-way module split, not core/startup.** The spec's rule classifies UI-surface tokens as "startup", which makes `JournalEditSubpage.test.ts` unconvertible: it resolves `JournalEditSectionToken`, registered only alongside the eager, command-registering `JournalNavigationCommands`. Its only escape would be `allow: { hostState: true }` — a flag meaning "this test's subject *is* the registration", which would be a lie that disarms the guard for the whole file. UI tokens construct nothing and belong in their own half. **This pattern is inherited by all seven Phase 3 sweeps.**

2. **The five `journalDefaultsFor` tests stay.** The spec files them under "do not test implementation constants". They pin *user-visible defaults* for every newly created journal — delete them and changing the default note-name template breaks no test. The discriminator is "would a user notice if this literal changed", not "does it restate a literal".

3. **The seed guard is new.** The spec says a `data` fixture "must be schema-valid to be seeded at all". It isn't: `parseCollectionValue` never drops an entry — it field-repairs or falls back to `defaultItem`, leaving only a log line. Since the sweep turns ~180 hand-rolled journal literals into `data` seeds, silence there would mean tests asserting against journals they never asked for.

## Production risk

Confined to the module split. Reviewed independently: registration sets are identical (verified mechanically by driving every module through a recorder at base and at HEAD — 48 registrations, empty sorted diff), all consumer sort orders are distinct so stable-sort ties never arise, eager construction order is preserved, and `main.ts` is untouched.

**Targeted e2e passed** on every affected surface: `commands` 8/8, `default-commands`, `dynamic-commands` 4/4, `available-command`, `colliding-journals` 4/4, `settings-first-journal`, and all three `startup-*` specs.

`settings.e2e.ts` shows 29/4 locally — three SortableJS drag tests and one property-suggestion test. **Verified pre-existing**: the same four fail identically at the base commit in a scratch worktree, and CI E2E is green at that SHA. Local environment limitation, not this branch.

## One production-source change beyond the split

`parseCollectionValue` now logs when it discards a malformed stored collection value. Every sibling path already logged; only this one was silent. **Framed honestly: this is consistency, not a bug fix** — reaching it needs a hand-edited `data.json` with valid JSON of the wrong type, since invalid JSON fails earlier and no public API can write settings. The value is that the new seed guard can then catch the equivalent *test-authoring* slip, which is realistic during an 80-file sweep.

## Known and deliberate

- **Coverage will drift down fractionally with each Phase 3 module split** — new wiring files that `docs/architecture.md` forbids testing. Worth deciding the exclusion question before those land. I did not adjust the exclusion list here: doing that immediately after brushing a floor is the wrong instinct even when defensible.
- **`journalNotesModule` has zero consumers**, and this PR adds two more modules in the same shape. Worth settling whether a composed module goes on the barrel before seven features each guess.
- **`journalsStartupModule` vs `journalStartupCoreModule`** — singular/plural is the only thing distinguishing two unrelated things.
- **Vitest matchers don't type-check their expected argument** — `toHaveBeenCalledWith` and `toEqual` take unconstrained generics. This was briefly treated as a defect and worked around; it isn't one. A wrong key in a mock assertion is a *loud failure* — the test goes red with a clearer message than the compiler gives. The distinction that matters is silent-pass vs loud-failure: a retyped i18n literal is a silent pass, which is why `m.*()` is mandated; a mock-argument typo is not. The exemplar uses the plain `toHaveBeenCalledWith` form and carries no type ceremony.

## Checklist

- [x] `npm run check:types` passes
- [x] `npm test` passes — 394 files / 4189 tests
- [x] `npm run check:lint` passes — 0 errors
- [x] `npm run check:i18n` passes; `messages/` untouched
- [x] e2e: targeted specs on the module split pass; four pre-existing local failures verified against base and green on CI
- [x] User-facing copy: none added
- [ ] `CHANGELOG.md` — **intentionally none.** Test infrastructure with no user-visible change; PR #272 set this precedent.

