### PR TITLE
ci: make CI blockable — report checks on the PR, gate the e2e matrix behind one name

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,6 +1,18 @@
 name: Checks
 
-on: [push]
+# `pull_request` and not a bare `push`: a check run attaches to a SHA, and a fork PR's
+# head SHA only ever sees push events in the fork, so a push-only workflow never reports
+# here. Required status checks read that as permanently pending, not as skipped, and the
+# PR becomes unmergeable with no way to clear it. The `push` half stays pinned to main so
+# the merge commit is covered without running every branch push twice.
+on:
+  pull_request:
+  push:
+    branches: [main]
+    # Tags stay covered because `release.yml` triggers on one and runs only
+    # `check:types` and `test`; dropping them here would quietly narrow what a
+    # release build is checked against. See docs/releasing.md.
+    tags: ["*"]
 
 jobs:
   build:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -98,3 +98,18 @@ jobs:
           # default — so every run so far uploaded nothing and CI-only failures had no
           # screenshot and no junit XML to diagnose from.
           include-hidden-files: true
+
+  # The one fixed name for the matrix above, so branch protection can require e2e without
+  # naming its legs. `e2e (ubuntu-latest, latest/latest)` and friends are a function of the
+  # trigger — schedule and full_matrix expand the `obsidian` axis — so requiring the literal
+  # names would pin one trigger's matrix into repo settings, and any name that stops being
+  # produced hangs "Expected" forever.
+  e2e-gate:
+    if: always()
+    needs: e2e
+    runs-on: ubuntu-latest
+    steps:
+      # `needs.e2e.result` is 'success' only when every leg succeeded; a cancelled or
+      # skipped matrix must not read as a pass.
+      - if: ${{ needs.e2e.result != 'success' }}
+        run: exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,11 +52,12 @@ proceeds.
 ## Quality gates
 
 `checks.yml` runs `compile:i18n` → `check:i18n` → `check:types` → `test` →
-`check:lint` on every push (`compile:i18n` is covered in Development setup
-above). It triggers on `push`, not `pull_request`, so for a pull request from
-a fork it runs in your fork rather than as a check on the PR itself — these
-four are your real gate, not just a convenience. Run them before opening a
-pull request; the order between them doesn't matter locally:
+`check:lint` on every pull request and on every push to `main` (`compile:i18n`
+is covered in Development setup above). It reports as the `build` check, which
+— together with `e2e-gate`, the fixed name standing in for the whole e2e matrix
+— blocks the merge button until both are green. A check that is still running
+blocks it too. Run these before opening a pull request anyway; the order
+between them doesn't matter locally:
 
 ```bash
 npm run check:types   # vue-tsc, no emit

--- a/docs/e2e-testing-strategy.md
+++ b/docs/e2e-testing-strategy.md
@@ -282,7 +282,7 @@ Three deliberate clocks:
 | ------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------ |
 | Local per-task gate | `test` / `check:types` / `check:lint`                               | **Unchanged** — mock-only and fast. e2e is _not_ in it.            |
 | Local on-demand     | `npm run test:e2e`                                                  | A dev runs it when touching the integration seam. Never automatic. |
-| CI                  | `pull_request` + `push` to `main` (full suite) + nightly `schedule` | Separate job, **not** wired into the every-push `checks.yml`.      |
+| CI                  | `pull_request` + `push` to `main` (full suite) + nightly `schedule` | Separate job, **not** wired into `checks.yml`.                     |
 
 The whole stable suite runs on **every PR and every merge to `main`** — it finishes
 in well under a minute, so there is no longer a reason to split a thin smoke gate


### PR DESCRIPTION
Prep work so that "require these checks to pass" can be switched on for `main`. The repository ruleset currently carries only `deletion` and `non_fast_forward`, so a PR can be merged while CI is still running, or after it has gone red. Two things had to change before requiring checks would be safe rather than a trap.

## `checks.yml` now reports on the pull request

It triggered on a bare `push`. Check runs attach to a SHA, and a fork PR's head SHA only ever sees push events *in the fork* — so the workflow never reported here. Required status checks read a check that never arrives as **permanently pending**, not as skipped, which would leave every fork PR unmergeable with no way to clear it short of an admin bypass.

It now triggers on `pull_request`, with the `push` half pinned to `main` so the merge commit stays covered without running each branch push twice. Tags stay in the filter deliberately: `release.yml` runs only `check:types` and `test`, so dropping tag pushes would quietly narrow what a release build is checked against.

**Behavior change worth knowing:** pushes to a branch with no open PR no longer run `checks.yml`. That is the same shape `e2e.yml` already has, and the trade for not running everything twice on every PR push.

## `e2e-gate` gives the matrix one stable name

The e2e job's check names are a function of the trigger — `schedule` and `full_matrix` expand the `obsidian` axis — so requiring the literal `e2e (ubuntu-latest, latest/latest)` and friends would pin one trigger's matrix into repository settings, and any name that stopped being produced would hang "Expected" forever. `e2e-gate` passes only when every leg succeeded (`needs.e2e.result == 'success'`, so cancelled and skipped both fail it), leaving the matrix free to change.

## Docs

`CONTRIBUTING.md` documented the push-not-pull_request behavior explicitly, and the e2e strategy doc called `checks.yml` "every-push". Both updated.

## Not in this PR

Turning the rule on is a repository settings change. After this merges and both checks have reported once on `main`, requiring `build` and `e2e-gate` is what actually makes them block:

```bash
gh api -X PUT repos/srg-kostyrko/obsidian-journal/rulesets/20838581 --input - <<'EOF'
{
  "name": "main", "target": "branch", "enforcement": "active",
  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
  "rules": [
    { "type": "deletion" },
    { "type": "non_fast_forward" },
    { "type": "pull_request", "parameters": {
        "required_approving_review_count": 0,
        "dismiss_stale_reviews_on_push": false,
        "require_code_owner_review": false,
        "require_last_push_approval": false,
        "required_review_thread_resolution": false,
        "allowed_merge_methods": ["merge", "squash", "rebase"] } },
    { "type": "required_status_checks", "parameters": {
        "strict_required_status_checks_policy": false,
        "do_not_enforce_on_create": false,
        "required_status_checks": [
          { "context": "build",    "integration_id": 15368 },
          { "context": "e2e-gate", "integration_id": 15368 }
        ] } }
  ]
}
EOF
```

`strict_required_status_checks_policy` is left off: "require branches up to date" would force a rebase before every merge, but it also invalidates every other open PR's green checks on each merge, and re-running a 3-OS e2e matrix for that is a poor trade at this repo's PR volume. A merge queue is the answer if it ever stops scaling.

## Verification

Prettier clean on all four files. The real proof is this PR's own checks: `build` should now appear as a `pull_request` check rather than only as a branch-push check, and `e2e-gate` should show up green beneath the matrix.
