### PR TITLE
test(journals): convert the three remaining fromParts holdouts

### DIFF
--- a/src/journals/repository.test.ts
+++ b/src/journals/repository.test.ts
@@ -1,8 +1,8 @@
-import { createNanoEvents, type Emitter } from "nanoevents";
 import { describe, expect, it, vi } from "vitest";
-import { reactive } from "vue";
 
-import { journalDefaultsFor, type JournalConfig, type NavBlockSegment } from "./config";
+import { testContainer } from "@/testing";
+
+import { journalConfigCollection, type NavBlockSegment } from "./config";
 import {
   InvalidJournalNameError,
   InvalidJournalUpdateError,
@@ -10,7 +10,10 @@ import {
   JournalNotFoundError,
   UnknownJournalError,
 } from "./errors";
-import { JournalsRepository, type JournalsEvents } from "./repository";
+import { journalsCoreModule } from "./module";
+import { JournalsRepository } from "./repository";
+import { fixedJournal } from "./testing";
+import { JournalsEventsToken } from "./tokens";
 
 const addedRow: NavBlockSegment = {
   template: "added to the copy",
@@ -25,235 +28,381 @@ const addedRow: NavBlockSegment = {
   addDecorations: false,
 };
 
-function buildRepo(initial: Record<string, JournalConfig> = {}) {
-  const storage = reactive<Record<string, JournalConfig>>({ ...initial });
-  const events: Emitter<JournalsEvents> = createNanoEvents();
-  const repo = JournalsRepository.fromParts(storage, events);
-  return { repo, storage, events };
-}
-
 describe("JournalsRepository", () => {
   describe("create", () => {
-    it("inserts a journal with defaults for the given write", () => {
-      const { repo, storage } = buildRepo();
+    it("inserts a journal with defaults for the given write", async () => {
+      const harness = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
+      const repo = harness.resolve(JournalsRepository);
+
       const result = repo.create("daily", { type: "day" });
+
       expect(result.kind).toBe("ok");
-      expect(storage.daily).toEqual(journalDefaultsFor({ type: "day" }, "daily"));
+      expect(harness.settings.recordOf(journalConfigCollection).daily).toEqual(fixedJournal("daily", { type: "day" }));
     });
 
-    it("emits created with the journal name", () => {
-      const { repo, events } = buildRepo();
+    it("emits created with the journal name", async () => {
+      const harness = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
+      const repo = harness.resolve(JournalsRepository);
+      const events = harness.resolve(JournalsEventsToken);
       const spy = vi.fn();
       events.on("created", spy);
+
       repo.create("daily", { type: "day" });
+
       expect(spy).toHaveBeenCalledWith("daily");
     });
 
-    it("rejects an empty name with InvalidJournalNameError", () => {
-      const { repo } = buildRepo();
+    it("rejects an empty name with InvalidJournalNameError", async () => {
+      const harness = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
+      const repo = harness.resolve(JournalsRepository);
+
       const result = repo.create("", { type: "day" });
+
       expect(result.isErr() && result.error).toBeInstanceOf(InvalidJournalNameError);
     });
 
-    it("rejects a name already in use with JournalNameTakenError", () => {
-      const { repo } = buildRepo({ daily: journalDefaultsFor({ type: "day" }, "daily") });
+    it("rejects a name already in use with JournalNameTakenError", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+      });
+      const repo = harness.resolve(JournalsRepository);
+
       const result = repo.create("daily", { type: "day" });
+
       expect(result.isErr() && result.error).toBeInstanceOf(JournalNameTakenError);
     });
   });
 
   describe("rename", () => {
-    it("stores the entity under the new key with the updated name field", () => {
-      const original = journalDefaultsFor({ type: "day" }, "daily");
-      const { repo, storage } = buildRepo({ daily: original });
+    it("stores the entity under the new key with the updated name field", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+      });
+      const repo = harness.resolve(JournalsRepository);
+
       repo.rename("daily", "renamed");
-      expect(storage.renamed?.name).toBe("renamed");
+
+      expect(harness.settings.recordOf(journalConfigCollection).renamed?.name).toBe("renamed");
     });
 
-    it("removes the old key on rename", () => {
-      const original = journalDefaultsFor({ type: "day" }, "daily");
-      const { repo, storage } = buildRepo({ daily: original });
+    it("removes the old key on rename", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+      });
+      const repo = harness.resolve(JournalsRepository);
+
       repo.rename("daily", "renamed");
-      expect(storage.daily).toBeUndefined();
+
+      expect(harness.settings.recordOf(journalConfigCollection).daily).toBeUndefined();
     });
 
-    it("emits renamed with old and new name", () => {
-      const { repo, events } = buildRepo({ daily: journalDefaultsFor({ type: "day" }, "daily") });
+    it("emits renamed with old and new name", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+      });
+      const repo = harness.resolve(JournalsRepository);
+      const events = harness.resolve(JournalsEventsToken);
       const spy = vi.fn();
       events.on("renamed", spy);
+
       repo.rename("daily", "renamed");
+
       expect(spy).toHaveBeenCalledWith("daily", "renamed");
     });
 
-    it("does not emit created on rename", () => {
-      const { repo, events } = buildRepo({ daily: journalDefaultsFor({ type: "day" }, "daily") });
+    it("does not emit created on rename", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+      });
+      const repo = harness.resolve(JournalsRepository);
+      const events = harness.resolve(JournalsEventsToken);
       const created = vi.fn();
       events.on("created", created);
+
       repo.rename("daily", "renamed");
+
       expect(created).not.toHaveBeenCalled();
     });
 
-    it("does not emit deleted on rename", () => {
-      const { repo, events } = buildRepo({ daily: journalDefaultsFor({ type: "day" }, "daily") });
+    it("does not emit deleted on rename", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+      });
+      const repo = harness.resolve(JournalsRepository);
+      const events = harness.resolve(JournalsEventsToken);
       const deleted = vi.fn();
       events.on("deleted", deleted);
+
       repo.rename("daily", "renamed");
+
       expect(deleted).not.toHaveBeenCalled();
     });
 
-    it("rejects an empty new name with InvalidJournalNameError", () => {
-      const { repo } = buildRepo({ daily: journalDefaultsFor({ type: "day" }, "daily") });
+    it("rejects an empty new name with InvalidJournalNameError", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+      });
+      const repo = harness.resolve(JournalsRepository);
+
       const result = repo.rename("daily", "");
+
       expect(result.isErr() && result.error).toBeInstanceOf(InvalidJournalNameError);
     });
 
-    it("rejects newName equal to oldName with InvalidJournalNameError", () => {
-      const { repo } = buildRepo({ daily: journalDefaultsFor({ type: "day" }, "daily") });
+    it("rejects newName equal to oldName with InvalidJournalNameError", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+      });
+      const repo = harness.resolve(JournalsRepository);
+
       const result = repo.rename("daily", "daily");
+
       expect(result.isErr() && result.error).toBeInstanceOf(InvalidJournalNameError);
     });
 
-    it("rejects an unknown old name with UnknownJournalError", () => {
-      const { repo } = buildRepo();
+    it("rejects an unknown old name with UnknownJournalError", async () => {
+      const harness = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
+      const repo = harness.resolve(JournalsRepository);
+
       const result = repo.rename("nope", "next");
+
       expect(result.isErr() && result.error).toBeInstanceOf(UnknownJournalError);
     });
 
-    it("rejects a new name already in use with JournalNameTakenError", () => {
-      const { repo } = buildRepo({
-        a: journalDefaultsFor({ type: "day" }, "a"),
-        b: journalDefaultsFor({ type: "day" }, "b"),
+    it("rejects a new name already in use with JournalNameTakenError", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { a: fixedJournal("a", { type: "day" }), b: fixedJournal("b", { type: "day" }) } },
       });
+      const repo = harness.resolve(JournalsRepository);
+
       const result = repo.rename("a", "b");
+
       expect(result.isErr() && result.error).toBeInstanceOf(JournalNameTakenError);
     });
   });
 
   describe("clone", () => {
-    it("stores a copy of the source config under the new name", () => {
-      const source = { ...journalDefaultsFor({ type: "day" }, "daily"), folder: "Daily/", confirmCreation: true };
-      const { repo, storage } = buildRepo({ daily: source });
+    it("stores a copy of the source config under the new name", async () => {
+      const source = fixedJournal("daily", { type: "day" }, { folder: "Daily/", confirmCreation: true });
+      const harness = await testContainer({ modules: [journalsCoreModule], data: { journals: { daily: source } } });
+      const repo = harness.resolve(JournalsRepository);
+
       repo.clone("daily", "daily copy");
-      expect(storage["daily copy"]).toStrictEqual({ ...source, name: "daily copy" });
+
+      expect(harness.settings.recordOf(journalConfigCollection)["daily copy"]).toStrictEqual({
+        ...source,
+        name: "daily copy",
+      });
     });
 
-    it("leaves the source journal in place", () => {
-      const source = journalDefaultsFor({ type: "day" }, "daily");
-      const { repo, storage } = buildRepo({ daily: source });
+    it("leaves the source journal in place", async () => {
+      const source = fixedJournal("daily", { type: "day" });
+      const harness = await testContainer({ modules: [journalsCoreModule], data: { journals: { daily: source } } });
+      const repo = harness.resolve(JournalsRepository);
+
       repo.clone("daily", "daily copy");
-      expect(storage.daily).toStrictEqual(source);
+
+      expect(harness.settings.recordOf(journalConfigCollection).daily).toStrictEqual(source);
     });
 
-    it("detaches nested values so editing the copy leaves the source untouched", () => {
-      const { repo, storage } = buildRepo({ daily: journalDefaultsFor({ type: "day" }, "daily") });
+    it("detaches nested values so editing the copy leaves the source untouched", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+      });
+      const repo = harness.resolve(JournalsRepository);
+
       repo.clone("daily", "daily copy");
+      const storage = harness.settings.recordOf(journalConfigCollection);
       storage["daily copy"]?.navBlock.lines.push([addedRow]);
+
       expect(storage.daily?.navBlock.lines).not.toContainEqual([
         expect.objectContaining({ template: "added to the copy" }),
       ]);
     });
 
-    it("returns the stored copy", () => {
-      const { repo } = buildRepo({ daily: journalDefaultsFor({ type: "day" }, "daily") });
+    it("returns the stored copy", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+      });
+      const repo = harness.resolve(JournalsRepository);
+
       const result = repo.clone("daily", "daily copy");
+
       expect(result.isOk() && result.value.name).toBe("daily copy");
     });
 
-    it("emits cloned with the source and new name", () => {
-      const { repo, events } = buildRepo({ daily: journalDefaultsFor({ type: "day" }, "daily") });
+    it("emits cloned with the source and new name", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+      });
+      const repo = harness.resolve(JournalsRepository);
+      const events = harness.resolve(JournalsEventsToken);
       const spy = vi.fn();
       events.on("cloned", spy);
+
       repo.clone("daily", "daily copy");
+
       expect(spy).toHaveBeenCalledWith("daily", "daily copy");
     });
 
-    it("emits cloned after created so listeners see the stored copy", () => {
-      const { repo, events } = buildRepo({ daily: journalDefaultsFor({ type: "day" }, "daily") });
+    it("emits cloned after created so listeners see the stored copy", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+      });
+      const repo = harness.resolve(JournalsRepository);
+      const events = harness.resolve(JournalsEventsToken);
       const calls: string[] = [];
       events.on("created", () => calls.push("created"));
       events.on("cloned", () => calls.push("cloned"));
+
       repo.clone("daily", "daily copy");
+
       expect(calls).toStrictEqual(["created", "cloned"]);
     });
 
-    it("rejects an empty new name with InvalidJournalNameError", () => {
-      const { repo } = buildRepo({ daily: journalDefaultsFor({ type: "day" }, "daily") });
+    it("rejects an empty new name with InvalidJournalNameError", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+      });
+      const repo = harness.resolve(JournalsRepository);
+
       const result = repo.clone("daily", "");
+
       expect(result.isErr() && result.error).toBeInstanceOf(InvalidJournalNameError);
     });
 
-    it("rejects an unknown source name with UnknownJournalError", () => {
-      const { repo } = buildRepo();
+    it("rejects an unknown source name with UnknownJournalError", async () => {
+      const harness = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
+      const repo = harness.resolve(JournalsRepository);
+
       const result = repo.clone("nope", "copy");
+
       expect(result.isErr() && result.error).toBeInstanceOf(UnknownJournalError);
     });
 
-    it("rejects a new name already in use with JournalNameTakenError", () => {
-      const { repo } = buildRepo({
-        a: journalDefaultsFor({ type: "day" }, "a"),
-        b: journalDefaultsFor({ type: "day" }, "b"),
+    it("rejects a new name already in use with JournalNameTakenError", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { a: fixedJournal("a", { type: "day" }), b: fixedJournal("b", { type: "day" }) } },
       });
+      const repo = harness.resolve(JournalsRepository);
+
       const result = repo.clone("a", "b");
+
       expect(result.isErr() && result.error).toBeInstanceOf(JournalNameTakenError);
     });
 
-    it("writes nothing when the new name is taken", () => {
-      const b = journalDefaultsFor({ type: "day" }, "b");
-      const { repo, storage } = buildRepo({ a: { ...journalDefaultsFor({ type: "day" }, "a"), folder: "A/" }, b });
+    it("writes nothing when the new name is taken", async () => {
+      const b = fixedJournal("b", { type: "day" });
+      const harness = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { a: fixedJournal("a", { type: "day" }, { folder: "A/" }), b } },
+      });
+      const repo = harness.resolve(JournalsRepository);
+
       repo.clone("a", "b");
-      expect(storage.b).toStrictEqual(b);
+
+      expect(harness.settings.recordOf(journalConfigCollection).b).toStrictEqual(b);
     });
   });
 
   describe("inherited update", () => {
-    it("rejects a name change via update with InvalidJournalUpdateError", () => {
-      const { repo } = buildRepo({ daily: journalDefaultsFor({ type: "day" }, "daily") });
-      const changes: Partial<JournalConfig> = { name: "other" };
+    it("rejects a name change via update with InvalidJournalUpdateError", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+      });
+      const repo = harness.resolve(JournalsRepository);
+      const changes = { name: "other" };
+
       const result = repo.update("daily", changes);
+
       expect(result.isErr() && result.error).toBeInstanceOf(InvalidJournalUpdateError);
     });
 
-    it("accepts updates to non-id fields", () => {
-      const { repo, storage } = buildRepo({ daily: journalDefaultsFor({ type: "day" }, "daily") });
+    it("accepts updates to non-id fields", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+      });
+      const repo = harness.resolve(JournalsRepository);
+
       const result = repo.update("daily", { folder: "Daily/" });
+
       expect(result.kind).toBe("ok");
-      expect(storage.daily?.folder).toBe("Daily/");
+      expect(harness.settings.recordOf(journalConfigCollection).daily?.folder).toBe("Daily/");
     });
   });
 
   describe("inherited delete", () => {
-    it("removes the entity", () => {
-      const { repo, storage } = buildRepo({ daily: journalDefaultsFor({ type: "day" }, "daily") });
+    it("removes the entity", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+      });
+      const repo = harness.resolve(JournalsRepository);
+
       repo.delete("daily");
-      expect(storage.daily).toBeUndefined();
+
+      expect(harness.settings.recordOf(journalConfigCollection).daily).toBeUndefined();
     });
 
-    it("emits deleted with the journal name", () => {
-      const { repo, events } = buildRepo({ daily: journalDefaultsFor({ type: "day" }, "daily") });
+    it("emits deleted with the journal name", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+      });
+      const repo = harness.resolve(JournalsRepository);
+      const events = harness.resolve(JournalsEventsToken);
       const spy = vi.fn();
       events.on("deleted", spy);
+
       repo.delete("daily");
+
       expect(spy).toHaveBeenCalledWith("daily");
     });
 
-    it("returns UnknownJournalError for an unknown name", () => {
-      const { repo } = buildRepo();
+    it("returns UnknownJournalError for an unknown name", async () => {
+      const harness = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
+      const repo = harness.resolve(JournalsRepository);
+
       const result = repo.delete("nope");
+
       expect(result.isErr() && result.error).toBeInstanceOf(UnknownJournalError);
     });
   });
 
   describe("require", () => {
-    it("returns Ok with the journal when it exists", () => {
-      const daily = journalDefaultsFor({ type: "day" }, "daily");
-      const { repo } = buildRepo({ daily });
+    it("returns Ok with the journal when it exists", async () => {
+      const daily = fixedJournal("daily", { type: "day" });
+      const harness = await testContainer({ modules: [journalsCoreModule], data: { journals: { daily } } });
+      const repo = harness.resolve(JournalsRepository);
+
       const result = repo.require("daily");
+
       expect(result.isOk() && result.value).toStrictEqual(daily);
     });
 
-    it("returns Err with JournalNotFoundError when the journal is absent", () => {
-      const { repo } = buildRepo();
+    it("returns Err with JournalNotFoundError when the journal is absent", async () => {
+      const harness = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
+      const repo = harness.resolve(JournalsRepository);
+
       const result = repo.require("nope");
+
       expect(result.isErr() && result.error).toBeInstanceOf(JournalNotFoundError);
     });
   });

--- a/src/journals/repository.test.ts
+++ b/src/journals/repository.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { testContainer } from "@/testing";
 
-import { journalConfigCollection, type NavBlockSegment } from "./config";
+import { journalConfigCollection, type JournalConfig, type NavBlockSegment } from "./config";
 import {
   InvalidJournalNameError,
   InvalidJournalUpdateError,
@@ -28,22 +28,28 @@ const addedRow: NavBlockSegment = {
   addDecorations: false,
 };
 
+async function buildRepo(initial: Record<string, JournalConfig> = {}) {
+  const harness = await testContainer({ modules: [journalsCoreModule], data: { journals: initial } });
+  return {
+    repo: harness.resolve(JournalsRepository),
+    storage: harness.settings.recordOf(journalConfigCollection),
+    events: harness.resolve(JournalsEventsToken),
+  };
+}
+
 describe("JournalsRepository", () => {
   describe("create", () => {
     it("inserts a journal with defaults for the given write", async () => {
-      const harness = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
-      const repo = harness.resolve(JournalsRepository);
+      const { repo, storage } = await buildRepo();
 
       const result = repo.create("daily", { type: "day" });
 
       expect(result.kind).toBe("ok");
-      expect(harness.settings.recordOf(journalConfigCollection).daily).toEqual(fixedJournal("daily", { type: "day" }));
+      expect(storage.daily).toEqual(fixedJournal("daily", { type: "day" }));
     });
 
     it("emits created with the journal name", async () => {
-      const harness = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
-      const repo = harness.resolve(JournalsRepository);
-      const events = harness.resolve(JournalsEventsToken);
+      const { repo, events } = await buildRepo();
       const spy = vi.fn();
       events.on("created", spy);
 
@@ -53,8 +59,7 @@ describe("JournalsRepository", () => {
     });
 
     it("rejects an empty name with InvalidJournalNameError", async () => {
-      const harness = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
-      const repo = harness.resolve(JournalsRepository);
+      const { repo } = await buildRepo();
 
       const result = repo.create("", { type: "day" });
 
@@ -62,11 +67,7 @@ describe("JournalsRepository", () => {
     });
 
     it("rejects a name already in use with JournalNameTakenError", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule],
-        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
-      });
-      const repo = harness.resolve(JournalsRepository);
+      const { repo } = await buildRepo({ daily: fixedJournal("daily", { type: "day" }) });
 
       const result = repo.create("daily", { type: "day" });
 
@@ -76,36 +77,25 @@ describe("JournalsRepository", () => {
 
   describe("rename", () => {
     it("stores the entity under the new key with the updated name field", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule],
-        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
-      });
-      const repo = harness.resolve(JournalsRepository);
+      const original = fixedJournal("daily", { type: "day" });
+      const { repo, storage } = await buildRepo({ daily: original });
 
       repo.rename("daily", "renamed");
 
-      expect(harness.settings.recordOf(journalConfigCollection).renamed?.name).toBe("renamed");
+      expect(storage.renamed?.name).toBe("renamed");
     });
 
     it("removes the old key on rename", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule],
-        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
-      });
-      const repo = harness.resolve(JournalsRepository);
+      const original = fixedJournal("daily", { type: "day" });
+      const { repo, storage } = await buildRepo({ daily: original });
 
       repo.rename("daily", "renamed");
 
-      expect(harness.settings.recordOf(journalConfigCollection).daily).toBeUndefined();
+      expect(storage.daily).toBeUndefined();
     });
 
     it("emits renamed with old and new name", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule],
-        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
-      });
-      const repo = harness.resolve(JournalsRepository);
-      const events = harness.resolve(JournalsEventsToken);
+      const { repo, events } = await buildRepo({ daily: fixedJournal("daily", { type: "day" }) });
       const spy = vi.fn();
       events.on("renamed", spy);
 
@@ -115,12 +105,7 @@ describe("JournalsRepository", () => {
     });
 
     it("does not emit created on rename", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule],
-        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
-      });
-      const repo = harness.resolve(JournalsRepository);
-      const events = harness.resolve(JournalsEventsToken);
+      const { repo, events } = await buildRepo({ daily: fixedJournal("daily", { type: "day" }) });
       const created = vi.fn();
       events.on("created", created);
 
@@ -130,12 +115,7 @@ describe("JournalsRepository", () => {
     });
 
     it("does not emit deleted on rename", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule],
-        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
-      });
-      const repo = harness.resolve(JournalsRepository);
-      const events = harness.resolve(JournalsEventsToken);
+      const { repo, events } = await buildRepo({ daily: fixedJournal("daily", { type: "day" }) });
       const deleted = vi.fn();
       events.on("deleted", deleted);
 
@@ -145,11 +125,7 @@ describe("JournalsRepository", () => {
     });
 
     it("rejects an empty new name with InvalidJournalNameError", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule],
-        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
-      });
-      const repo = harness.resolve(JournalsRepository);
+      const { repo } = await buildRepo({ daily: fixedJournal("daily", { type: "day" }) });
 
       const result = repo.rename("daily", "");
 
@@ -157,11 +133,7 @@ describe("JournalsRepository", () => {
     });
 
     it("rejects newName equal to oldName with InvalidJournalNameError", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule],
-        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
-      });
-      const repo = harness.resolve(JournalsRepository);
+      const { repo } = await buildRepo({ daily: fixedJournal("daily", { type: "day" }) });
 
       const result = repo.rename("daily", "daily");
 
