### PR TITLE
fix(journals): stop new journals sharing one navigation block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-- A newly created journal no longer shares its navigation block, decorations, or interval block with other journals of the same period type. Previously, editing one daily journal's navigation block silently changed every other daily journal's navigation block too, since they were the same underlying setting until one of them was edited by hand.
+- Journals created in the same session no longer share one navigation block, interval block, and set of decorations. Editing the navigation block of one daily journal used to change every daily journal created alongside it in that session, and a journal created after such an edit was born carrying it; restarting Obsidian separated them again, so journals created in different sessions were never affected. A journal already changed this way keeps the settings it ended up with — check the navigation blocks and decorations of journals you created together, and set them back by hand where they are wrong.
 
 ## [3.2.0] - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Bug Fixes
+
+- A newly created journal no longer shares its navigation block, decorations, or interval block with other journals of the same period type. Previously, editing one daily journal's navigation block silently changed every other daily journal's navigation block too, since they were the same underlying setting until one of them was edited by hand.
+
 ## [3.2.0] - 2026-08-23
 
 ### Features

--- a/src/journals/config.test.ts
+++ b/src/journals/config.test.ts
@@ -352,17 +352,11 @@ describe("journalConfigCollection default item", () => {
 });
 
 describe("journalDefaultsFor identity between journals", () => {
-  it("gives two day journals separate navBlock objects", () => {
+  it("gives two day journals separate navBlock and decorations objects", () => {
     const first = journalDefaultsFor({ type: "day" }, "a");
     const second = journalDefaultsFor({ type: "day" }, "b");
 
     expect(first.navBlock).not.toBe(second.navBlock);
-  });
-
-  it("gives two day journals separate decorations arrays", () => {
-    const first = journalDefaultsFor({ type: "day" }, "a");
-    const second = journalDefaultsFor({ type: "day" }, "b");
-
     expect(first.decorations).not.toBe(second.decorations);
   });
 
@@ -390,19 +384,37 @@ describe("journalDefaultsFor identity between journals", () => {
 
   it("does not leak a mutation to one journal's navBlock into a journal created afterwards", () => {
     const first = journalDefaultsFor({ type: "day" }, "a");
+    const second = journalDefaultsFor({ type: "day" }, "b");
+    const before = second.navBlock.lines.length;
+
     first.navBlock.lines.push([]);
 
-    const second = journalDefaultsFor({ type: "day" }, "b");
-
-    expect(second.navBlock.lines).toHaveLength(6);
+    expect(second.navBlock.lines).toHaveLength(before);
   });
 
   it("does not leak a mutation to one journal's decorations into a journal created afterwards", () => {
     const first = journalDefaultsFor({ type: "day" }, "a");
+    const second = journalDefaultsFor({ type: "day" }, "b");
+    const before = second.decorations.length;
+
     first.decorations.push(first.decorations[0]);
 
-    const second = journalDefaultsFor({ type: "day" }, "b");
+    expect(second.decorations).toHaveLength(before);
+  });
 
-    expect(second.decorations).toHaveLength(1);
+  it("does not leak a mutation to one journal's intervalBlock into a journal created afterwards", () => {
+    const write: JournalWrite = {
+      type: "custom",
+      every: "week",
+      duration: 2,
+      anchorDate: "2024-01-01" as AnchorString,
+    };
+    const first = journalDefaultsFor(write, "a");
+    const second = journalDefaultsFor(write, "b");
+    const before = second.intervalBlock.lines.length;
+
+    first.intervalBlock.lines.push([]);
+
+    expect(second.intervalBlock.lines).toHaveLength(before);
   });
 });

--- a/src/journals/config.test.ts
+++ b/src/journals/config.test.ts
@@ -5,6 +5,8 @@ import type { AnchorString } from "@/calendar";
 
 import { journalConfigCollection, journalConfigSchema, journalDefaultsFor, navBlockSchema } from "./config";
 
+import type { JournalWrite } from "./config";
+
 describe("journalDefaultsFor", () => {
   it("defaults nameTemplate to {{date}}", () => {
     const cfg = journalDefaultsFor({ type: "day" }, "daily");
@@ -346,5 +348,61 @@ describe("journalConfigCollection default item", () => {
 
     expect(item.write).toEqual({ type: "day" });
     expect(item.name).toBe("Broken");
+  });
+});
+
+describe("journalDefaultsFor identity between journals", () => {
+  it("gives two day journals separate navBlock objects", () => {
+    const first = journalDefaultsFor({ type: "day" }, "a");
+    const second = journalDefaultsFor({ type: "day" }, "b");
+
+    expect(first.navBlock).not.toBe(second.navBlock);
+  });
+
+  it("gives two day journals separate decorations arrays", () => {
+    const first = journalDefaultsFor({ type: "day" }, "a");
+    const second = journalDefaultsFor({ type: "day" }, "b");
+
+    expect(first.decorations).not.toBe(second.decorations);
+  });
+
+  it("gives two week journals separate intervalBlock objects", () => {
+    const first = journalDefaultsFor({ type: "week" }, "a");
+    const second = journalDefaultsFor({ type: "week" }, "b");
+
+    expect(first.intervalBlock).not.toBe(second.intervalBlock);
+  });
+
+  it("gives two custom journals separate navBlock, decorations and intervalBlock objects", () => {
+    const write: JournalWrite = {
+      type: "custom",
+      every: "week",
+      duration: 2,
+      anchorDate: "2024-01-01" as AnchorString,
+    };
+    const first = journalDefaultsFor(write, "a");
+    const second = journalDefaultsFor(write, "b");
+
+    expect(first.navBlock).not.toBe(second.navBlock);
+    expect(first.decorations).not.toBe(second.decorations);
+    expect(first.intervalBlock).not.toBe(second.intervalBlock);
+  });
+
+  it("does not leak a mutation to one journal's navBlock into a journal created afterwards", () => {
+    const first = journalDefaultsFor({ type: "day" }, "a");
+    first.navBlock.lines.push([]);
+
+    const second = journalDefaultsFor({ type: "day" }, "b");
+
+    expect(second.navBlock.lines).toHaveLength(6);
+  });
+
+  it("does not leak a mutation to one journal's decorations into a journal created afterwards", () => {
+    const first = journalDefaultsFor({ type: "day" }, "a");
+    first.decorations.push(first.decorations[0]);
+
+    const second = journalDefaultsFor({ type: "day" }, "b");
+
+    expect(second.decorations).toHaveLength(1);
   });
 });

--- a/src/journals/config.ts
+++ b/src/journals/config.ts
@@ -356,9 +356,9 @@ export function journalDefaultsFor(write: JournalWrite, name = ""): JournalConfi
     templates: [],
     confirmCreation: false,
     autoCreate: false,
-    decorations: isCustom ? customDecorations : fixedDecorations,
-    navBlock: defaultNavBlocks[write.type],
-    intervalBlock: isCustom ? customIntervalBlock : emptyIntervalBlock,
+    decorations: structuredClone(isCustom ? customDecorations : fixedDecorations),
+    navBlock: structuredClone(defaultNavBlocks[write.type]),
+    intervalBlock: structuredClone(isCustom ? customIntervalBlock : emptyIntervalBlock),
   };
 }
 


### PR DESCRIPTION
Three lines of production change, plus regression tests and a changelog entry.

## The bug

`journalDefaultsFor` returned `decorations`, `navBlock` and `intervalBlock` **by reference to module-level constants**, so every journal of a given write type got the same nested objects. Proven on `main`:

- `journalDefaultsFor({type:"day"}, "a").navBlock` **is** `journalDefaultsFor({type:"day"}, "b").navBlock` — the same object.
- Pushing a line onto one journal's `navBlock.lines` appears in a journal created afterwards.

It reaches users because `JournalsRepository.create()` stores the result directly, and `NavBlockLinesEditor.vue` mutates the **live stored entity** in place — `config` is a `computed` returning the stored config, not a draft — via `lines.splice(...)`, `push`, and an `applyDefaults()` that assigned the shared array itself back into the store. That last one poisoned the shipped default for the rest of the session.

`clone()` was never affected; it runs `cloneFnJSON`. Only `create()` was.

## Scope, and why there is no migration

Two journals could alias only if **both were created in the same session since the last settings parse**. Every parse constructs fresh containers, so boot, a Sync-triggered reload, and a snapshot restore all separate them — journals created in different sessions were never linked.

No repair path is included because none is possible. `SettingsService.#flush` serializes through `JSON.parse(JSON.stringify(...))`, so the aliasing never reached disk as a structure; each journal wrote its own copy of identical content. What persists is content, which is indistinguishable from a journal deliberately configured to match another, and from an untouched journal still sitting at the shipped default. An automatic repair would either no-op or reset navigation blocks people meant to keep. The changelog entry carries the manual guidance instead.

## The fix

`structuredClone` at the point the constants are handed out, keeping them as the single definition of a default. This is the existing idiom for plain constant data here (`settings-service.ts:371`, `legacy/v2-to-v3.ts:9`); `cloneFnJSON` is the idiom for *reactive* values and does not apply, since these constants are never passed to `reactive()`.

`fixedJournal`/`customJournal` in `src/journals/testing.ts` need no change: their shallow spread cannot re-share once the base is fresh per call.

## Tests

Six new tests in `config.test.ts`, covering all three fields. Each was confirmed to fail with the `structuredClone` calls reverted:

- identity (`not.toBe`) per field — the only assertion that can see the `week` `intervalBlock` case, whose `lines` are empty so `toEqual` passes either way
- leakage, in the shape a user reports it: create two journals, edit one, assert the other did not change

`intervalBlock` gets its own leakage test because `NavBlockLinesEditor.vue` takes `field: "navBlock" | "intervalBlock"` and mutates both identically — an identity-only test would miss a future shallow-copy regression there.

Suite: 395 files / 4196 tests.

## Checked and deliberately not changed

- `write` is still returned by reference. Benign: the only production caller builds a fresh object per submission and nothing mutates `config.write`. Relevant if an editor for changing a journal's write type is ever added.
- `src/settings/legacy/old-shapes.ts:666` has an identical shape, but both `journal-conversion.ts` call sites already wrap it in `structuredClone`. The other three collections build fresh literals in their `defaultItem`.
- No hot path pays for the clone: `defaultItem` at `config.ts:370` is reached only for an entry that failed both the schema parse and the repair.