### PR TITLE
chore: ignore the lockfile npm leaves in packages/api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 
 # npm
 node_modules
+# packages/api is not a workspace, so `cd packages/api && npm publish` (docs/releasing.md)
+# resolves its own peer tree and leaves a lockfile behind. node_modules is already covered
+# above; without this line the lockfile beside it is one `git add -A` from being committed.
+packages/api/package-lock.json
 
 
 test-vault/.obsidian/plugins/journals/*


### PR DESCRIPTION
One line in `.gitignore`.

## What happens today

`packages/api` is not an npm workspace — the root `package.json` has no `workspaces` key — and `docs/releasing.md` publishes it with:

```
cd packages/api && npm publish --access public
```

Run from inside that directory, npm resolves the package's own `peerDependencies: { obsidian: ">=1.0.0" }` and writes both a `node_modules/` and a `package-lock.json` there. The lockfile holds obsidian plus its transitive peers — `@codemirror/*`, `moment`, `crelt`, `style-mod`, `w3c-keyname`.

The bare `node_modules` pattern already hides the directory at any depth. The lockfile written beside it by the same command was ignored nowhere, so it shows up as untracked and is one `git add -A` away from being committed.

## Why not just commit it

The package declares a single peer dependency, so a lockfile pins nothing meaningful. `files` in its `package.json` lists only `index.js`, `index.d.ts` and `README.md`, so it would never ship. The one durable effect of tracking it would be handing renovate a second lockfile to maintain.

## Not the repo's own tooling

Ruled out while diagnosing: `scripts/check-api-package.mjs` does all its work in a `mkdtemp` scratch directory and shells out only to `tsc`, and `scripts/build-api-types.mjs` shells out to nothing. Neither writes into `packages/api/`.

## Checks

- `git check-ignore -v packages/api/package-lock.json` → matches the new rule.
- The root `package-lock.json` is unaffected and still tracked.