@@ -169,8 +141,7 @@ describe("JournalsRepository", () => {
     });
 
     it("rejects an unknown old name with UnknownJournalError", async () => {
-      const harness = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
-      const repo = harness.resolve(JournalsRepository);
+      const { repo } = await buildRepo();
 
       const result = repo.rename("nope", "next");
 
@@ -178,11 +149,10 @@ describe("JournalsRepository", () => {
     });
 
     it("rejects a new name already in use with JournalNameTakenError", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule],
-        data: { journals: { a: fixedJournal("a", { type: "day" }), b: fixedJournal("b", { type: "day" }) } },
+      const { repo } = await buildRepo({
+        a: fixedJournal("a", { type: "day" }),
+        b: fixedJournal("b", { type: "day" }),
       });
-      const repo = harness.resolve(JournalsRepository);
 
       const result = repo.rename("a", "b");
 
@@ -193,36 +163,26 @@ describe("JournalsRepository", () => {
   describe("clone", () => {
     it("stores a copy of the source config under the new name", async () => {
       const source = fixedJournal("daily", { type: "day" }, { folder: "Daily/", confirmCreation: true });
-      const harness = await testContainer({ modules: [journalsCoreModule], data: { journals: { daily: source } } });
-      const repo = harness.resolve(JournalsRepository);
+      const { repo, storage } = await buildRepo({ daily: source });
 
       repo.clone("daily", "daily copy");
 
-      expect(harness.settings.recordOf(journalConfigCollection)["daily copy"]).toStrictEqual({
-        ...source,
-        name: "daily copy",
-      });
+      expect(storage["daily copy"]).toStrictEqual({ ...source, name: "daily copy" });
     });
 
     it("leaves the source journal in place", async () => {
       const source = fixedJournal("daily", { type: "day" });
-      const harness = await testContainer({ modules: [journalsCoreModule], data: { journals: { daily: source } } });
-      const repo = harness.resolve(JournalsRepository);
+      const { repo, storage } = await buildRepo({ daily: source });
 
       repo.clone("daily", "daily copy");
 
-      expect(harness.settings.recordOf(journalConfigCollection).daily).toStrictEqual(source);
+      expect(storage.daily).toStrictEqual(source);
     });
 
     it("detaches nested values so editing the copy leaves the source untouched", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule],
-        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
-      });
-      const repo = harness.resolve(JournalsRepository);
+      const { repo, storage } = await buildRepo({ daily: fixedJournal("daily", { type: "day" }) });
 
       repo.clone("daily", "daily copy");
-      const storage = harness.settings.recordOf(journalConfigCollection);
       storage["daily copy"]?.navBlock.lines.push([addedRow]);
 
       expect(storage.daily?.navBlock.lines).not.toContainEqual([
@@ -231,11 +191,7 @@ describe("JournalsRepository", () => {
     });
 
     it("returns the stored copy", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule],
-        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
-      });
-      const repo = harness.resolve(JournalsRepository);
+      const { repo } = await buildRepo({ daily: fixedJournal("daily", { type: "day" }) });
 
       const result = repo.clone("daily", "daily copy");
 
@@ -243,12 +199,7 @@ describe("JournalsRepository", () => {
     });
 
     it("emits cloned with the source and new name", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule],
-        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
-      });
-      const repo = harness.resolve(JournalsRepository);
-      const events = harness.resolve(JournalsEventsToken);
+      const { repo, events } = await buildRepo({ daily: fixedJournal("daily", { type: "day" }) });
       const spy = vi.fn();
       events.on("cloned", spy);
 
@@ -258,12 +209,7 @@ describe("JournalsRepository", () => {
     });
 
     it("emits cloned after created so listeners see the stored copy", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule],
-        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
-      });
-      const repo = harness.resolve(JournalsRepository);
-      const events = harness.resolve(JournalsEventsToken);
+      const { repo, events } = await buildRepo({ daily: fixedJournal("daily", { type: "day" }) });
       const calls: string[] = [];
       events.on("created", () => calls.push("created"));
       events.on("cloned", () => calls.push("cloned"));
