### PR TITLE
docs(testing): own the unit testing standard and gate on coverage

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -28,7 +28,9 @@ jobs:
       - run: npm run compile:i18n
       - run: npm run check:i18n
       - run: npm run check:types
-      - run: npm test
+      # `coverage` runs the same suite as `npm test` and adds the floor from vitest.config.mts.
+      # Running both would pay for the suite twice to get one signal.
+      - run: npm run coverage
       - run: npm run check:lint
       # The published API types are generated from src/api/public-api.ts and committed,
       # so any change to the public surface shows up as a diff in the PR that caused it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,8 @@ restate it.
 | Document                                                               | Owns                                                                                             |
 | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | [`CONTEXT.md`](CONTEXT.md)                                             | domain vocabulary — periods, journals, shelves, decorations                                      |
-| [`docs/architecture.md`](docs/architecture.md)                         | code layout, DI, `Result`/`Option`, dates and union dispatch, schemas, i18n, testing conventions |
+| [`docs/architecture.md`](docs/architecture.md)                         | code layout, DI, `Result`/`Option`, dates and union dispatch, schemas, i18n, test file locations |
+| [`docs/unit-testing-strategy.md`](docs/unit-testing-strategy.md)       | the unit and component suite — tiers, `testContainer`, fixtures, assertions, lint rules          |
 | [`docs/e2e-testing-strategy.md`](docs/e2e-testing-strategy.md)         | the e2e layer — runner, fixtures, selectors, execution model                                     |
 | [`docs/i18n-glossary.md`](docs/i18n-glossary.md)                       | translation terms, and the `check:i18n` rules that `scripts/check-i18n-glossary.mjs` enforces    |
 | [`docs/2026-07-13-ux-text-audit.md`](docs/2026-07-13-ux-text-audit.md) | user-facing copy style — sentence case, error grammar, en-US                                     |
@@ -351,26 +352,6 @@ on it.
   domain (`icons.action.edit`, `icons.entity.shelf`), never a bare Lucide
   literal. User-entered icon fields stay free-form strings, and the renderer
   keeps a `(name: string)` signature so it handles both.
-
-### Unit-suite gotchas
-
-- No `simulate*Error` queues in fakes. A test that needs an error path uses
-  `vi.spyOn` with `mockReturnValueOnce`; a baked-in queue adds a parallel state
-  machine — typed buffers, ordering, drain semantics — to every fake.
-- Skip tests whose only assertion is the framework's own contract: `instanceof`
-  on an error subclass that just calls `super()`, Promise thenable behavior, Vue
-  lifecycle, vee-validate, moment locale switching. Ask what application
-  behavior would break the test; if the answer is "only if Vue breaks", delete
-  it.
-- No wrappers around `expect()` chains, and no test-local re-implementations of
-  library factories. A narrowing helper that returns the inner value and prints
-  the actual `Err` earns its place; one that hides a matcher does not.
-- The unit suite runs `isolate: false` in a shared vitest project, so workers
-  reuse one module registry across files. A test that reaches past its own file
-  through a process-global belongs in `*.isolated.test.ts` — `vi.mock`
-  (eslint-enforced) and rewriting moment's global locale are the two known
-  kinds. The resulting flake surfaces as a nondeterministic count in a
-  _different_ file than the polluting one.
 
 ### Performance
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ proceeds.
 
 ## Quality gates
 
-`checks.yml` runs `compile:i18n` → `check:i18n` → `check:types` → `test` →
+`checks.yml` runs `compile:i18n` → `check:i18n` → `check:types` → `coverage` →
 `check:lint` on every pull request and on every push to `main` (`compile:i18n`
 is covered in Development setup above). It reports as the `build` check, which
 — together with `e2e-gate`, the fixed name standing in for the whole e2e matrix
@@ -60,10 +60,10 @@ blocks it too. Run these before opening a pull request anyway; the order
 between them doesn't matter locally:
 
 ```bash
-npm run check:types   # vue-tsc, no emit
-npm test              # vitest, the unit and component suite
-npm run check:lint    # eslint over the whole project
-npm run check:i18n    # guards messages/*.json against reintroducing banned mistranslations
+npm run check:types  # vue-tsc, no emit
+npm run coverage     # vitest, the unit and component suite, gated on a coverage floor
+npm run check:lint   # eslint over the whole project
+npm run check:i18n   # guards messages/*.json against reintroducing banned mistranslations
 ```
 
 The e2e layer drives a real Obsidian binary through WebdriverIO. It's slow, so
@@ -92,7 +92,9 @@ requests actually run in CI.
 
 ## Making a change
 
-Write the test first. Unit tests sit beside the implementation as `*.test.ts`.
+Write the test first. Unit tests sit beside the implementation as `*.test.ts`;
+see [`docs/unit-testing-strategy.md`](docs/unit-testing-strategy.md) for how
+we write them.
 
 No `eslint-disable` comments — the lint config rejects the comment itself, so
 the fix has to be in the code.
@@ -152,7 +154,9 @@ Branch from `main` and open the pull request against `main`.
 
 - [`docs/architecture.md`](docs/architecture.md) — the conventions the code is
   built on: dependency injection, `Result`/`Option`, dates, schemas,
-  internationalization, testing.
+  internationalization, test file locations.
+- [`docs/unit-testing-strategy.md`](docs/unit-testing-strategy.md) — the unit
+  and component testing standard.
 - [`CONTEXT.md`](CONTEXT.md) — the domain vocabulary the codebase reasons in.
 - [`docs/e2e-testing-strategy.md`](docs/e2e-testing-strategy.md) — what the
   end-to-end suite covers and why it exists alongside the unit suite.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -169,34 +169,22 @@ the mistranslations that motivated them.
 ## Testing
 
 Unit tests are colocated as `*.test.ts` beside the implementation they cover.
-Shared test infrastructure lives in a sibling testing/ directory or a
-`testing.ts` file (e.g. `src/journals/testing.ts`), never in a top-level
-mocks/ or fixtures/ folder.
+Vue component tests sit beside their `.vue` file (e.g.
+`src/ui/UiCollapsibleBlock.test.ts`). Shared test infrastructure lives in a
+sibling testing/ directory or a `testing.ts` file (e.g.
+`src/journals/testing.ts`), never in a top-level mocks/ or fixtures/ folder —
+that separation is what keeps test-only code out of the production bundle.
 
-Vue components are tested through `@testing-library/vue` with `user-event`,
-querying by role and text rather than by CSS class or test-only attributes.
+A test that reaches past its own file through a process-global is named
+`*.isolated.test.ts` and runs in its own module registry; see the isolation
+section of the unit testing doc for why.
 
-Assert observable outcomes. Reach for a spy or a call-count assertion only when
-the side effect itself is the contract being tested.
+How to write those tests — tiers, the `testContainer` harness, fixtures,
+assertions, and the lint rules that enforce them — is documented in
+[`docs/unit-testing-strategy.md`](unit-testing-strategy.md).
 
-One behavior per test — a test name with "and" in it is describing two tests.
-Name tests as subject plus verb ("rejects an empty title", not "title
-validation"). Express test scope with nested `describe()` blocks rather than
-dashes, colons, or periods packed into one label.
-
-Use `expectTypeOf` for compile-time type assertions; never `@ts-expect-error`.
-
-Don't test module wiring, barrel shapes, or the fakes/mocks themselves — the
-compiler and the tooling already guarantee those, and a test for a fake tests
-test infrastructure rather than behavior.
-
-`src/testing.ts` is the exception the rule implies rather than contradicts: its guards and options
-have behavior that can fail — a seed silently repaired, a leak undetected, an override applied
-after the service resolved — and a defect there makes every test in the repo lie. Test those; its
-wiring stays untested like any other module's.
-
-The e2e layer — what it covers, how it's structured, and why the mock-based
-unit suite can't reach it — is documented separately in
+The end-to-end layer — what it covers, how it's structured, and why the
+mock-based unit suite can't reach it — is documented in
 [`docs/e2e-testing-strategy.md`](e2e-testing-strategy.md).
 
 ## Further reading
@@ -207,5 +195,7 @@ unit suite can't reach it — is documented separately in
   convention here covers.
 - [`docs/e2e-testing-strategy.md`](e2e-testing-strategy.md) — the end-to-end
   testing layer.
+- [`docs/unit-testing-strategy.md`](unit-testing-strategy.md) — the unit and
+  component testing standard.
 - [`docs/i18n-glossary.md`](i18n-glossary.md) — the internationalization term
   glossary.

--- a/docs/e2e-testing-strategy.md
+++ b/docs/e2e-testing-strategy.md
@@ -1,8 +1,9 @@
 # End-to-end testing strategy
 
 How we introduce e2e tests that exercise the plugin inside a **real Obsidian
-process** — the one seam our 3518 mock-based unit/component tests (359 files)
-structurally cannot reach.
+process** — the one seam the mock-based unit/component suite (owned by
+[`docs/unit-testing-strategy.md`](unit-testing-strategy.md)) structurally
+cannot reach.
 
 ## Why e2e at all
 

--- a/docs/unit-testing-strategy.md
+++ b/docs/unit-testing-strategy.md
@@ -1,0 +1,177 @@
+# Unit and component testing strategy
+
+How we write the 4,190 tests that run against `__mocks__/obsidian.ts` — the fast
+suite. The end-to-end layer, which exercises a real Obsidian process, is a
+separate subject with its own owner: [`docs/e2e-testing-strategy.md`](e2e-testing-strategy.md).
+
+## Why this doc exists
+
+Three pains, in the order they cost the most:
+
+1. **Cost of change.** Touching source broke tests that had no behavioral stake
+   in the change. A new test cost around forty lines of ceremony before its
+   first assertion.
+2. **Unreadable as documentation.** The intent of a test was buried in setup.
+3. **Contributors invent a harness each.** With no documented pattern, every
+   contributor — human or agent — wrote its own container builder and its own
+   entity fixtures. The suite carried 27 local container builders and 29 local
+   fixture factories.
+
+Distrust of the suite's _signal_ is deliberately not on that list. The suite
+catches what it is meant to catch; what it cost to write and read was the
+problem.
+
+## Tiers
+
+Four tiers. Every new test is routed by one rule, and the rule is: **write it as
+a pure test; descend a tier only when you cannot.**
+
+| Tier          | Wiring                                         | Belongs here when                                                                                                |
+| ------------- | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| **Pure**      | none                                           | The unit takes everything it needs as arguments. Calendar periods, schemas, template rendering, config defaults. |
+| **Service**   | `testContainer` + the feature's core module(s) | Behavior spanning real collaborators inside one feature.                                                         |
+| **Component** | `testContainer` + `harness.render`             | Behavior a user can see or trigger.                                                                              |
+| **E2E**       | real Obsidian                                  | The seam the fake host cannot reach. Owned by [`docs/e2e-testing-strategy.md`](e2e-testing-strategy.md).         |
+
+If you reached for a container in what should have been a pure test, the unit
+wants an argument, not a dependency.
+
+`src/journals/settings/ui/use-collision-check.ts` is the worked example of doing
+this right. The composable genuinely needs a container — it calls `useService` —
+but its logic lives in the pure `findPathCollision` in
+`name-template-collision.ts`, whose test
+([`src/journals/settings/ui/name-template-collision.test.ts`](../src/journals/settings/ui/name-template-collision.test.ts))
+builds no harness at all. Extract the pure core, test it pure, and the thin
+composable keeps a small service test.
+
+## Wiring
+
+One entry point, `testContainer` from `@/testing`. It always supplies the
+logger (a memory sink), flows, settings core, calendar, templates, and the host
+via `createHostModule`. Everything else is opt-in, one line per feature:
+
+```ts
+const harness = await testContainer({
+  modules: [journalsCoreModule],
+  data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+});
+```
+
+| Option       | What it does                                                                                                                                                                                                                    |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `modules`    | Feature **CORE** modules (plus UI modules for component tests). Never a full `<feature>Module` — see below.                                                                                                                     |
+| `data`       | Seeded settings, keyed by collection or slice key, parsed by the real schema. Omit it entirely, rather than passing `{}`, to simulate a fresh install.                                                                          |
+| `overrides`  | `overrideWith(Token, fake)` entries, applied after every module registers and before `autoLoad` resolves anything.                                                                                                              |
+| `initialize` | Services to `initialize()` after `autoLoad`, named per test. `main.ts` initializes eight; a test opting into two modules cannot run that list, and baking one into the harness would be a second wiring definition that drifts. |
+| `autoLoad`   | Defaults to `true`. `false` for a test that must not boot eager services.                                                                                                                                                       |
+| `allow`      | Disarms a guard for a test whose subject **is** the guarded thing.                                                                                                                                                              |
+
+`TestHarness` hands back:
+
+| Handle                                                                          | Use                                                                                          |
+| ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `resolve(Token)`                                                                | the bound resolver; carries both the single- and multi-token overloads                       |
+| `container`                                                                     | the raw `Container`, for the rare case `resolve` cannot cover                                |
+| `render`, `renderModal`                                                         | see [Mounting](#mounting)                                                                    |
+| `modals`                                                                        | for code that **opens** a modal — `modals.lastOpen()`                                        |
+| `host`                                                                          | the fake vault: `putFile`, `putFolder`, `emitVault`, `emitMetadata`, `commands`, `workspace` |
+| `logs`, `notices`, `suggests`, `inputSuggests`, `templater`, `data`, `settings` | the fakes and seams                                                                          |
+| `dispose`                                                                       | rarely needed — the harness disposes itself via `onTestFinished`                             |
+
+**The harness disposes itself, and the default calendar is installed globally.**
+A test needs no `afterEach(cleanup)`, no `dispose()` call, and no
+`installTestCalendar` triple. `installTestCalendar({ dow, doy })` remains for a
+test that needs a non-default week grid; the global `beforeEach` re-pins every
+test to the default grid before it runs, so a changed grid cannot reach the next
+test.
+
+`host.pluginData` is inert. It backs the fake plugin's own `loadData`/`saveData`,
+but `PluginData` is overridden, so nothing in the resolved graph reaches it. The
+live seam for settings persistence is the `data` handle.
+
+### Override through the option, never the handle
+
+`overrides` entries are applied in the one safe window — after every module has
+registered, before `autoLoad` constructs anything eager. Overriding through
+`harness.container` afterwards is a trap: whether it succeeds depends on whether
+some eager service happened to resolve the token first, which changes whenever
+an unrelated module gains a dependency. An eager one throws
+`CannotOverrideError{reason:"resolved"}`.
+
+`Container.override` is lint-restricted to test files and `testing.ts`. It
+exists for the host boundary and has no production caller.
+
+### Modules split three ways
+
+Tests reuse production module _slices_ rather than a parallel set of test
+modules — a parallel set would be a smaller instance of the disease this
+standard cures.
+
+- `<feature>CoreModule` — services and event buses. No `.eager()`, no UI
+  tokens, no settings-section registrations.
+- `<feature>UiModule` — UI-surface tokens, in its own file. These construct
+  nothing, so a component test can take them without the host side effects.
+- `<feature>StartupModule` — registrations whose constructors touch the host.
+- `<feature>Module` — core + ui + startup. What `main.ts` composes; unchanged.
+
+The full module never restates its core module's list, so the two cannot drift.
+
+**The split rule is mechanical.** A service is _startup_ if either clause holds;
+otherwise it is _core_:
+
+1. **Construction causes a host side effect.** `JournalNavigationCommands`
+   registers commands in its constructor, so including it in core would leave
+   `host.commands` non-empty in every test of that feature.
+2. **It injects another feature's tokens.** `.eager()` plus `autoLoad: true`
+   means the service is constructed in every test including its module, so a
+   cross-feature eager service in core throws `TokenNotRegisteredError` unless
+   the caller also passes the other feature.
+
+A service may be moved out of its original registration position only if it has
+no disposer and its constructor's side effects are order-independent. Check that
+before preserving a position; three journals services qualified and moving them
+was observationally identical, confirmed against the e2e suite.
+
+Service tests take core. Component tests take core plus ui. Only a test whose
+subject **is** a host registration passes a full module, with
+`allow: { hostState: true }`.
+
+### The two guards
+
+`testContainer` throws rather than letting a misconfigured boot pass quietly.
+
+`TestContainerLeakedHostStateError` fires when a boot left commands, setting
+tabs, or ribbon icons behind — which a core module never produces. The usual
+cause is a full `<feature>Module` in `modules`. **The type system does not catch
+this**: the tokens a full module adds beyond core are all multi-tokens, whose
+bindings are additive, so registering one a second time succeeds silently.
+`allow: { hostState: true }` is for a test that asserts on `host.commands` on
+purpose — not for "the guard is in my way". A component test needing UI tokens
+takes `<feature>UiModule`.
+
+`TestContainerInvalidSeedError` fires when a `data` fixture did not survive the
+settings parse unchanged. The parse never rejects an entry — it field-repairs it
+or falls back to the default item, leaving only a log line — so without the guard
+a test asserts against a journal it did not ask for and fails somewhere far away.
+**If it fires, your fixture is incomplete; fix the fixture.**
+`allow: { dataRepair: true }` is only for a test whose subject _is_ the repair
+path.
+
+## Mounting
+
+`harness.render` and `harness.renderModal` come pre-bound to the harness's
+injector, so it cannot be forgotten and no container is threaded through call
+sites. Importing `@testing-library/vue`'s raw `render` in a file that already
+builds a harness is a lint error.
+
+```ts
+harness.render(ShelfEditSubpage, { props: { shelfName: "Work", nav } });
+const { submit, cancel } = harness.renderModal(RenameJournalModal, { props });
+```
+
+Both merge a caller's `global.plugins`, `stubs`, and `provide`.
+
+**`renderModal` and `modals` are not interchangeable.** `renderModal` mounts a
+component that **is** a modal, wiring its `useModal()` to mock `submit`/`cancel`.
+For a component that **opens** a modal, assert on `modals.lastOpen()` instead.
+Picking the wrong one produces a test that passes without exercising anything.

--- a/docs/unit-testing-strategy.md
+++ b/docs/unit-testing-strategy.md
@@ -57,14 +57,14 @@ const harness = await testContainer({
 });
 ```
 
-| Option       | What it does                                                                                                                                                                                                                    |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `modules`    | Feature **CORE** modules (plus UI modules for component tests). Never a full `<feature>Module` — see below.                                                                                                                     |
-| `data`       | Seeded settings, keyed by collection or slice key, parsed by the real schema. Omit it entirely, rather than passing `{}`, to simulate a fresh install.                                                                          |
-| `overrides`  | `overrideWith(Token, fake)` entries, applied after every module registers and before `autoLoad` resolves anything.                                                                                                              |
-| `initialize` | Services to `initialize()` after `autoLoad`, named per test. `main.ts` initializes eight; a test opting into two modules cannot run that list, and baking one into the harness would be a second wiring definition that drifts. |
-| `autoLoad`   | Defaults to `true`. `false` for a test that must not boot eager services.                                                                                                                                                       |
-| `allow`      | Disarms a guard for a test whose subject **is** the guarded thing.                                                                                                                                                              |
+| Option       | What it does                                                                                                                                                                                                                                                                 |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `modules`    | Feature **CORE** modules (plus UI modules for component tests). Never a full `<feature>Module` — see below.                                                                                                                                                                  |
+| `data`       | Seeded settings, keyed by collection or slice key, parsed by the real schema. Omit it entirely, rather than passing `{}`, to simulate a fresh install. `data.version` is an honored key too — it defaults to `CURRENT_VERSION` but can be set lower to exercise a migration. |
+| `overrides`  | `overrideWith(Token, fake)` entries, applied after every module registers and before `autoLoad` resolves anything.                                                                                                                                                           |
+| `initialize` | Services to `initialize()` after `autoLoad`, named per test. `main.ts` initializes eight; a test opting into two modules cannot run that list, and baking one into the harness would be a second wiring definition that drifts.                                              |
+| `autoLoad`   | Defaults to `true`. `false` for a test that must not boot eager services.                                                                                                                                                                                                    |
+| `allow`      | Disarms a guard for a test whose subject **is** the guarded thing.                                                                                                                                                                                                           |
 
 `TestHarness` hands back:
 
@@ -98,8 +98,10 @@ some eager service happened to resolve the token first, which changes whenever
 an unrelated module gains a dependency. An eager one throws
 `CannotOverrideError{reason:"resolved"}`.
 
-`Container.override` is lint-restricted to test files and `testing.ts`. It
-exists for the host boundary and has no production caller.
+`Container.override` is lint-restricted to test files and `testing.ts`, with
+one carve-out: `src/infrastructure/di/**` is exempt from the ban, because
+that is where `Container.override` itself is defined and tested. Outside that
+directory it exists for the host boundary and has no production caller.
 
 ### Modules split three ways
 
@@ -210,15 +212,42 @@ export function buildCommand(overrides: Partial<CommandConfig> = {}): CommandCon
 
 The schema-parse form fails loudly when the schema changes and cannot drift.
 
-**Naming: `build<Entity>(overrides)`.** Keep a variant-named wrapper only where
-the variant genuinely changes the shape — `fixedJournal` versus `customJournal`.
+**Naming: `build<Entity>(overrides)`.** The base form takes a single
+`Partial<Entity>` argument — the entity's name passes through `overrides` like
+any other field, with a default supplied the same way the rest are. Promote a
+field to a leading positional argument only inside a variant-named wrapper,
+and only when that field selects the variant's shape before the entity can be
+built at all — `fixedJournal(name, write, overrides)` takes `write`
+positionally for that reason (parsing needs the write kind before it can
+construct the shape), and takes `name` positionally alongside it rather than
+splitting one wrapper into "some fields positional, some not". Keep a
+variant-named wrapper at all only where the variant genuinely changes the
+shape — `fixedJournal` versus `customJournal`.
 
 **Fixtures live in the feature's `testing.ts`**, never as a local factory in a
-test file. Under `src/journals` — the only directory converted onto this
-harness so far — a local `makeJournal`/`seedView`/`viewWith` is a lint error:
-eslint's `no-restricted-syntax` bans a `make`/`build`/`seed`/`create`
-function-name pattern there, pointing back at the feature's `testing.ts`. The
-rule extends to each directory as its own sweep converts it.
+test file — that is the rule. What enforces it inside `src/journals` today is
+narrower than the rule itself: eslint's `no-restricted-syntax` flags only a
+`FunctionDeclaration` (not a `const foo = (...) => ...`) whose name matches
+`^(make|build|seed|create)(Journal|Command|View|Shelf|Decoration|Config)`. It
+is a naming tripwire, not a general ban — still worth having, because it
+catches the common shape without anyone having to remember it — but it has
+known gaps even inside `src/journals`, where six local factories currently
+pass lint: `baseConfig` (`use-folder-extractor.test.ts`) and `withName`
+(`use-invertibility-check.test.ts`) don't start with one of the four prefixes
+at all; `buildRepo` (`repository.test.ts`), `makeParameters`
+(`bulk-add-service.test.ts`) and `makeSectionComponent`
+(`JournalEditSubpage.test.ts`) start with a matching prefix but name a noun
+outside the six-word alternation. `baseConfig` also hand-builds a full
+`JournalConfig` literal, which contradicts the "no literal that restates a
+schema default" rule above — the selector gap let it through.
+
+The entity alternation (`Journal|Command|View|Shelf|Decoration|Config`) and
+the message ("use fixedJournal/customJournal") are both journals-specific. A
+sweep enabling this rule for its own directory must extend the alternation
+with its own entity nouns and rewrite the message for its own fixture names —
+widening only the file glob to cover, say, `src/notes-calendar` or
+`src/code-blocks` turns on a selector that matches nothing there, which looks
+identical to a working one (see [Enforcement](#enforcement)).
 
 ### The standard for new tests
 
@@ -231,13 +260,18 @@ The path it is retiring still exists. Five `static fromParts` methods —
 `src/shelves/repository.ts:24`, `src/shelves/service.ts:11`,
 `src/views/repository.ts:20` — bypass the schema entirely: each does
 `Object.create(this.prototype)` to skip the constructor, then casts through a
-local `Mutable` interface to write protected fields. Fourteen test files, all
-in directories not yet converted, still call the matching
-`fakeRepo`/`fromParts` fixture. Data seeded that way never sees the parse
-defaults or the repair path, and the helpers live in production source, which
-the [file-location rules](architecture.md#testing) forbid. Deleting a
-feature's `fromParts` is the closing step of that feature's Phase 3 sweep —
-not a decision to make ahead of the sweep that owns it.
+local `Mutable` interface to write protected fields. Forty-four test files
+still reach one of these methods: 35 call `fromParts` directly and 14 call
+the `fakeRepo` fixture that wraps it (5 files do both). Two of the 44 —
+`src/journals/repository.test.ts` and `src/journals/view-model.test.ts` — sit
+inside `src/journals` itself, so "converted" does not yet mean
+`JournalsRepository.fromParts` is unused; the journals sweep retires it only
+once those two are rewritten onto `testContainer({ data })`. Data seeded
+through `fromParts`/`fakeRepo` never sees the parse defaults or the repair
+path, and the helpers live in production source, which the
+[file-location rules](architecture.md#testing) forbid. Deleting a feature's
+`fromParts` is the closing step of that feature's Phase 3 sweep — not a
+decision to make ahead of the sweep that owns it.
 
 ### Fakes do not carry error queues
 
@@ -274,6 +308,10 @@ with nested `describe()` blocks, not dashes, colons, or periods packed into
 one label.
 
 ### Do not test the framework, and do not test constants
+
+This section covers per-assertion cases inside a test that is otherwise worth
+writing. [What not to test](#what-not-to-test) covers the other end of the
+same question — whole categories of file that should carry no test at all.
 
 Skip a test whose only assertion is the framework's own contract: `instanceof`
 on an error subclass that only calls `super()`, Promise thenable behavior, Vue
@@ -361,13 +399,13 @@ a container override instead.
 All rules use `no-restricted-syntax` selectors — the mechanism the config already
 uses for the `vi.mock` ban. No custom plugin.
 
-| Rule                                                           | What it catches                                               |
-| -------------------------------------------------------------- | ------------------------------------------------------------- |
-| No `new Container()` in a test                                 | Build it with `testContainer()` from `@/testing`              |
-| No `.register(...).use*` inside a test body or hook            | Pass a feature CORE/UI module to `testContainer({ modules })` |
-| No local entity factories                                      | Fixtures live in the feature's `testing.ts`                   |
-| No raw `render` import in a file that already builds a harness | Mount through `harness.render`, which binds the injector      |
-| `vi.mock` only in `*.isolated.test.ts`                         | The shared module registry, see [Isolation](#isolation)       |
+| Rule                                                           | What it catches                                                                 |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| No `new Container()` in a test                                 | Build it with `testContainer()` from `@/testing`                                |
+| No `.register(...).use*` inside a test body or hook            | Pass a feature CORE/UI module to `testContainer({ modules })`                   |
+| No local factory matching journals' naming tripwire            | Fixtures live in the feature's `testing.ts` — see [gaps](#fixtures-and-seeding) |
+| No raw `render` import in a file that already builds a harness | Mount through `harness.render`, which binds the injector                        |
+| `vi.mock` only in `*.isolated.test.ts`                         | The shared module registry, see [Isolation](#isolation)                         |
 
 **Scope is per-directory, and rolls out as each feature converts.** Today the
 full set is enabled for `src/journals/**/*.test.ts`; the base `vi.mock` rule
@@ -402,15 +440,30 @@ conversion campaign, not a target to chase.
 DI wiring files — `src/**/module.ts` and `src/**/ui-module.ts` — are excluded.
 Module wiring is not testable by this standard's own rules, so counting it
 measured lines nobody was permitted to act on, and every module split added a
-fresh zero-covered file that dragged the floor down.
+fresh zero-covered file that dragged the floor down. The exclusion rests on an
+invariant, not the filename alone: a `module.ts` holds wiring only. The moment
+one exports behavior of its own, that behavior needs a test the same as
+anything else — `src/settings/legacy/module.ts` already does this, exporting
+a `legacyMigrations` array that `module.test.ts` exercises directly; the
+exclusion covers the registration function beside it, not that array.
 
 **The thresholds are never regenerated automatically.** A PR that lowers coverage
-edits the numbers in the same diff, where a reviewer sees the change. An earlier
-gate in this campaign counted assertions against a committed baseline and was
-deleted precisely because the cheapest route past a failure was regenerating the
-baseline, which trains reviewers to dismiss it.
+edits the numbers in the same diff, where a reviewer sees the change. The same
+applies in the other direction: a PR that raises coverage raises the floor in
+the same diff, rather than leaving the gap between the floor and the measured
+value to widen. Across eight sweeps expected to raise coverage, an untouched
+floor drifts further below actual each time, and the gap is exactly what lets
+a later deletion pass silently — the failure mode this floor exists to catch.
+An earlier gate in this campaign counted assertions against a committed
+baseline and was deleted precisely because the cheapest route past a failure
+was regenerating the baseline, which trains reviewers to dismiss it.
 
 ## What not to test
+
+Whole categories of file that should carry no test at all — see
+[Do not test the framework, and do not test constants](#do-not-test-the-framework-and-do-not-test-constants)
+for the per-assertion version of the same question inside a test worth
+writing.
 
 Module wiring, barrel shapes, and the fakes themselves. The compiler and the
 tooling already guarantee those, and a test for a fake tests test infrastructure
@@ -418,11 +471,16 @@ rather than behavior. Wiring is the e2e suite's job: dropping a startup module's
 registration leaves `npm test` fully green while the e2e command-palette journey
 fails immediately.
 
-`src/testing.ts` is the exception the rule implies rather than contradicts. Its
-guards and options have behavior that can fail — a seed silently repaired, a leak
-undetected, an override applied after the service resolved — and a defect there
-makes every test in the repo lie. Test those. Its wiring stays untested like any
-other module's.
+The exception the rule implies rather than contradicts is a class, not one
+file: test infrastructure whose own behavior can fail. `src/testing.ts` is the
+named example — its guards and options have behavior that can fail, a seed
+silently repaired, a leak undetected, an override applied after the service
+resolved, and a defect there makes every test in the repo lie, so it is
+tested. `src/calendar/testing.test.ts` pins the ambient-calendar reset the
+harness depends on, and `src/infrastructure/host/internal/testing.test.ts`
+pins the fake host's vault ↔ `metadataCache` consistency — both are the same
+class of exception for the same reason. Wiring stays untested like any other
+module's; behavior a defect in which would make other tests lie does not.
 
 ## Exemplars
 

--- a/docs/unit-testing-strategy.md
+++ b/docs/unit-testing-strategy.md
@@ -355,3 +355,81 @@ happy-dom, such as `@vueuse/integrations/useSortable` and `obsidian`. Not the
 project's own modules, and never a child component: mocking a child asserts
 which component the parent renders rather than what the user sees. Reach for
 a container override instead.
+
+## Enforcement
+
+All rules use `no-restricted-syntax` selectors — the mechanism the config already
+uses for the `vi.mock` ban. No custom plugin.
+
+| Rule                                                           | What it catches                                               |
+| -------------------------------------------------------------- | ------------------------------------------------------------- |
+| No `new Container()` in a test                                 | Build it with `testContainer()` from `@/testing`              |
+| No `.register(...).use*` inside a test body or hook            | Pass a feature CORE/UI module to `testContainer({ modules })` |
+| No local entity factories                                      | Fixtures live in the feature's `testing.ts`                   |
+| No raw `render` import in a file that already builds a harness | Mount through `harness.render`, which binds the injector      |
+| `vi.mock` only in `*.isolated.test.ts`                         | The shared module registry, see [Isolation](#isolation)       |
+
+**Scope is per-directory, and rolls out as each feature converts.** Today the
+full set is enabled for `src/journals/**/*.test.ts`; the base `vi.mock` rule
+applies to every `**/*.test.ts`. A Phase 3 sweep enables the rest for its own
+directory in the same PR that converts it.
+
+Two mechanics that have already caused a silent failure once each:
+
+- **Flat-config rule options replace, they do not merge.** A per-directory block
+  must sit _after_ the general test-file block and **re-declare the `vi.mock`
+  selector**, or the ban silently lifts for that whole feature.
+- **A selector matching nothing looks identical to one that works.** Verify a new
+  rule by writing a violation and watching it fire, then removing it.
+
+Two selectors are deliberately narrowed, and the narrowing is load-bearing:
+
+- The `.register` ban matches a binding chain **inside a test body or hook**,
+  because a bare `.register(` also names `JournalsIndex.register`, the domain
+  method the suite seeds index entries through.
+- The raw-`render` ban is conditioned on the file already importing `@/testing`,
+  rather than banned outright — a pure-tier component test whose component
+  injects nothing needs no injector. An allowlist of those files was rejected
+  because a stale `ignores` glob that matches nothing is indistinguishable from a
+  working one.
+
+### The coverage floor
+
+`npm run coverage` enforces a floor in `vitest.config.mts`, and `checks.yml` runs
+it in place of `npm test`. It is a floor to catch silent deletion during the
+conversion campaign, not a target to chase.
+
+DI wiring files — `src/**/module.ts` and `src/**/ui-module.ts` — are excluded.
+Module wiring is not testable by this standard's own rules, so counting it
+measured lines nobody was permitted to act on, and every module split added a
+fresh zero-covered file that dragged the floor down.
+
+**The thresholds are never regenerated automatically.** A PR that lowers coverage
+edits the numbers in the same diff, where a reviewer sees the change. An earlier
+gate in this campaign counted assertions against a committed baseline and was
+deleted precisely because the cheapest route past a failure was regenerating the
+baseline, which trains reviewers to dismiss it.
+
+## What not to test
+
+Module wiring, barrel shapes, and the fakes themselves. The compiler and the
+tooling already guarantee those, and a test for a fake tests test infrastructure
+rather than behavior. Wiring is the e2e suite's job: dropping a startup module's
+registration leaves `npm test` fully green while the e2e command-palette journey
+fails immediately.
+
+`src/testing.ts` is the exception the rule implies rather than contradicts. Its
+guards and options have behavior that can fail — a seed silently repaired, a leak
+undetected, an override applied after the service resolved — and a defect there
+makes every test in the repo lie. Test those. Its wiring stays untested like any
+other module's.
+
+## Exemplars
+
+Copy these rather than the prose.
+
+| Tier              | File                                                                                                                      | What it shows                                                   |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| Pure              | [`src/journals/settings/ui/name-template-collision.test.ts`](../src/journals/settings/ui/name-template-collision.test.ts) | 38 lines, no harness at all — that is the point                 |
+| Service           | [`src/journals/cycle.test.ts`](../src/journals/cycle.test.ts)                                                             | both halves of the arrange rule, at scale                       |
+| Component / modal | [`src/journals/settings/ui/RenameJournalModal.test.ts`](../src/journals/settings/ui/RenameJournalModal.test.ts)           | `renderModal`, a `data` seed, and copy asserted through `m.*()` |

--- a/docs/unit-testing-strategy.md
+++ b/docs/unit-testing-strategy.md
@@ -230,27 +230,24 @@ narrower than the rule itself: eslint's `no-restricted-syntax` flags only a
 `FunctionDeclaration` (not a `const foo = (...) => ...`) whose name matches
 `^(make|build|seed|create)(Journal|Command|View|Shelf|Decoration|Config)`. It
 is a naming tripwire, not a general ban — still worth having, because it
-catches the common shape without anyone having to remember it — but it
-matches on a name, not on what the function does, so it also misses names
-outside its six-word alternation. A name escaping the selector is not by
-itself evidence of a violation: inside `src/journals` today, most of the
-functions the selector misses are either compliant helpers that merely happen
-to share the naming shape — `withName`
-(`use-invertibility-check.test.ts`) and `makeParameters`
-(`bulk-add-service.test.ts`) both delegate straight to a feature fixture or
-factory rather than building anything by hand — or arrange/seed helpers that
-were never entity fixtures to begin with, such as `makeSectionComponent`
-(`JournalEditSubpage.test.ts`, a Vue component stub) or `seedWeek`
-(`week-preset-service.test.ts`, which writes and registers a note through the
-harness). One escape is a genuine violation the tripwire fails to catch:
-`baseConfig` (`use-folder-extractor.test.ts`) hand-builds a full
-`JournalConfig` literal restating schema defaults field by field, which is
-exactly what the "no literal that restates a schema default" rule above
-forbids — the selector gap let it through uncaught. Treat the selector as a
-naming-convention aid, not a compliance check: a sweep enabling it elsewhere
-should expect both false negatives (real violations under other names) and
-functions that merely resemble one, and should judge each escapee on what it
-does rather than trust the lint result either way.
+catches the common shape without anyone having to remember it — but matching
+is purely syntactic, so passing lint and violating the rule are independent
+in both directions. A factory can violate the rule and still pass lint
+permanently, by construction of the selector rather than by luck: the
+selector only matches `FunctionDeclaration`, so `const makeJournal = () =>
+buildLiteral(...)` hand-builds an entity and is invisible to it no matter
+what any future sweep fixes, and a `function` whose name lands outside the
+six-word alternation escapes the same way. The converse also holds — a name
+that happens to match the shape says nothing about whether the function
+builds anything by hand at all; some do (a hand-built entity literal
+restating schema defaults, say) and some are compliant one-line delegators to
+a feature fixture, or arrange/seed helpers that were never entity fixtures to
+begin with. Neither a lint pass nor a lint failure is a verdict — only
+reading the function body is. Treat the selector as a naming-convention aid,
+not a compliance check: a sweep enabling it for its own directory should
+expect both false negatives (real violations the selector's shape can't see)
+and escapees that turn out to be fine on inspection, and should judge each
+one by what it does rather than by whether lint flagged it.
 
 The entity alternation (`Journal|Command|View|Shelf|Decoration|Config`) and
 the message ("use fixedJournal/customJournal") are both journals-specific. A
@@ -271,14 +268,18 @@ The path it is retiring still exists. Five `static fromParts` methods —
 `src/shelves/repository.ts:24`, `src/shelves/service.ts:11`,
 `src/views/repository.ts:20` — bypass the schema entirely: each does
 `Object.create(this.prototype)` to skip the constructor, then casts through a
-local `Mutable` interface to write protected fields. Forty-four test files
-still reach one of these methods: 35 call `fromParts` directly and 14 call
-the `fakeRepo` fixture that wraps it (5 files do both). Two of the 44 —
-`src/journals/repository.test.ts` and `src/journals/view-model.test.ts` — sit
-inside `src/journals` itself, so "converted" does not yet mean
-`JournalsRepository.fromParts` is unused; the journals sweep retires it only
-once those two are rewritten onto `testContainer({ data })`. Data seeded
-through `fromParts`/`fakeRepo` never sees the parse defaults or the repair
+local `Mutable` interface to write protected fields. At the time of writing,
+forty-four test files still reach one of these methods: 35 call `fromParts`
+directly and 14 call the `fakeRepo` fixture that wraps it (5 files do both).
+That count is a moving target, not a fixed inventory — check the call sites
+directly rather than trusting a number here, since each feature's Phase 3
+sweep rewrites its own callers onto `testContainer({ data })` as it lands. A
+directory being "converted" does not by itself mean its `fromParts` is
+unused: a leftover `fromParts`/`fakeRepo` caller can sit inside an
+otherwise-converted directory until that feature's own sweep retires the
+method, `src/journals` included — don't assume none remain just from the
+directory name. Data seeded through `fromParts`/`fakeRepo` never sees the
+parse defaults or the repair
 path, and the helpers live in production source, which the
 [file-location rules](architecture.md#testing) forbid. Deleting a feature's
 `fromParts` is the closing step of that feature's Phase 3 sweep — not a

--- a/docs/unit-testing-strategy.md
+++ b/docs/unit-testing-strategy.md
@@ -230,16 +230,27 @@ narrower than the rule itself: eslint's `no-restricted-syntax` flags only a
 `FunctionDeclaration` (not a `const foo = (...) => ...`) whose name matches
 `^(make|build|seed|create)(Journal|Command|View|Shelf|Decoration|Config)`. It
 is a naming tripwire, not a general ban — still worth having, because it
-catches the common shape without anyone having to remember it — but it has
-known gaps even inside `src/journals`, where six local factories currently
-pass lint: `baseConfig` (`use-folder-extractor.test.ts`) and `withName`
-(`use-invertibility-check.test.ts`) don't start with one of the four prefixes
-at all; `buildRepo` (`repository.test.ts`), `makeParameters`
-(`bulk-add-service.test.ts`) and `makeSectionComponent`
-(`JournalEditSubpage.test.ts`) start with a matching prefix but name a noun
-outside the six-word alternation. `baseConfig` also hand-builds a full
-`JournalConfig` literal, which contradicts the "no literal that restates a
-schema default" rule above — the selector gap let it through.
+catches the common shape without anyone having to remember it — but it
+matches on a name, not on what the function does, so it also misses names
+outside its six-word alternation. A name escaping the selector is not by
+itself evidence of a violation: inside `src/journals` today, most of the
+functions the selector misses are either compliant helpers that merely happen
+to share the naming shape — `withName`
+(`use-invertibility-check.test.ts`) and `makeParameters`
+(`bulk-add-service.test.ts`) both delegate straight to a feature fixture or
+factory rather than building anything by hand — or arrange/seed helpers that
+were never entity fixtures to begin with, such as `makeSectionComponent`
+(`JournalEditSubpage.test.ts`, a Vue component stub) or `seedWeek`
+(`week-preset-service.test.ts`, which writes and registers a note through the
+harness). One escape is a genuine violation the tripwire fails to catch:
+`baseConfig` (`use-folder-extractor.test.ts`) hand-builds a full
+`JournalConfig` literal restating schema defaults field by field, which is
+exactly what the "no literal that restates a schema default" rule above
+forbids — the selector gap let it through uncaught. Treat the selector as a
+naming-convention aid, not a compliance check: a sweep enabling it elsewhere
+should expect both false negatives (real violations under other names) and
+functions that merely resemble one, and should judge each escapee on what it
+does rather than trust the lint result either way.
 
 The entity alternation (`Journal|Command|View|Shelf|Decoration|Config`) and
 the message ("use fixedJournal/customJournal") are both journals-specific. A

--- a/docs/unit-testing-strategy.md
+++ b/docs/unit-testing-strategy.md
@@ -161,15 +161,21 @@ path.
 
 `harness.render` and `harness.renderModal` come pre-bound to the harness's
 injector, so it cannot be forgotten and no container is threaded through call
-sites. Importing `@testing-library/vue`'s raw `render` in a file that already
-builds a harness is a lint error.
+sites. Under `src/journals` — the directory converted onto this harness —
+importing `@testing-library/vue`'s raw `render` in a file that already builds
+a harness is a lint error; the guard is scoped to that directory only, so an
+unconverted file elsewhere (`src/shelves/ui/ShelfEditSubpage.test.ts`, for
+example) can still import it directly.
 
 ```ts
-harness.render(ShelfEditSubpage, { props: { shelfName: "Work", nav } });
-const { submit, cancel } = harness.renderModal(RenameJournalModal, { props });
+harness.render(JournalEditSubpage, { props: { journalName: "work", nav: noopNav } });
+const { submit } = harness.renderModal(RenameJournalModal, { props: { currentName: "daily" } });
 ```
 
-Both merge a caller's `global.plugins`, `stubs`, and `provide`.
+Both prepend the harness's own plugin — the one that provides the injector,
+and for `renderModal` also the modal API — ahead of whatever plugins the
+caller passed in `global.plugins`; a caller's `global.stubs` and
+`global.provide` pass through untouched.
 
 **`renderModal` and `modals` are not interchangeable.** `renderModal` mounts a
 component that **is** a modal, wiring its `useModal()` to mock `submit`/`cancel`.

--- a/docs/unit-testing-strategy.md
+++ b/docs/unit-testing-strategy.md
@@ -181,3 +181,177 @@ caller passed in `global.plugins`; a caller's `global.stubs` and
 component that **is** a modal, wiring its `useModal()` to mock `submit`/`cancel`.
 For a component that **opens** a modal, assert on `modals.lastOpen()` instead.
 Picking the wrong one produces a test that passes without exercising anything.
+
+## Fixtures and seeding
+
+**A fixture never contains a literal that restates a schema default or a
+production defaults function. It delegates.**
+
+Two delegation forms. Journals has a production defaults factory, which is
+richer than the schema defaults — `journalDefaultsFor` populates `navBlock`
+and a per-type `nameTemplate` that the schema's own defaults do not:
+
+```ts
+export function fixedJournal(name: string, write: JournalWrite, overrides: Partial<JournalConfig> = {}): JournalConfig;
+```
+
+(`src/journals/testing.ts`.)
+
+A feature with no defaults factory of its own parses a minimal object through
+the production schema instead, then applies overrides. No fixture like this
+exists yet for commands — this is the shape a Phase 3 sweep should write, not
+a file to go looking for:
+
+```ts
+export function buildCommand(overrides: Partial<CommandConfig> = {}): CommandConfig {
+  return { ...v.parse(commandConfigSchema, MINIMAL_COMMAND), ...overrides };
+}
+```
+
+The schema-parse form fails loudly when the schema changes and cannot drift.
+
+**Naming: `build<Entity>(overrides)`.** Keep a variant-named wrapper only where
+the variant genuinely changes the shape — `fixedJournal` versus `customJournal`.
+
+**Fixtures live in the feature's `testing.ts`**, never as a local factory in a
+test file. Under `src/journals` — the only directory converted onto this
+harness so far — a local `makeJournal`/`seedView`/`viewWith` is a lint error:
+eslint's `no-restricted-syntax` bans a `make`/`build`/`seed`/`create`
+function-name pattern there, pointing back at the feature's `testing.ts`. The
+rule extends to each directory as its own sweep converts it.
+
+### The standard for new tests
+
+`testContainer({ data })` routes through the real settings parse. It is the
+standard, and the only seeding path a new test should use: a name-keyed
+record mirroring on-disk settings, not an array.
+
+The path it is retiring still exists. Five `static fromParts` methods —
+`src/journals/repository.ts:33`, `src/commands/repository.ts:22`,
+`src/shelves/repository.ts:24`, `src/shelves/service.ts:11`,
+`src/views/repository.ts:20` — bypass the schema entirely: each does
+`Object.create(this.prototype)` to skip the constructor, then casts through a
+local `Mutable` interface to write protected fields. Fourteen test files, all
+in directories not yet converted, still call the matching
+`fakeRepo`/`fromParts` fixture. Data seeded that way never sees the parse
+defaults or the repair path, and the helpers live in production source, which
+the [file-location rules](architecture.md#testing) forbid. Deleting a
+feature's `fromParts` is the closing step of that feature's Phase 3 sweep —
+not a decision to make ahead of the sweep that owns it.
+
+### Fakes do not carry error queues
+
+A fake never grows a `simulate*Error` queue. A test that needs an error path
+uses `vi.spyOn` with `mockReturnValueOnce`. A baked-in queue adds a parallel
+state machine — typed buffers, ordering, drain semantics — to every fake, to
+serve the minority of tests that need one.
+
+## Assertions
+
+**Spy on a boundary you cannot see past; assert the outcome whenever the
+outcome is observable.** The discriminator is whether the fake host can show
+you the result.
+
+A spy is right for `flows.invoke` in a component test: components call
+`void flows.invoke(Flow, args)` fire-and-forget, so dispatching the flow _is_
+the entire contract and there is no result to observe.
+
+A spy is wrong for something like `creation.attachNote`
+(`src/journals/notes/note-creation.ts`). The contract is the frontmatter
+written to the note, and that is readable through the fake host's vault.
+Assert the note, not the call. The suite leaned on spies partly because the
+old partial fakes had no vault; the fake host removes that excuse.
+
+### One behavior per test
+
+> When tests share an identical arrange and act and differ only in which
+> field of one result they read, they are one test. When the arrange differs,
+> they stay separate.
+
+A test name containing "and" is describing two tests. Name a test as subject
+plus verb — "rejects an empty title", not "title validation". Express scope
+with nested `describe()` blocks, not dashes, colons, or periods packed into
+one label.
+
+### Do not test the framework, and do not test constants
+
+Skip a test whose only assertion is the framework's own contract: `instanceof`
+on an error subclass that only calls `super()`, Promise thenable behavior, Vue
+lifecycle, vee-validate, moment locale switching. Ask what application
+behavior would break the test. If the answer is "only if Vue breaks", delete
+it.
+
+Likewise a test that restates one literal from a defaults function proves the
+literal was copied twice. The invariant version — "accepts the unmodified
+defaults for a {type} journal", asserting that the defaults satisfy the
+schema — is the one worth keeping. The discriminator is **"would a user
+notice if this literal changed"**, not "does it restate a literal": a default
+a user sees on every newly created journal is behavior, and a test pinning it
+stays.
+
+### Query by role, text, and label — through `m.*()`
+
+Vue components are tested through `@testing-library/vue` with `user-event`,
+querying by role and text rather than by CSS class or test-only attributes.
+Pass user-facing copy through the generated paraglide messages so a reword
+becomes a typecheck failure instead of silent drift:
+
+```ts
+await userEvent.click(screen.getByText(m.common_action_submit()));
+```
+
+One carve-out: grid surfaces address cells positionally, and the e2e layer
+already pins day cells by `data-anchor`. Those may use attribute selectors.
+Everything else may not.
+
+### No ceremony around matchers
+
+No wrappers around `expect()` chains, and no test-local re-implementations of
+library factories. A narrowing helper that returns the inner value and prints
+the actual `Err` earns its place — `expectOk`/`expectErr`
+(`src/infrastructure/result/testing.ts`) are the standing example — one that
+hides a matcher does not.
+
+No type ceremony in a mock assertion either. Write:
+
+```ts
+expect(submit).toHaveBeenCalledWith({ newName: "morning" });
+```
+
+Vitest's matchers take unconstrained generics and do not typecheck the
+expected value. That is fine here, because a wrong key fails the assertion
+loudly. Type checking earns its place only where a mistake causes a **silent
+pass** — which is why `m.*()` is mandatory for user-facing copy and nothing
+analogous is mandated for mock arguments.
+
+Use `expectTypeOf` for compile-time type assertions; never `@ts-expect-error`.
+
+### Naming
+
+`harness`, never `h`. `container`, never `c`. Single letters are for loop
+indices.
+
+## Isolation
+
+The unit suite runs `isolate: false` in a shared vitest project, so workers
+reuse one module registry across the files they run. That is what keeps the
+suite fast: the import graph is paid once per worker instead of once per file.
+
+The cost is that a file can reach the next one through anything
+process-global. A test that does belongs in `*.isolated.test.ts`, which runs
+in its own registry. Two kinds are known:
+
+- `vi.mock`, whose factory replaces the module for every later file in the
+  worker. This one is eslint-enforced.
+- Rewriting moment's **global** locale, which leaves the next file on a
+  different week grid.
+
+The resulting flake surfaces as a nondeterministic count in a _different_ file
+than the polluting one, which is why the rule is worth following before you
+have a failure to explain.
+
+**`vi.mock` is for third-party modules only** — modules that cannot run under
+happy-dom, such as `@vueuse/integrations/useSortable` and `obsidian`. Not the
+project's own modules, and never a child component: mocking a child asserts
+which component the parent renders rather than what the user sees. Reach for
+a container override instead.

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -169,7 +169,10 @@ export interface TestHarness {
   readonly templater: FakeTemplaterService;
   readonly data: FakePluginData;
   readonly settings: SettingsService;
-  /** Mounts under the harness's own injector. Merges a caller's `global.plugins`/`stubs`/`provide`. */
+  /**
+   * Mounts under the harness's own injector, prepended ahead of a caller's `global.plugins`.
+   * A caller's `global.stubs`/`provide` pass through untouched.
+   */
   render<C>(component: C, options?: RenderOptions<C>): RenderResult;
   /**
    * Mounts a component that IS a modal, wiring its `useModal()` to mock `submit`/`cancel`. For a

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -27,7 +27,23 @@ export default defineConfig({
         "**/*.testing.ts",
         "**/*.test.ts",
         "**/*.bench.ts",
+        // DI wiring. `docs/unit-testing-strategy.md` forbids testing it, so counting it measured
+        // lines nobody was permitted to act on — and every module split added a fresh 0% file
+        // that dragged the floor down for reasons unrelated to test quality.
+        "src/**/module.ts",
+        "src/**/ui-module.ts",
       ],
+      // A floor to catch silent deletion during the test-conversion campaign, not a target to
+      // chase. Set at the measured value: a PR that lowers coverage edits these numbers in the
+      // same diff, where a reviewer sees it. Deliberately not `thresholds.autoUpdate` — an
+      // earlier gate in this campaign was deleted because the cheapest route past a failure was
+      // regenerating its baseline, which trains reviewers to dismiss it.
+      thresholds: {
+        statements: 92.25,
+        branches: 87.86,
+        functions: 89.1,
+        lines: 94.38,
+      },
     },
     projects: [
       {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -19,7 +19,7 @@ export default defineConfig({
   test: {
     coverage: {
       provider: "v8",
-      reporter: ["text-summary", "json-summary", "html"],
+      reporter: ["text", "text-summary", "json-summary", "html"],
       include: ["src/**"],
       exclude: [
         "src/i18n/paraglide/**",

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -29,7 +29,10 @@ export default defineConfig({
         "**/*.bench.ts",
         // DI wiring. `docs/unit-testing-strategy.md` forbids testing it, so counting it measured
         // lines nobody was permitted to act on — and every module split added a fresh 0% file
-        // that dragged the floor down for reasons unrelated to test quality.
+        // that dragged the floor down for reasons unrelated to test quality. Safe only because a
+        // `module.ts` is assumed to hold wiring only — `src/settings/legacy/module.ts` already
+        // breaks that assumption (its `legacyMigrations` array is real behavior with its own
+        // test), so a file matching this glob still needs checking for non-wiring exports.
         "src/**/module.ts",
         "src/**/ui-module.ts",
       ],


### PR DESCRIPTION
Phase 2 of the testing-strategy campaign. Docs and CI config only, with one deliberate exception noted below — no test file is touched, and the suite stays at 395 files / 4190 tests.

## What this does

- Adds `docs/unit-testing-strategy.md`, which now owns the unit and component standard: tiers, the `testContainer` harness, fixtures and seeding, assertions, isolation, the lint rules, and three exemplar files.
- Shrinks `docs/architecture.md`'s Testing section to file-location rules and pointers.
- Adds the routing row to `CLAUDE.md` and deletes its "Unit-suite gotchas" section, whose four rules the new doc absorbs.
- Gates CI on the coverage floor: `checks.yml` runs `npm run coverage` in place of `npm test`, with thresholds in `vitest.config.mts` at the measured value.

## Why the coverage gate moves up from Phase 6

The spec's Phase 3 gate reads "per-PR coverage floor", but with nothing in `checks.yml` that gate was a human remembering to run `npm run coverage` and compare against a number living in a git-ignored file. Eight sweep PRs are about to rely on it.

## The wiring exclusion

`src/**/module.ts` and `src/**/ui-module.ts` are excluded from coverage. The standard forbids testing module wiring, so the floor was counting lines nobody is permitted to act on — and each Phase 3 module split adds a fresh 0%-covered file that drags the floor down for reasons unrelated to test quality. This settles the open question the PR 2 handoff raised. Excluding them moves statements 91.56 → 92.25 and lines 93.57 → 94.38; branches are unchanged at 87.86.

The thresholds are deliberately not `autoUpdate` — automatic regeneration is why the earlier assertion ratchet in this campaign was deleted.

## One comment-only exception in `src/`

`src/testing.ts:172`'s JSDoc on `TestHarness.render` claimed it "merges" a caller's `global.plugins`/`stubs`/`provide`. Only `plugins` is actually combined — `stubs` and `provide` pass through the `withPlugins` spread untouched — and `docs/unit-testing-strategy.md` already stated the real behavior correctly, so source and doc disagreed. Fixed the comment wording only; no executable line changed (`git diff -- src/` shows a single JSDoc hunk).