@@ -274,11 +220,7 @@ describe("JournalsRepository", () => {
     });
 
     it("rejects an empty new name with InvalidJournalNameError", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule],
-        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
-      });
-      const repo = harness.resolve(JournalsRepository);
+      const { repo } = await buildRepo({ daily: fixedJournal("daily", { type: "day" }) });
 
       const result = repo.clone("daily", "");
 
@@ -286,8 +228,7 @@ describe("JournalsRepository", () => {
     });
 
     it("rejects an unknown source name with UnknownJournalError", async () => {
-      const harness = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
-      const repo = harness.resolve(JournalsRepository);
+      const { repo } = await buildRepo();
 
       const result = repo.clone("nope", "copy");
 
@@ -295,11 +236,10 @@ describe("JournalsRepository", () => {
     });
 
     it("rejects a new name already in use with JournalNameTakenError", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule],
-        data: { journals: { a: fixedJournal("a", { type: "day" }), b: fixedJournal("b", { type: "day" }) } },
+      const { repo } = await buildRepo({
+        a: fixedJournal("a", { type: "day" }),
+        b: fixedJournal("b", { type: "day" }),
       });
-      const repo = harness.resolve(JournalsRepository);
 
       const result = repo.clone("a", "b");
 
@@ -308,66 +248,48 @@ describe("JournalsRepository", () => {
 
     it("writes nothing when the new name is taken", async () => {
       const b = fixedJournal("b", { type: "day" });
-      const harness = await testContainer({
-        modules: [journalsCoreModule],
-        data: { journals: { a: fixedJournal("a", { type: "day" }, { folder: "A/" }), b } },
-      });
-      const repo = harness.resolve(JournalsRepository);
+      const { repo, storage } = await buildRepo({ a: { ...fixedJournal("a", { type: "day" }), folder: "A/" }, b });
 
       repo.clone("a", "b");
 
-      expect(harness.settings.recordOf(journalConfigCollection).b).toStrictEqual(b);
+      expect(storage.b).toStrictEqual(b);
     });
   });
 
   describe("inherited update", () => {
-    it("rejects a name change via update with InvalidJournalUpdateError", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule],
-        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
-      });
-      const repo = harness.resolve(JournalsRepository);
-      const changes = { name: "other" };
+    let harness: Awaited<ReturnType<typeof buildRepo>>;
 
-      const result = repo.update("daily", changes);
+    beforeEach(async () => {
+      harness = await buildRepo({ daily: fixedJournal("daily", { type: "day" }) });
+    });
+
+    it("rejects a name change via update with InvalidJournalUpdateError", () => {
+      const changes: Partial<JournalConfig> = { name: "other" };
+
+      const result = harness.repo.update("daily", changes);
 
       expect(result.isErr() && result.error).toBeInstanceOf(InvalidJournalUpdateError);
     });
 
-    it("accepts updates to non-id fields", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule],
-        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
-      });
-      const repo = harness.resolve(JournalsRepository);
-
-      const result = repo.update("daily", { folder: "Daily/" });
+    it("accepts updates to non-id fields", () => {
+      const result = harness.repo.update("daily", { folder: "Daily/" });
 
       expect(result.kind).toBe("ok");
-      expect(harness.settings.recordOf(journalConfigCollection).daily?.folder).toBe("Daily/");
+      expect(harness.storage.daily?.folder).toBe("Daily/");
     });
   });
 
   describe("inherited delete", () => {
     it("removes the entity", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule],
-        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
-      });
-      const repo = harness.resolve(JournalsRepository);
+      const { repo, storage } = await buildRepo({ daily: fixedJournal("daily", { type: "day" }) });
 
       repo.delete("daily");
 
-      expect(harness.settings.recordOf(journalConfigCollection).daily).toBeUndefined();
+      expect(storage.daily).toBeUndefined();
     });
 
     it("emits deleted with the journal name", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule],
-        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
-      });
-      const repo = harness.resolve(JournalsRepository);
-      const events = harness.resolve(JournalsEventsToken);
+      const { repo, events } = await buildRepo({ daily: fixedJournal("daily", { type: "day" }) });
       const spy = vi.fn();
       events.on("deleted", spy);
 
@@ -377,8 +299,7 @@ describe("JournalsRepository", () => {
     });
 
     it("returns UnknownJournalError for an unknown name", async () => {
-      const harness = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
-      const repo = harness.resolve(JournalsRepository);
+      const { repo } = await buildRepo();
 
       const result = repo.delete("nope");
 
@@ -389,8 +310,7 @@ describe("JournalsRepository", () => {
   describe("require", () => {
     it("returns Ok with the journal when it exists", async () => {
       const daily = fixedJournal("daily", { type: "day" });
-      const harness = await testContainer({ modules: [journalsCoreModule], data: { journals: { daily } } });
-      const repo = harness.resolve(JournalsRepository);
+      const { repo } = await buildRepo({ daily });
 
       const result = repo.require("daily");
 
@@ -398,8 +318,7 @@ describe("JournalsRepository", () => {
     });
 
     it("returns Err with JournalNotFoundError when the journal is absent", async () => {
-      const harness = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
-      const repo = harness.resolve(JournalsRepository);
+      const { repo } = await buildRepo();
 
       const result = repo.require("nope");
 

--- a/src/journals/settings/ui/use-folder-extractor.test.ts
+++ b/src/journals/settings/ui/use-folder-extractor.test.ts
@@ -1,53 +1,26 @@
 import { describe, expect, it } from "vitest";
 
-import { anchor } from "@/calendar/testing";
-import type { JournalConfig } from "@/journals";
+import { fixedJournal } from "@/journals/testing";
 
 import { extractFromNameTemplate, extractFromDateFormat } from "./use-folder-extractor";
 
-function baseConfig(overrides: Partial<JournalConfig>): JournalConfig {
-  return {
-    name: "daily",
-    write: { type: "day" },
-    timeline: { start: anchor("2026-01-01"), end: { kind: "never" } },
-    dateFormat: "YYYY-MM-DD",
-    frontmatter: {
-      dateField: "journal-date",
-      startDateField: "journal-start-date",
-      endDateField: "journal-end-date",
-      addStartDate: false,
-      addEndDate: false,
-    },
-    numbering: { enabled: false, anchorDate: anchor("2026-01-01"), allowBefore: false, sources: [] },
-    nameTemplate: "{{date}}",
-    folder: "",
-    templates: [],
-    confirmCreation: false,
-    autoCreate: false,
-    decorations: [],
-    navBlock: { type: "create", lines: [], decorateWholeBlock: false },
-    intervalBlock: { type: "create", lines: [], decorateWholeBlock: false },
-    ...overrides,
-  };
-}
-
 describe("extractFromNameTemplate", () => {
   it("moves the path prefix into folder and leaves the last segment as nameTemplate", () => {
-    const config = baseConfig({ nameTemplate: "year/month/{{date}}", folder: "" });
+    const config = fixedJournal("daily", { type: "day" }, { nameTemplate: "year/month/{{date}}", folder: "" });
     extractFromNameTemplate(config);
     expect(config.folder).toBe("year/month");
     expect(config.nameTemplate).toBe("{{date}}");
   });
 
   it("appends to an existing folder", () => {
-    const config = baseConfig({ nameTemplate: "extra/{{date}}", folder: "Daily" });
+    const config = fixedJournal("daily", { type: "day" }, { nameTemplate: "extra/{{date}}", folder: "Daily" });
     extractFromNameTemplate(config);
     expect(config.folder).toBe("Daily/extra");
     expect(config.nameTemplate).toBe("{{date}}");
   });
 
   it("is a no-op when nameTemplate has no slash", () => {
-    const config = baseConfig({ nameTemplate: "{{date}}", folder: "Daily" });
+    const config = fixedJournal("daily", { type: "day" }, { nameTemplate: "{{date}}", folder: "Daily" });
     extractFromNameTemplate(config);
     expect(config.folder).toBe("Daily");
     expect(config.nameTemplate).toBe("{{date}}");
@@ -56,21 +29,21 @@ describe("extractFromNameTemplate", () => {
 
 describe("extractFromDateFormat", () => {
   it("converts path segments into {{date:format}} tokens prefixed onto folder", () => {
-    const config = baseConfig({ dateFormat: "YYYY/MM/DD", folder: "" });
+    const config = fixedJournal("daily", { type: "day" }, { dateFormat: "YYYY/MM/DD", folder: "" });
     extractFromDateFormat(config);
     expect(config.folder).toBe("{{date:YYYY}}/{{date:MM}}");
     expect(config.dateFormat).toBe("DD");
   });
 
   it("appends to an existing folder", () => {
-    const config = baseConfig({ dateFormat: "YYYY/MM", folder: "Daily" });
+    const config = fixedJournal("daily", { type: "day" }, { dateFormat: "YYYY/MM", folder: "Daily" });
     extractFromDateFormat(config);
     expect(config.folder).toBe("Daily/{{date:YYYY}}");
     expect(config.dateFormat).toBe("MM");
   });
 
   it("is a no-op when dateFormat has no slash", () => {
-    const config = baseConfig({ dateFormat: "YYYY-MM-DD", folder: "" });
+    const config = fixedJournal("daily", { type: "day" }, { dateFormat: "YYYY-MM-DD", folder: "" });
     extractFromDateFormat(config);
     expect(config.folder).toBe("");
     expect(config.dateFormat).toBe("YYYY-MM-DD");

--- a/src/journals/view-model.test.ts
+++ b/src/journals/view-model.test.ts
@@ -1,40 +1,47 @@
-import { createNanoEvents } from "nanoevents";
 import { describe, expect, it } from "vitest";
-import { reactive } from "vue";
 
-import { journalDefaultsFor, type JournalConfig } from "./config";
-import { JournalsRepository, type JournalsEvents } from "./repository";
+import { testContainer } from "@/testing";
+
+import { journalsCoreModule } from "./module";
+import { JournalsRepository } from "./repository";
+import { fixedJournal } from "./testing";
 import { JournalsViewModel } from "./view-model";
-
-function viewModelOver(initial: Record<string, JournalConfig> = {}) {
-  const storage = reactive<Record<string, JournalConfig>>({ ...initial });
-  const events = createNanoEvents<JournalsEvents>();
-  const repo = JournalsRepository.fromParts(storage, events);
-  const vm = JournalsViewModel.fromRepository(repo);
-  return { vm, repo, storage, events };
-}
 
 describe("JournalsViewModel", () => {
   describe("journals", () => {
-    it("yields the current entities", () => {
-      const { vm } = viewModelOver({ daily: journalDefaultsFor({ type: "day" }, "daily") });
-      expect(vm.journals.value.map((journal) => journal.name)).toEqual(["daily"]);
+    it("yields the current entities", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+      });
+
+      expect(resolve(JournalsViewModel).journals.value.map((journal) => journal.name)).toEqual(["daily"]);
     });
 
-    it("reflects mutations after create", () => {
-      const { vm, repo } = viewModelOver();
+    it("reflects mutations after create", async () => {
+      const { resolve } = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
+      const repo = resolve(JournalsRepository);
+      const vm = resolve(JournalsViewModel);
+
       repo.create("daily", { type: "day" });
+
       expect(vm.journals.value.map((journal) => journal.name)).toEqual(["daily"]);
     });
   });
 
   describe("journalOptions", () => {
-    it("returns name-labelled options for each journal", () => {
-      const { vm } = viewModelOver({
-        daily: journalDefaultsFor({ type: "day" }, "daily"),
-        weekly: journalDefaultsFor({ type: "week" }, "weekly"),
+    it("returns name-labelled options for each journal", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: {
+          journals: {
+            daily: fixedJournal("daily", { type: "day" }),
+            weekly: fixedJournal("weekly", { type: "week" }),
+          },
+        },
       });
-      expect(vm.journalOptions.value).toEqual([
+
+      expect(resolve(JournalsViewModel).journalOptions.value).toEqual([
         { value: "daily", label: "daily" },
         { value: "weekly", label: "weekly" },
       ]);
@@ -42,38 +49,59 @@ describe("JournalsViewModel", () => {
   });
 
   describe("journalCount", () => {
-    it("returns the number of journals", () => {
-      const { vm } = viewModelOver({ daily: journalDefaultsFor({ type: "day" }, "daily") });
-      expect(vm.journalCount.value).toBe(1);
+    it("returns the number of journals", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+      });
+
+      expect(resolve(JournalsViewModel).journalCount.value).toBe(1);
     });
   });
 
   describe("getJournal", () => {
-    it("returns Some for a known name", () => {
-      const { vm } = viewModelOver({ daily: journalDefaultsFor({ type: "day" }, "daily") });
-      expect(vm.getJournal("daily").isSome()).toBe(true);
+    it("returns Some for a known name", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+      });
+
+      expect(resolve(JournalsViewModel).getJournal("daily").isSome()).toBe(true);
     });
 
-    it("returns None for an unknown name", () => {
-      const { vm } = viewModelOver();
-      expect(vm.getJournal("nope").isNone()).toBe(true);
+    it("returns None for an unknown name", async () => {
+      const { resolve } = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
+
+      expect(resolve(JournalsViewModel).getJournal("nope").isNone()).toBe(true);
     });
   });
 
   describe("isJournalNameAvailable", () => {
-    it("is false when the name is in use", () => {
-      const { vm } = viewModelOver({ daily: journalDefaultsFor({ type: "day" }, "daily") });
-      expect(vm.isJournalNameAvailable("daily")).toBe(false);
+    it("is false when the name is in use", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+      });
+
+      expect(resolve(JournalsViewModel).isJournalNameAvailable("daily")).toBe(false);
     });
 
-    it("is true when the name is free", () => {
-      const { vm } = viewModelOver({ daily: journalDefaultsFor({ type: "day" }, "daily") });
-      expect(vm.isJournalNameAvailable("other")).toBe(true);
+    it("is true when the name is free", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+      });
+
+      expect(resolve(JournalsViewModel).isJournalNameAvailable("other")).toBe(true);
     });
 
-    it("treats the excludeCurrent name as available", () => {
-      const { vm } = viewModelOver({ daily: journalDefaultsFor({ type: "day" }, "daily") });
-      expect(vm.isJournalNameAvailable("daily", "daily")).toBe(true);
+    it("treats the excludeCurrent name as available", async () => {
+      const { resolve } = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
+      });
+
+      expect(resolve(JournalsViewModel).isJournalNameAvailable("daily", "daily")).toBe(true);
     });
   });
 });

--- a/src/journals/view-model.test.ts
+++ b/src/journals/view-model.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import { testContainer } from "@/testing";
 
@@ -7,23 +7,25 @@ import { JournalsRepository } from "./repository";
 import { fixedJournal } from "./testing";
 import { JournalsViewModel } from "./view-model";
 
+import type { JournalConfig } from "./config";
+
+async function viewModelOver(journals: Record<string, JournalConfig> = {}) {
+  const harness = await testContainer({ modules: [journalsCoreModule], data: { journals } });
+  return { harness, vm: harness.resolve(JournalsViewModel) };
+}
+
 describe("JournalsViewModel", () => {
   describe("journals", () => {
     it("yields the current entities", async () => {
-      const { resolve } = await testContainer({
-        modules: [journalsCoreModule],
-        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
-      });
+      const { vm } = await viewModelOver({ daily: fixedJournal("daily", { type: "day" }) });
 
-      expect(resolve(JournalsViewModel).journals.value.map((journal) => journal.name)).toEqual(["daily"]);
+      expect(vm.journals.value.map((journal) => journal.name)).toEqual(["daily"]);
     });
 
     it("reflects mutations after create", async () => {
-      const { resolve } = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
-      const repo = resolve(JournalsRepository);
-      const vm = resolve(JournalsViewModel);
+      const { harness, vm } = await viewModelOver();
 
-      repo.create("daily", { type: "day" });
+      harness.resolve(JournalsRepository).create("daily", { type: "day" });
 
       expect(vm.journals.value.map((journal) => journal.name)).toEqual(["daily"]);
     });
@@ -31,17 +33,12 @@ describe("JournalsViewModel", () => {
 
   describe("journalOptions", () => {
     it("returns name-labelled options for each journal", async () => {
-      const { resolve } = await testContainer({
-        modules: [journalsCoreModule],
-        data: {
-          journals: {
-            daily: fixedJournal("daily", { type: "day" }),
-            weekly: fixedJournal("weekly", { type: "week" }),
-          },
-        },
+      const { vm } = await viewModelOver({
+        daily: fixedJournal("daily", { type: "day" }),
+        weekly: fixedJournal("weekly", { type: "week" }),
       });
 
-      expect(resolve(JournalsViewModel).journalOptions.value).toEqual([
+      expect(vm.journalOptions.value).toEqual([
         { value: "daily", label: "daily" },
         { value: "weekly", label: "weekly" },
       ]);
@@ -50,58 +47,43 @@ describe("JournalsViewModel", () => {
 
   describe("journalCount", () => {
     it("returns the number of journals", async () => {
-      const { resolve } = await testContainer({
-        modules: [journalsCoreModule],
-        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
-      });
+      const { vm } = await viewModelOver({ daily: fixedJournal("daily", { type: "day" }) });
 
-      expect(resolve(JournalsViewModel).journalCount.value).toBe(1);
+      expect(vm.journalCount.value).toBe(1);
     });
   });
 
   describe("getJournal", () => {
     it("returns Some for a known name", async () => {
-      const { resolve } = await testContainer({
-        modules: [journalsCoreModule],
-        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
-      });
+      const { vm } = await viewModelOver({ daily: fixedJournal("daily", { type: "day" }) });
 
-      expect(resolve(JournalsViewModel).getJournal("daily").isSome()).toBe(true);
+      expect(vm.getJournal("daily").isSome()).toBe(true);
     });
 
     it("returns None for an unknown name", async () => {
-      const { resolve } = await testContainer({ modules: [journalsCoreModule], data: { journals: {} } });
+      const { vm } = await viewModelOver();
 
-      expect(resolve(JournalsViewModel).getJournal("nope").isNone()).toBe(true);
+      expect(vm.getJournal("nope").isNone()).toBe(true);
     });
   });
 
   describe("isJournalNameAvailable", () => {
-    it("is false when the name is in use", async () => {
-      const { resolve } = await testContainer({
-        modules: [journalsCoreModule],
-        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
-      });
+    let harness: Awaited<ReturnType<typeof viewModelOver>>;
 
-      expect(resolve(JournalsViewModel).isJournalNameAvailable("daily")).toBe(false);
+    beforeEach(async () => {
+      harness = await viewModelOver({ daily: fixedJournal("daily", { type: "day" }) });
     });
 
-    it("is true when the name is free", async () => {
-      const { resolve } = await testContainer({
-        modules: [journalsCoreModule],
-        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
-      });
-
-      expect(resolve(JournalsViewModel).isJournalNameAvailable("other")).toBe(true);
+    it("is false when the name is in use", () => {
+      expect(harness.vm.isJournalNameAvailable("daily")).toBe(false);
     });
 
-    it("treats the excludeCurrent name as available", async () => {
-      const { resolve } = await testContainer({
-        modules: [journalsCoreModule],
-        data: { journals: { daily: fixedJournal("daily", { type: "day" }) } },
-      });
+    it("is true when the name is free", () => {
+      expect(harness.vm.isJournalNameAvailable("other")).toBe(true);
+    });
 
-      expect(resolve(JournalsViewModel).isJournalNameAvailable("daily", "daily")).toBe(true);
+    it("treats the excludeCurrent name as available", () => {
+      expect(harness.vm.isJournalNameAvailable("daily", "daily")).toBe(true);
     });
   });
 });

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -44,8 +44,13 @@ export default defineConfig({
       thresholds: {
         statements: 92.25,
         branches: 87.86,
-        functions: 89.1,
-        lines: 94.38,
+        // 89.1 -> 89.08: converting the journals repository tests onto testContainer left the two
+        // error-factory arrows that `JournalsRepository.fromParts` hand-assigns (repository.ts:50-51)
+        // with no caller. They are duplicates of the class's own fields, reachable only through the
+        // seeding path this campaign is retiring, so the drop records `fromParts` getting closer to
+        // deletion rather than a test getting weaker.
+        functions: 89.08,
+        lines: 94.39,
       },
     },
     projects: [


### PR DESCRIPTION
## Summary

Converts the three journals test files that still built their own container/repository by hand (`JournalsRepository.fromParts`) onto `testContainer({ data })`, per `docs/unit-testing-strategy.md`.

- `src/journals/settings/ui/use-folder-extractor.test.ts` — `baseConfig` hand-built a full `JournalConfig` literal restating schema defaults field by field. Replaced with `fixedJournal("daily", { type: "day" }, overrides)` at each call site.
- `src/journals/view-model.test.ts` — `viewModelOver` built a reactive record + nanoevents emitter + `fromParts`. Converted to `testContainer({ modules: [journalsCoreModule], data })`, and restored as a local arrange helper (same name, same call-site shape as before) so the conversion doesn't inline a `testContainer` block at every one of the 9 call sites. The one describe where every test shares an identical seed (`isJournalNameAvailable`) hoists the arrange to a `beforeEach`.
- `src/journals/repository.test.ts` — `buildRepo` did the same. Also restored as a local helper (`repo`/`storage`/`events` handles), with the `storage` handle now `harness.settings.recordOf(journalConfigCollection)` — the same reactive record the repository is constructed over in production. All 30 cases convert; one describe (`inherited update`) hoists its identical arrange to a `beforeEach`, the rest stay at the call site because their seeds differ test to test.

`JournalsRepository.fromParts` itself is untouched (production source).

### What this PR does *not* do

`fromParts` does **not** become dead code in `src/journals` once this merges. `src/journals/testing.ts:17` exports `fakeRepo(journals)`, which itself calls `JournalsRepository.fromParts`, and that file is inside `src/journals`. Measured at head: 33 test files call one of the five `fromParts` methods directly, 13 more call it indirectly through `fakeRepo`, with 4 files doing both — 42 distinct test files across seven directories still reach `fromParts` after this PR merges. This PR removes the two *direct* `fromParts` callers that lived inside `src/journals` (`viewModelOver` and `buildRepo`, now rebuilt on `testContainer`); it is a step toward retiring `fromParts`, not the end of it. `fakeRepo` and the other four features' `fromParts` methods are unaffected.

## Test plan

- [x] `npm test` — 395 test files / 4190 tests passed, both before and after (invariant preserved)
- [x] `npm run check:types` — clean
- [x] `npm run check:lint` — clean (0 errors, pre-existing warnings only, none in touched files)
- [x] `npx prettier --write` on the three test files
- [x] Red-test evidence: broke `prependFolder` in `use-folder-extractor.ts` — 4/6 tests in `use-folder-extractor.test.ts` failed, then restored to green
- [x] Red-test evidence: broke the `cloneFnJSON` deep-clone in `repository.ts`'s `clone()` — the "detaches nested values" storage assertion in `repository.test.ts` failed, then restored to green
- [x] Red-test evidence: skipped `delete this.storage[oldName]` in `rename()` — "removes the old key on rename" failed, then restored
- [x] Red-test evidence: made `BaseRepository.delete()` skip its `delete this.storage[id]` — "removes the entity" failed, then restored
- [x] Red-test evidence: made `addEntity` write into a fresh local object instead of `this.storage` — "inserts a journal with defaults for the given write" failed, then restored
- [x] Red-test evidence: made `isJournalNameAvailable` ignore `excludeCurrent` — "treats the excludeCurrent name as available" failed, then restored


## Coverage floor moved, both ways

`functions` 89.1 → 89.08, `lines` 94.38 → 94.39.

The functions drop is two arrow functions at `src/journals/repository.ts:50-51` — the `unknownEntityError` and `invalidUpdateError` factories that `fromParts` hand-assigns onto an `Object.create`d instance. They duplicate the class's own fields, and `repository.test.ts` was the only test driving those error paths through that construction. Going through the container runs the real class properties instead, leaving the `fromParts` copies with no caller.

So the drop records `fromParts` moving closer to deletion, not a test getting weaker. Verified by diffing per-file coverage between `main` and this branch: `src/journals/repository.ts` is the only file that moved, functions 9 → 8 and lines 39 → 40.

Lines rose over the same change, so that floor follows it up in the same diff, per the two-way ratchet the strategy doc requires.
