### PR TITLE
test: convert shelves, commands, maintenance and api onto testContainer

### DIFF
--- a/docs/unit-testing-strategy.md
+++ b/docs/unit-testing-strategy.md
@@ -422,7 +422,14 @@ uses for the `vi.mock` ban. No custom plugin.
 **Scope is per-directory, and rolls out as each feature converts.** Today the
 full set is enabled for `src/journals/**/*.test.ts`; the base `vi.mock` rule
 applies to every `**/*.test.ts`. A Phase 3 sweep enables the rest for its own
-directory in the same PR that converts it.
+directory in the same PR that converts it, by appending one glob to the
+`convertedTestGlobs` array in `eslint.config.mjs`.
+
+**`src/infrastructure/**` is not on that list, and will not be.** Its
+`host`/`di`/`flows` tests are what `testContainer()` itself is built and
+verified against — converting them onto the harness would test the harness
+through itself. This is a permanent boundary, not a directory the campaign
+hasn't reached yet.
 
 Two mechanics that have already caused a silent failure once each:
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,7 +27,7 @@ const noStrayDefineModal = {
 // `src/infrastructure/**` is deliberately absent and stays absent: its host/di/flows
 // tests are what testContainer is built from, so converting them onto the harness
 // would test the harness through itself.
-const convertedTestGlobs = ["src/journals/**/*.test.ts"];
+const convertedTestGlobs = ["src/journals/**/*.test.ts", "src/shelves/**/*.test.ts"];
 
 // `no-restricted-syntax` options replace rather than merge, so this array must carry
 // the vi.mock selector too — a block that omits it lifts the isolation ban for every
@@ -53,7 +53,7 @@ const campaignTestSelectors = [
   },
   {
     selector: "FunctionDeclaration[id.name=/^(make|build|seed|create)(Journal|Command|View|Shelf|Decoration|Config)/]",
-    message: "Entity fixtures live in the feature's testing.ts — use fixedJournal/customJournal.",
+    message: "Entity fixtures live in the feature's testing.ts — use fixedJournal/customJournal/buildShelf.",
   },
   {
     // Conditioned on the file already building a harness, rather than banning the raw import

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,6 +32,7 @@ const convertedTestGlobs = [
   "src/shelves/**/*.test.ts",
   "src/commands/**/*.test.ts",
   "src/maintenance/**/*.test.ts",
+  "src/api/**/*.test.ts",
 ];
 
 // `no-restricted-syntax` options replace rather than merge, so this array must carry

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,7 +27,7 @@ const noStrayDefineModal = {
 // `src/infrastructure/**` is deliberately absent and stays absent: its host/di/flows
 // tests are what testContainer is built from, so converting them onto the harness
 // would test the harness through itself.
-const convertedTestGlobs = ["src/journals/**/*.test.ts", "src/shelves/**/*.test.ts"];
+const convertedTestGlobs = ["src/journals/**/*.test.ts", "src/shelves/**/*.test.ts", "src/commands/**/*.test.ts"];
 
 // `no-restricted-syntax` options replace rather than merge, so this array must carry
 // the vi.mock selector too — a block that omits it lifts the isolation ban for every

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,7 +27,12 @@ const noStrayDefineModal = {
 // `src/infrastructure/**` is deliberately absent and stays absent: its host/di/flows
 // tests are what testContainer is built from, so converting them onto the harness
 // would test the harness through itself.
-const convertedTestGlobs = ["src/journals/**/*.test.ts", "src/shelves/**/*.test.ts", "src/commands/**/*.test.ts"];
+const convertedTestGlobs = [
+  "src/journals/**/*.test.ts",
+  "src/shelves/**/*.test.ts",
+  "src/commands/**/*.test.ts",
+  "src/maintenance/**/*.test.ts",
+];
 
 // `no-restricted-syntax` options replace rather than merge, so this array must carry
 // the vi.mock selector too — a block that omits it lifts the isolation ban for every

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,50 @@ const noStrayDefineModal = {
   message: "`defineModal()` is only allowed in `<feature>/ui/modals.ts`. Move the modal definition there.",
 };
 
+// Test files whose feature has been converted onto testContainer. The Phase 3 sweeps
+// append one glob each; Phase 6 replaces the list with "**/*.test.ts".
+// `src/infrastructure/**` is deliberately absent and stays absent: its host/di/flows
+// tests are what testContainer is built from, so converting them onto the harness
+// would test the harness through itself.
+const convertedTestGlobs = ["src/journals/**/*.test.ts"];
+
+// `no-restricted-syntax` options replace rather than merge, so this array must carry
+// the vi.mock selector too — a block that omits it lifts the isolation ban for every
+// glob it covers, and a selector matching nothing looks exactly like one that works.
+const campaignTestSelectors = [
+  {
+    selector: "CallExpression[callee.object.name='vi'][callee.property.name='mock']",
+    message:
+      "vi.mock replaces the module for every later file sharing the worker's registry. Rename this file to *.isolated.test.ts so it runs in its own.",
+  },
+  {
+    selector: "NewExpression[callee.name='Container']",
+    message: "Build the container with testContainer() from @/testing.",
+  },
+  {
+    // Narrowed to a binding chain inside a test body. A bare `.register(` also names
+    // JournalsIndex.register, the domain method the suite seeds index entries through.
+    // The second branch covers the `it.each(...)(...)` / `describe.each(...)(...)` shape,
+    // where the hook name sits one call deeper.
+    selector:
+      ":matches(CallExpression[callee.name=/^(it|test|beforeEach|beforeAll|afterEach|afterAll)$/], CallExpression[callee.callee.property.name='each']) MemberExpression[object.callee.property.name='register'][property.name=/^use(Value|Class|Factory|Existing)$/]",
+    message: "Pass a feature CORE/UI module to testContainer({ modules }) instead of registering by hand.",
+  },
+  {
+    selector: "FunctionDeclaration[id.name=/^(make|build|seed|create)(Journal|Command|View|Shelf|Decoration|Config)/]",
+    message: "Entity fixtures live in the feature's testing.ts — use fixedJournal/customJournal.",
+  },
+  {
+    // Conditioned on the file already building a harness, rather than banning the raw import
+    // outright: a pure-tier component test whose component injects nothing needs no injector,
+    // and an allowlist of those files would go stale silently (a stale `ignores` glob that
+    // matches nothing is indistinguishable from a working one).
+    selector:
+      "Program:has(ImportDeclaration[source.value='@/testing']) ImportDeclaration[source.value='@testing-library/vue'] ImportSpecifier[imported.name='render']",
+    message: "This file already builds a harness — mount through harness.render, which binds the injector for you.",
+  },
+];
+
 // `initLocale()` runs inside `onload()`, long after the import graph has evaluated, so a message
 // resolved at module scope freezes in the base locale for every user. Calls inside a function body
 // (including arrows and getters) and class field initializers run later, so they are exempt.
@@ -352,47 +396,11 @@ export default [
     },
   },
   {
-    // Must sit after the two test blocks above: rule options replace rather than merge, so the
-    // vi.mock selector is re-declared here or the ban lifts across all of src/journals.
-    files: ["src/journals/**/*.test.ts"],
+    // Must sit after the two test blocks above: rule options replace rather than merge.
+    files: convertedTestGlobs,
     ignores: ["**/*.isolated.test.ts"],
     rules: {
-      "no-restricted-syntax": [
-        "error",
-        {
-          selector: "CallExpression[callee.object.name='vi'][callee.property.name='mock']",
-          message:
-            "vi.mock replaces the module for every later file sharing the worker's registry. Rename this file to *.isolated.test.ts so it runs in its own.",
-        },
-        {
-          selector: "NewExpression[callee.name='Container']",
-          message: "Build the container with testContainer() from @/testing.",
-        },
-        {
-          // Narrowed to a binding chain inside a test body. A bare `.register(` also names
-          // JournalsIndex.register, the domain method the suite seeds index entries through.
-          // The second branch covers the `it.each(...)(...)` / `describe.each(...)(...)` shape,
-          // where the hook name sits one call deeper.
-          selector:
-            ":matches(CallExpression[callee.name=/^(it|test|beforeEach|beforeAll|afterEach|afterAll)$/], CallExpression[callee.callee.property.name='each']) MemberExpression[object.callee.property.name='register'][property.name=/^use(Value|Class|Factory|Existing)$/]",
-          message: "Pass a feature CORE/UI module to testContainer({ modules }) instead of registering by hand.",
-        },
-        {
-          selector:
-            "FunctionDeclaration[id.name=/^(make|build|seed|create)(Journal|Command|View|Shelf|Decoration|Config)/]",
-          message: "Entity fixtures live in the feature's testing.ts — use fixedJournal/customJournal.",
-        },
-        {
-          // Conditioned on the file already building a harness, rather than banning the raw import
-          // outright: a pure-tier component test whose component injects nothing needs no injector,
-          // and an allowlist of those files would go stale silently (a stale `ignores` glob that
-          // matches nothing is indistinguishable from a working one).
-          selector:
-            "Program:has(ImportDeclaration[source.value='@/testing']) ImportDeclaration[source.value='@testing-library/vue'] ImportSpecifier[imported.name='render']",
-          message:
-            "This file already builds a harness — mount through harness.render, which binds the injector for you.",
-        },
-      ],
+      "no-restricted-syntax": ["error", ...campaignTestSelectors],
     },
   },
   {

--- a/src/api/convert.test.ts
+++ b/src/api/convert.test.ts
@@ -1,6 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
-import { installTestCalendar } from "@/calendar/testing";
 import { customJournal, fixedJournal } from "@/journals/testing";
 
 import { normalizeSelector, toCalendarDate, toJournalInfo } from "./convert";
@@ -11,16 +10,6 @@ function anchorOf(input: Parameters<typeof toCalendarDate>[0]): string | null {
 }
 
 describe("toCalendarDate", () => {
-  let teardown: () => void;
-
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-
-  afterEach(() => {
-    teardown();
-  });
-
   it("reads a JS Date in local time, ignoring its clock", () => {
     expect(anchorOf(new Date(2026, 7, 18, 23, 45))).toBe("2026-08-18");
   });

--- a/src/api/journals-api.test.ts
+++ b/src/api/journals-api.test.ts
@@ -204,9 +204,11 @@ describe("JournalsApiService writes", () => {
 
     const result = await api.ensureNote("daily", "2026-08-18");
 
-    // The index is still empty — the result must come from the write, not a lookup.
     expect(index.entryByAnchor("daily", "2026-08-18" as AnchorString).isNone()).toBe(true);
     expect(result.note.path).toBe("2026-08-18.md");
+    // The index is still empty, and a lookup reports `file: null` for a note it does not know
+    // yet — so a non-null file is what proves the result came from the write. The path cannot
+    // prove it: a lookup renders the same path from the same template on the same miss.
     expect(result.note.file).not.toBeNull();
     expect(result.note.endDate).toBe("2026-08-18");
   });

--- a/src/api/journals-api.test.ts
+++ b/src/api/journals-api.test.ts
@@ -1,115 +1,46 @@
-import { createNanoEvents } from "nanoevents";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { AnchorString } from "@/calendar";
-import { installTestCalendar } from "@/calendar/testing";
-import { Container } from "@/infrastructure/di";
 import { Flows } from "@/infrastructure/flows";
-import { SuggestService, WorkspaceService } from "@/infrastructure/host";
 import type { VaultPath } from "@/infrastructure/host";
-import { NoteFileService } from "@/infrastructure/host/internal/note-file-service";
-import { LoggerModule } from "@/infrastructure/logger";
-import { AsyncResult, Err, Ok } from "@/infrastructure/result";
 import type { JournalConfig } from "@/journals/config";
-import { CycleService } from "@/journals/cycle";
-import { JournalDateResolver } from "@/journals/flows";
-import { FrontmatterService } from "@/journals/frontmatter";
+import { EnsureJournalEntryFlow, OpenJournalEntryFlow } from "@/journals/flows";
 import { JournalsIndex } from "@/journals/journals-index";
-import { NoteCreationService } from "@/journals/notes/note-creation";
-import { NotePathService } from "@/journals/notes/note-path";
-import { NumberingService } from "@/journals/numbering";
+import { journalsCoreModule } from "@/journals/module";
 import { JournalsRepository } from "@/journals/repository";
-import type { JournalsEvents } from "@/journals/repository";
 import { fixedJournal } from "@/journals/testing";
-import { TimelineService } from "@/journals/timeline";
-import { JournalsEventsToken } from "@/journals/tokens";
-import { ShelvesService } from "@/shelves/service";
-import { TemplateEngine } from "@/templates";
+import { VaultSubscriptionService } from "@/journals/vault-subscription";
+import type { ShelfConfig } from "@/shelves/config";
+import { shelvesCoreModule } from "@/shelves/module";
+import { buildShelf } from "@/shelves/testing";
+import { testContainer } from "@/testing";
 
 import { JournalsApiService } from "./journals-api";
+import { apiModule } from "./module";
 
 interface BuildOptions {
-  /** Which shelf each journal sits on. Default: none. */
-  shelfOf?: (name: string) => string;
-  /** What the picker returns when several journals match. null = dismissed. */
-  pick?: string | null;
+  /** Shelves to seed, keyed the same as their own name. Default: none. */
+  shelves?: Record<string, ShelfConfig>;
   /** Leave the index un-ready so whenReady() stays pending. Default true. */
   ready?: boolean;
 }
 
-interface FlowCall {
-  flow: string;
-  parameters: Record<string, unknown>;
+async function buildApi(journals: Record<string, JournalConfig>, options: BuildOptions = {}) {
+  const harness = await testContainer({
+    modules: [journalsCoreModule, shelvesCoreModule, apiModule],
+    data: { journals, shelves: options.shelves ?? {} },
+    initialize: options.ready === false ? [] : [VaultSubscriptionService],
+  });
+  const api = harness.resolve(JournalsApiService);
+  const index = harness.resolve(JournalsIndex);
+  const repo = harness.resolve(JournalsRepository);
+  const flows = vi.spyOn(harness.resolve(Flows), "invoke");
+  return { harness, api, index, repo, flows };
 }
-
-function buildApi(journals: Record<string, JournalConfig>, options: BuildOptions = {}) {
-  const pickedNames: string[][] = [];
-  const flowCalls: FlowCall[] = [];
-
-  const c = new Container();
-  c.addModule(LoggerModule);
-  // fakeRepo would build its own emitter; the API subscribes through the DI token, so both
-  // sides have to share one.
-  const journalEvents = createNanoEvents<JournalsEvents>();
-  const repo = JournalsRepository.fromParts(journals, journalEvents);
-  c.register(JournalsRepository).useValue(repo);
-  c.register(JournalsEventsToken).useValue(journalEvents);
-  c.register(JournalsIndex).useClass(JournalsIndex);
-  c.register(CycleService).useClass(CycleService);
-  c.register(TimelineService).useClass(TimelineService);
-  c.register(NumberingService).useClass(NumberingService);
-  c.register(FrontmatterService).useClass(FrontmatterService);
-  c.register(TemplateEngine).useClass(TemplateEngine);
-  c.register(NotePathService).useClass(NotePathService);
-  c.register(ShelvesService).useValue({ shelfOf: options.shelfOf ?? (() => "") } as never);
-  c.register(NoteFileService).useValue({ resolve: (path: string) => ({ path }) } as never);
-  c.register(WorkspaceService).useValue({} as never);
-  c.register(SuggestService).useValue({
-    open: (_definition: unknown, names: string[]) => {
-      pickedNames.push([...names]);
-      return Promise.resolve(options.pick == null ? new Err(new Error("dismissed")) : new Ok(options.pick));
-    },
-  } as never);
-  c.register(JournalDateResolver).useClass(JournalDateResolver);
-  c.register(NoteCreationService).useValue({} as never);
-
-  const index = c.resolve(JournalsIndex);
-  if (options.ready !== false) index.markReady();
-
-  // Stands in for Flows. It deliberately does NOT register the new entry: a real write
-  // returns as soon as the note is on disk, and JournalsIndex only learns about it once
-  // Obsidian re-parses the frontmatter. Idempotent for an entry that already exists,
-  // matching NoteCreationService.ensureNote.
-  c.register(Flows).useValue({
-    invoke: (cls: { name: string }, parameters: Record<string, unknown>) => {
-      flowCalls.push({ flow: cls.name, parameters });
-      const name = String(parameters.journalName);
-      const anchor = String(parameters.anchor) as AnchorString;
-      const existing = index.entryByAnchor(name, anchor);
-      if (existing.isSome()) return AsyncResult.ok({ path: existing.value.path, created: false });
-      return AsyncResult.ok({ path: `${name}/${anchor}.md` as VaultPath, created: true });
-    },
-  } as never);
-  c.register(JournalsApiService).useClass(JournalsApiService);
-
-  return { api: c.resolve(JournalsApiService), index, repo, pickedNames, flowCalls };
-}
-
-const ISO_WEEK = { dow: 1, doy: 4 };
 
 describe("JournalsApiService reads", () => {
-  let teardown: () => void;
-
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar(ISO_WEEK));
-  });
-
-  afterEach(() => {
-    teardown();
-  });
-
   it("lists every journal when the selector is omitted", async () => {
-    const { api } = buildApi({
+    const { api } = await buildApi({
       daily: fixedJournal("daily", { type: "day" }),
       weekly: fixedJournal("weekly", { type: "week" }),
     });
@@ -120,7 +51,7 @@ describe("JournalsApiService reads", () => {
   });
 
   it("does not wait for the index to be ready", async () => {
-    const { api } = buildApi({ daily: fixedJournal("daily", { type: "day" }) }, { ready: false });
+    const { api } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) }, { ready: false });
 
     const listed = await api.listJournals();
 
@@ -128,13 +59,13 @@ describe("JournalsApiService reads", () => {
   });
 
   it("ANDs the selector fields", async () => {
-    const { api } = buildApi(
+    const { api } = await buildApi(
       {
         workDaily: fixedJournal("workDaily", { type: "day" }),
         homeDaily: fixedJournal("homeDaily", { type: "day" }),
         workWeekly: fixedJournal("workWeekly", { type: "week" }),
       },
-      { shelfOf: (name) => (name.startsWith("work") ? "Work" : "") },
+      { shelves: { Work: buildShelf("Work", { journals: ["workDaily", "workWeekly"] }) } },
     );
 
     const listed = await api.listJournals({ writeType: "day", shelf: "Work" });
@@ -143,9 +74,9 @@ describe("JournalsApiService reads", () => {
   });
 
   it("selects off-shelf journals with a null shelf", async () => {
-    const { api } = buildApi(
+    const { api } = await buildApi(
       { onShelf: fixedJournal("onShelf", { type: "day" }), loose: fixedJournal("loose", { type: "day" }) },
-      { shelfOf: (name) => (name === "onShelf" ? "Work" : "") },
+      { shelves: { Work: buildShelf("Work", { journals: ["onShelf"] }) } },
     );
 
     const listed = await api.listJournals({ shelf: null });
@@ -154,13 +85,13 @@ describe("JournalsApiService reads", () => {
   });
 
   it("returns null from journalInfo for an unknown journal", async () => {
-    const { api } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    const { api } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
 
     expect(await api.journalInfo("nope")).toBeNull();
   });
 
   it("reports a period with no note as file null and a predicted path", async () => {
-    const { api } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    const { api } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
 
     const [note] = await api.notesFor("daily", "2026-08-18");
 
@@ -172,7 +103,7 @@ describe("JournalsApiService reads", () => {
   });
 
   it("gives a weekly note its first day as date and its representative as displayDate", async () => {
-    const { api } = buildApi({ weekly: fixedJournal("weekly", { type: "week" }) });
+    const { api } = await buildApi({ weekly: fixedJournal("weekly", { type: "week" }) });
 
     const [note] = await api.notesFor("weekly", "2026-01-01");
 
@@ -182,7 +113,8 @@ describe("JournalsApiService reads", () => {
   });
 
   it("reports the note's real path when one exists, not the rendered one", async () => {
-    const { api, index } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    const { api, index, harness } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    harness.host.putFile("Somewhere/Else/renamed.md", "existing");
     index.register({
       journalName: "daily",
       anchor: "2026-08-18" as AnchorString,
@@ -196,7 +128,7 @@ describe("JournalsApiService reads", () => {
   });
 
   it("fans out across every matching journal", async () => {
-    const { api } = buildApi({
+    const { api } = await buildApi({
       a: fixedJournal("a", { type: "day" }),
       b: fixedJournal("b", { type: "day" }),
     });
@@ -207,7 +139,7 @@ describe("JournalsApiService reads", () => {
   });
 
   it("gives a null path for a date outside the timeline with no note", async () => {
-    const { api } = buildApi({
+    const { api } = await buildApi({
       past: fixedJournal(
         "past",
         { type: "day" },
@@ -227,13 +159,13 @@ describe("JournalsApiService reads", () => {
   });
 
   it("rejects a date it cannot read with invalid-date", async () => {
-    const { api } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    const { api } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
 
     await expect(api.notesFor("daily", "whenever")).rejects.toMatchObject({ code: "invalid-date" });
   });
 
   it("resolves journalOf from the file it was handed", async () => {
-    const { api, index } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    const { api, index } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
     index.register({
       journalName: "daily",
       anchor: "2026-08-18" as AnchorString,
@@ -249,57 +181,50 @@ describe("JournalsApiService reads", () => {
   });
 
   it("returns null from journalOf for a note that is not connected", async () => {
-    const { api } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    const { api } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
 
     expect(await api.journalOf({ path: "Random/note.md" })).toBeNull();
   });
 });
 
 describe("JournalsApiService writes", () => {
-  let teardown: () => void;
-
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar(ISO_WEEK));
-  });
-
-  afterEach(() => {
-    teardown();
-  });
-
   it("creates the note through the ensure flow and reports created", async () => {
-    const { api, flowCalls } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    const { api, flows } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
 
     const result = await api.ensureNote("daily", "2026-08-18");
 
     expect(result.created).toBe(true);
     expect(result.note.journal).toBe("daily");
     expect(result.note.file).not.toBeNull();
-    expect(flowCalls.at(-1)?.flow).toBe("EnsureJournalEntryFlow");
+    expect(flows).toHaveBeenLastCalledWith(EnsureJournalEntryFlow, expect.anything(), expect.anything());
   });
 
   it("returns the created note before the index has caught up", async () => {
-    const { api, index } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    const { api, index } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
 
     const result = await api.ensureNote("daily", "2026-08-18");
 
     // The index is still empty — the result must come from the write, not a lookup.
     expect(index.entryByAnchor("daily", "2026-08-18" as AnchorString).isNone()).toBe(true);
-    expect(result.note.path).toBe("daily/2026-08-18.md");
+    expect(result.note.path).toBe("2026-08-18.md");
     expect(result.note.file).not.toBeNull();
     expect(result.note.endDate).toBe("2026-08-18");
   });
 
   it("opens through the open flow, passing the open mode", async () => {
-    const { api, flowCalls } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    const { api, flows } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
 
     await api.openNote("daily", "2026-08-18", { openMode: "split" });
 
-    expect(flowCalls.at(-1)?.flow).toBe("OpenJournalEntryFlow");
-    expect(flowCalls.at(-1)?.parameters).toMatchObject({ openMode: "split" });
+    expect(flows).toHaveBeenLastCalledWith(
+      OpenJournalEntryFlow,
+      expect.objectContaining({ openMode: "split" }),
+      expect.anything(),
+    );
   });
 
   it("rejects with no-matching-journal when the selector matches nothing", async () => {
-    const { api } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    const { api } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
 
     await expect(api.ensureNote({ writeType: "quarter" }, "2026-08-18")).rejects.toMatchObject({
       code: "no-matching-journal",
@@ -307,13 +232,13 @@ describe("JournalsApiService writes", () => {
   });
 
   it("rejects with journal-not-found for an unknown name", async () => {
-    const { api } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    const { api } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
 
     await expect(api.ensureNote("nope", "2026-08-18")).rejects.toMatchObject({ code: "journal-not-found" });
   });
 
   it("rejects with outside-timeline when no note exists and the date is out of range", async () => {
-    const { api } = buildApi({
+    const { api } = await buildApi({
       past: fixedJournal(
         "past",
         { type: "day" },
@@ -330,7 +255,7 @@ describe("JournalsApiService writes", () => {
   });
 
   it("still reaches a note that exists outside the timeline", async () => {
-    const { api, index } = buildApi({
+    const { api, index, harness } = await buildApi({
       past: fixedJournal(
         "past",
         { type: "day" },
@@ -342,6 +267,7 @@ describe("JournalsApiService writes", () => {
         },
       ),
     });
+    harness.host.putFile("Past/2026-08-18.md", "existing");
     index.register({
       journalName: "past",
       anchor: "2026-08-18" as AnchorString,
@@ -355,70 +281,74 @@ describe("JournalsApiService writes", () => {
   });
 
   it("shows the picker when several journals match, and uses the choice", async () => {
-    const { api, pickedNames } = buildApi(
-      { a: fixedJournal("a", { type: "day" }), b: fixedJournal("b", { type: "day" }) },
-      { pick: "b" },
-    );
+    const { api, harness } = await buildApi({
+      a: fixedJournal("a", { type: "day" }),
+      b: fixedJournal("b", { type: "day" }),
+    });
 
-    const result = await api.ensureNote({ writeType: "day" }, "2026-08-18");
+    const pending = api.ensureNote({ writeType: "day" }, "2026-08-18");
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(harness.suggests.opens).toHaveLength(1);
+    expect(harness.suggests.lastOpen<string[], string>().input).toEqual(["a", "b"]);
+    harness.suggests.lastOpen<string[], string>().choose("b");
+    const result = await pending;
 
-    expect(pickedNames).toEqual([["a", "b"]]);
     expect(result.note.journal).toBe("b");
   });
 
   it("rejects with aborted when the user dismisses the picker", async () => {
-    const { api } = buildApi(
-      { a: fixedJournal("a", { type: "day" }), b: fixedJournal("b", { type: "day" }) },
-      { pick: null },
-    );
+    const { api, harness } = await buildApi({
+      a: fixedJournal("a", { type: "day" }),
+      b: fixedJournal("b", { type: "day" }),
+    });
 
-    await expect(api.ensureNote({ writeType: "day" }, "2026-08-18")).rejects.toMatchObject({ code: "aborted" });
+    const pending = api.ensureNote({ writeType: "day" }, "2026-08-18");
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    harness.suggests.lastOpen<string[], string>().cancel();
+
+    await expect(pending).rejects.toMatchObject({ code: "aborted" });
   });
 
   it("passes skipConfirmation only when confirm is given", async () => {
-    const { api, flowCalls } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    const { api, flows } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
 
     await api.ensureNote("daily", "2026-08-18", { confirm: false });
-    expect(flowCalls.at(-1)?.parameters).toMatchObject({ skipConfirmation: true });
+    expect(flows.mock.calls.at(-1)?.[1]).toMatchObject({ skipConfirmation: true });
 
     await api.ensureNote("daily", "2026-08-19");
-    expect(flowCalls.at(-1)?.parameters.skipConfirmation).toBeUndefined();
+    expect((flows.mock.calls.at(-1)?.[1] as { skipConfirmation?: boolean }).skipConfirmation).toBeUndefined();
   });
 
   it("shares one flow invocation between concurrent calls for the same period", async () => {
-    const { api, flowCalls } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    const { api, flows } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
 
     const [first, second] = await Promise.all([
       api.ensureNote("daily", "2026-08-18"),
       api.ensureNote("daily", "2026-08-18"),
     ]);
 
-    expect(flowCalls).toHaveLength(1);
+    expect(flows).toHaveBeenCalledTimes(1);
     expect(first.note.path).toBe(second.note.path);
   });
 
   it("does not share invocations across different periods", async () => {
-    const { api, flowCalls } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    const { api, flows } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
 
     await Promise.all([api.ensureNote("daily", "2026-08-18"), api.ensureNote("daily", "2026-08-19")]);
 
-    expect(flowCalls).toHaveLength(2);
+    expect(flows).toHaveBeenCalledTimes(2);
   });
 });
 
 describe("JournalsApiService events", () => {
-  let teardown: () => void;
-
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar(ISO_WEEK));
-  });
-
-  afterEach(() => {
-    teardown();
-  });
-
-  it("reports a rename with both names", () => {
-    const { api, repo } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+  it("reports a rename with both names", async () => {
+    const { api, repo } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
     const seen: { from: string; to: string }[] = [];
     api.on("journalRenamed", (event) => {
       seen.push(event);
@@ -429,8 +359,8 @@ describe("JournalsApiService events", () => {
     expect(seen).toEqual([{ from: "daily", to: "journal" }]);
   });
 
-  it("reports an added note by date", () => {
-    const { api, index } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+  it("reports an added note by date", async () => {
+    const { api, index } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
     const seen: { journal: string; date: string; path: string }[] = [];
     api.on("noteAdded", (event) => {
       seen.push(event);
@@ -445,8 +375,8 @@ describe("JournalsApiService events", () => {
     expect(seen).toEqual([{ journal: "daily", date: "2026-08-18", path: "Journal/2026-08-18.md" }]);
   });
 
-  it("reports a removed note", () => {
-    const { api, index } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+  it("reports a removed note", async () => {
+    const { api, index } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
     index.register({
       journalName: "daily",
       anchor: "2026-08-18" as AnchorString,
@@ -462,8 +392,8 @@ describe("JournalsApiService events", () => {
     expect(seen).toEqual([{ journal: "daily", date: "2026-08-18" }]);
   });
 
-  it("stops delivering after the disposer runs", () => {
-    const { api, index } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+  it("stops delivering after the disposer runs", async () => {
+    const { api, index } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
     let calls = 0;
     const off = api.on("noteAdded", () => {
       calls += 1;
@@ -481,18 +411,8 @@ describe("JournalsApiService events", () => {
 });
 
 describe("JournalsApiService unloading", () => {
-  let teardown: () => void;
-
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar(ISO_WEEK));
-  });
-
-  afterEach(() => {
-    teardown();
-  });
-
   it("rejects an in-flight call with plugin-unloaded", async () => {
-    const { api } = buildApi({ daily: fixedJournal("daily", { type: "day" }) }, { ready: false });
+    const { api } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) }, { ready: false });
     const pending = api.notesFor("daily", "2026-08-18");
 
     await api[Symbol.asyncDispose]();
@@ -501,7 +421,7 @@ describe("JournalsApiService unloading", () => {
   });
 
   it("rejects calls made after disposal", async () => {
-    const { api } = buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    const { api } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
 
     await api[Symbol.asyncDispose]();
 

--- a/src/commands/command-registry.test.ts
+++ b/src/commands/command-registry.test.ts
@@ -1,166 +1,126 @@
-import { createNanoEvents } from "nanoevents";
 import { describe, expect, it, vi } from "vitest";
 
 import { CalendarDate } from "@/calendar";
 import { anchor } from "@/calendar/testing";
 import { m } from "@/i18n";
-import { Flows, FlowsModule } from "@/infrastructure/flows";
-import { CommandService, NoticeService, WorkspaceService } from "@/infrastructure/host";
+import { Flows } from "@/infrastructure/flows";
 import type { VaultPath } from "@/infrastructure/host";
-import { createFakeHost } from "@/infrastructure/host/internal/testing";
-import { InternalPluginToken } from "@/infrastructure/host/internal/tokens";
-import { FakeNoticeService, FakeWorkspaceService } from "@/infrastructure/host/testing";
+import type { FakeHost } from "@/infrastructure/host/internal/testing";
 import { AsyncResult } from "@/infrastructure/result";
-import {
-  CycleService,
-  JournalsIndex,
-  JournalsRepository,
-  JournalsEventsToken,
-  OpenDateFlow,
-  TimelineService,
-  journalConfigCollection,
-} from "@/journals";
-import type { JournalsEvents } from "@/journals";
+import { JournalsIndex, JournalsRepository, OpenDateFlow } from "@/journals";
+import type { JournalConfig } from "@/journals";
+import { journalsCoreModule } from "@/journals/module";
+import { fixedJournal } from "@/journals/testing";
 import { SettingsEventsToken } from "@/settings";
-import { createSettingsService } from "@/settings/testing";
-import { ShelvesRepository, ShelvesEventsToken, shelvesCollection } from "@/shelves";
-import type { ShelvesEvents } from "@/shelves";
+import { ShelvesRepository } from "@/shelves";
+import type { ShelfConfig } from "@/shelves";
+import { shelvesCoreModule } from "@/shelves/module";
+import { buildShelf } from "@/shelves/testing";
+import { testContainer } from "@/testing";
 
 import { DynamicCommandRegistry } from "./command-registry";
 import { commandCollection } from "./config";
-import { CommandsRepository, type CommandsEvents } from "./repository";
-import { CommandsEventsToken } from "./tokens";
+import { commandsModule } from "./module";
+import { CommandsRepository } from "./repository";
+import { buildCommand } from "./testing";
 
 import type { CommandConfig } from "./config";
 
-function makeCommand(overrides: Partial<CommandConfig>): CommandConfig {
+interface RegistrySeed {
+  readonly journals?: Record<string, JournalConfig>;
+  readonly shelves?: Record<string, ShelfConfig>;
+  readonly commands?: Record<string, CommandConfig>;
+}
+
+// The subject IS the host registration, so this is one of the few full-module boots:
+// commandsModule brings the startup half that owns DynamicCommandRegistry, and
+// allow.hostState lets the commands it registers stand.
+async function buildRegistry(seed: RegistrySeed = {}) {
+  const harness = await testContainer({
+    modules: [journalsCoreModule, shelvesCoreModule, commandsModule],
+    data: {
+      journals: seed.journals ?? {},
+      shelves: seed.shelves ?? {},
+      commands: seed.commands ?? {},
+    },
+    allow: { hostState: true },
+    initialize: [DynamicCommandRegistry],
+  });
   return {
-    name: "Cmd",
-    icon: "",
-    showInRibbon: false,
-    openMode: "active",
-    target: { kind: "all", writeType: "day" },
-    type: "same",
-    context: "today",
-    ...overrides,
+    host: harness.host,
+    notices: harness.notices,
+    index: harness.resolve(JournalsIndex),
+    flows: harness.resolve(Flows),
+    settingsEvents: harness.resolve(SettingsEventsToken),
+    commandsRepo: harness.resolve(CommandsRepository),
+    commandsStorage: harness.settings.recordOf(commandCollection),
+    journalsRepo: harness.resolve(JournalsRepository),
+    shelvesRepo: harness.resolve(ShelvesRepository),
   };
 }
 
-async function build() {
-  const { service: settings, container } = createSettingsService({
-    collections: [journalConfigCollection, commandCollection, shelvesCollection],
-  });
-  await settings.initialize();
-
-  const journalsStorage = settings.recordOf(journalConfigCollection);
-  const shelvesStorage = settings.recordOf(shelvesCollection);
-  const commandsStorage = settings.recordOf(commandCollection);
-
-  const journalsEvents = createNanoEvents<JournalsEvents>();
-  const shelvesEvents = createNanoEvents<ShelvesEvents>();
-  const commandsEvents = createNanoEvents<CommandsEvents>();
-
-  const journalsRepo = JournalsRepository.fromParts(journalsStorage, journalsEvents);
-  const shelvesRepo = ShelvesRepository.fromParts(shelvesStorage, shelvesEvents);
-  const commandsRepo = CommandsRepository.fromParts(commandsStorage, commandsEvents);
-
-  const host = createFakeHost();
-  const workspace = new FakeWorkspaceService();
-  const notices = new FakeNoticeService();
-
-  container.register(InternalPluginToken).useValue(host.plugin);
-  container.register(CommandService).useClass(CommandService);
-  container.register(WorkspaceService).useValue(workspace as unknown as WorkspaceService);
-  container.register(NoticeService).useValue(notices);
-  container.register(JournalsIndex).useClass(JournalsIndex);
-  container.register(CycleService).useClass(CycleService);
-  container.register(TimelineService).useClass(TimelineService);
-  container.register(JournalsEventsToken).useValue(journalsEvents);
-  container.register(JournalsRepository).useValue(journalsRepo);
-  container.register(ShelvesEventsToken).useValue(shelvesEvents);
-  container.register(ShelvesRepository).useValue(shelvesRepo);
-  container.register(CommandsEventsToken).useValue(commandsEvents);
-  container.register(CommandsRepository).useValue(commandsRepo);
-  container.addModule(FlowsModule);
-  container.register(DynamicCommandRegistry).useClass(DynamicCommandRegistry);
-
-  const index = container.resolve(JournalsIndex);
-  const flows = container.resolve(Flows);
-  const settingsEvents = container.resolve(SettingsEventsToken);
-  const registry = container.resolve(DynamicCommandRegistry);
-  registry.initialize();
-
-  return {
-    host,
-    workspace,
-    notices,
-    journalsRepo,
-    shelvesRepo,
-    commandsRepo,
-    commandsStorage,
-    settingsEvents,
-    index,
-    flows,
-  };
+function activate(host: FakeHost, path: VaultPath): void {
+  host.emitActiveLeafChange(host.putFile(path));
 }
 
 describe("DynamicCommandRegistry registration", () => {
   it("registers a command added to the collection", async () => {
-    const { host, commandsRepo } = await build();
-    commandsRepo.create("cmd-1", makeCommand({ name: "Open daily" }));
+    const { host, commandsRepo } = await buildRegistry();
+    commandsRepo.create("cmd-1", buildCommand({ name: "Open daily" }));
     expect(host.commands.get("cmd-1")?.name).toBe("Open daily");
   });
 
   it("prefixes a journal-targeted command's palette name with the journal name", async () => {
-    const { host, commandsRepo } = await build();
+    const { host, commandsRepo } = await buildRegistry();
     commandsRepo.create(
       "cmd-1",
-      makeCommand({ name: "Open today", target: { kind: "journal", journalName: "daily" } }),
+      buildCommand({ name: "Open today", target: { kind: "journal", journalName: "daily" } }),
     );
     expect(host.commands.get("cmd-1")?.name).toBe("daily: Open today");
   });
 
   it("prefixes a shelf-targeted command's palette name with the shelf name", async () => {
-    const { host, commandsRepo } = await build();
+    const { host, commandsRepo } = await buildRegistry();
     commandsRepo.create(
       "cmd-1",
-      makeCommand({ name: "Open today", target: { kind: "shelf", shelfName: "work", writeType: "day" } }),
+      buildCommand({ name: "Open today", target: { kind: "shelf", shelfName: "work", writeType: "day" } }),
     );
     expect(host.commands.get("cmd-1")?.name).toBe("Shelf: work: Open today");
   });
 
   it("unregisters a command removed from the collection", async () => {
-    const { host, commandsRepo } = await build();
-    commandsRepo.create("cmd-1", makeCommand({}));
+    const { host, commandsRepo } = await buildRegistry();
+    commandsRepo.create("cmd-1", buildCommand());
     commandsRepo.delete("cmd-1");
     expect(host.commands.get("cmd-1")).toBeUndefined();
   });
 
   it("re-registers a command when its definition changes", async () => {
-    const { host, commandsRepo } = await build();
-    commandsRepo.create("cmd-1", makeCommand({ name: "Old" }));
+    const { host, commandsRepo } = await buildRegistry();
+    commandsRepo.create("cmd-1", buildCommand({ name: "Old" }));
     commandsRepo.update("cmd-1", { name: "New" });
     expect(host.commands.get("cmd-1")?.name).toBe("New");
   });
 
   it("registers a command synced into storage when settings are reloaded", async () => {
-    const { host, commandsStorage, settingsEvents } = await build();
-    commandsStorage["cmd-1"] = makeCommand({ name: "Synced" });
+    const { host, commandsStorage, settingsEvents } = await buildRegistry();
+    commandsStorage["cmd-1"] = buildCommand({ name: "Synced" });
     settingsEvents.emit("reloaded");
     expect(host.commands.get("cmd-1")?.name).toBe("Synced");
   });
 
   it("unregisters a command removed by a settings reload", async () => {
-    const { host, commandsRepo, commandsStorage, settingsEvents } = await build();
-    commandsRepo.create("cmd-1", makeCommand({}));
+    const { host, commandsStorage, settingsEvents } = await buildRegistry({
+      commands: { "cmd-1": buildCommand() },
+    });
     delete commandsStorage["cmd-1"];
     settingsEvents.emit("reloaded");
     expect(host.commands.get("cmd-1")).toBeUndefined();
   });
 
   it("keeps a single ribbon icon when a ribbon command is updated", async () => {
-    const { host, commandsRepo } = await build();
-    commandsRepo.create("cmd-1", makeCommand({ name: "Old", icon: "star", showInRibbon: true }));
+    const { host, commandsRepo } = await buildRegistry();
+    commandsRepo.create("cmd-1", buildCommand({ name: "Old", icon: "star", showInRibbon: true }));
     commandsRepo.update("cmd-1", { name: "New" });
     expect(host.ribbonIcons).toHaveLength(1);
   });
@@ -168,78 +128,92 @@ describe("DynamicCommandRegistry registration", () => {
 
 describe("DynamicCommandRegistry availability", () => {
   it("is unavailable when no journal matches an all target", async () => {
-    const { host, commandsRepo } = await build();
-    commandsRepo.create("cmd-1", makeCommand({}));
+    const { host } = await buildRegistry({ commands: { "cmd-1": buildCommand() } });
     expect(host.commands.get("cmd-1")?.checkCallback?.(true)).toBe(false);
   });
 
   it("is available when a matching journal exists", async () => {
-    const { host, commandsRepo, journalsRepo } = await build();
-    journalsRepo.create("daily", { type: "day" });
-    commandsRepo.create("cmd-1", makeCommand({}));
+    const { host } = await buildRegistry({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      commands: { "cmd-1": buildCommand() },
+    });
     expect(host.commands.get("cmd-1")?.checkCallback?.(true)).toBe(true);
   });
 
   it("is unavailable when the command type is unsupported for the write type", async () => {
-    const { host, commandsRepo, journalsRepo } = await build();
-    journalsRepo.create("weekly", { type: "week" });
-    commandsRepo.create("cmd-1", makeCommand({ target: { kind: "all", writeType: "week" }, type: "same_next_week" }));
+    const { host } = await buildRegistry({
+      journals: { weekly: fixedJournal("weekly", { type: "week" }) },
+      commands: { "cmd-1": buildCommand({ target: { kind: "all", writeType: "week" }, type: "same_next_week" }) },
+    });
     expect(host.commands.get("cmd-1")?.checkCallback?.(true)).toBe(false);
   });
 
   it("is unavailable when the resolved date is past the journal's timeline end", async () => {
-    const { host, commandsRepo, journalsRepo } = await build();
-    journalsRepo.create("daily", { type: "day" });
-    journalsRepo.update("daily", {
-      timeline: { start: anchor("2020-01-01"), end: { kind: "date", date: anchor("2020-12-31") } },
+    const { host } = await buildRegistry({
+      journals: {
+        daily: fixedJournal(
+          "daily",
+          { type: "day" },
+          { timeline: { start: anchor("2020-01-01"), end: { kind: "date", date: anchor("2020-12-31") } } },
+        ),
+      },
+      commands: { "cmd-1": buildCommand() },
     });
-    commandsRepo.create("cmd-1", makeCommand({}));
     expect(host.commands.get("cmd-1")?.checkCallback?.(true)).toBe(false);
   });
 
   it("is unavailable for only_open_note context without an active journal note", async () => {
-    const { host, commandsRepo, journalsRepo } = await build();
-    journalsRepo.create("daily", { type: "day" });
-    commandsRepo.create("cmd-1", makeCommand({ context: "only_open_note" }));
+    const { host } = await buildRegistry({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      commands: { "cmd-1": buildCommand({ context: "only_open_note" }) },
+    });
     expect(host.commands.get("cmd-1")?.checkCallback?.(true)).toBe(false);
   });
 
   it("is unavailable for only_open_note context when the active note belongs to no journal", async () => {
-    const { host, commandsRepo, journalsRepo, workspace } = await build();
-    journalsRepo.create("daily", { type: "day" });
-    workspace.setActive("inbox/scratch.md" as VaultPath);
-    commandsRepo.create("cmd-1", makeCommand({ context: "only_open_note" }));
+    const { host } = await buildRegistry({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      commands: { "cmd-1": buildCommand({ context: "only_open_note" }) },
+    });
+    activate(host, "inbox/scratch.md" as VaultPath);
     expect(host.commands.get("cmd-1")?.checkCallback?.(true)).toBe(false);
   });
 
   it("is available for only_open_note context when the active note belongs to the target", async () => {
-    const { host, commandsRepo, journalsRepo, index, workspace } = await build();
-    journalsRepo.create("daily", { type: "day" });
+    const { host, index } = await buildRegistry({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      commands: { "cmd-1": buildCommand({ context: "only_open_note" }) },
+    });
     const path = "daily/2026-05-21.md" as VaultPath;
     index.register({ journalName: "daily", anchor: anchor("2026-05-21"), path });
-    workspace.setActive(path);
-    commandsRepo.create("cmd-1", makeCommand({ context: "only_open_note" }));
+    activate(host, path);
     expect(host.commands.get("cmd-1")?.checkCallback?.(true)).toBe(true);
   });
 
   it("is available for only_open_note context when the active note belongs to another journal", async () => {
-    const { host, commandsRepo, journalsRepo, index, workspace } = await build();
-    journalsRepo.create("daily", { type: "day" });
-    journalsRepo.create("monthly", { type: "month" });
+    const { host, index } = await buildRegistry({
+      journals: {
+        daily: fixedJournal("daily", { type: "day" }),
+        monthly: fixedJournal("monthly", { type: "month" }),
+      },
+      commands: { "cmd-1": buildCommand({ context: "only_open_note" }) },
+    });
     const path = "monthly/2026-05.md" as VaultPath;
     index.register({ journalName: "monthly", anchor: anchor("2026-05-01"), path });
-    workspace.setActive(path);
-    commandsRepo.create("cmd-1", makeCommand({ context: "only_open_note" }));
+    activate(host, path);
     expect(host.commands.get("cmd-1")?.checkCallback?.(true)).toBe(true);
   });
 });
 
 describe("DynamicCommandRegistry execution", () => {
   it("invokes OpenDateFlow with the resolved anchor and candidate journals", async () => {
-    const { host, commandsRepo, journalsRepo, flows } = await build();
-    journalsRepo.create("daily", { type: "day" });
+    const { host, flows } = await buildRegistry({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      commands: {
+        "cmd-1": buildCommand({ name: "Cmd", type: "same", context: "today", openMode: "split" }),
+      },
+    });
     const invokeSpy = vi.spyOn(flows, "invoke").mockReturnValue(AsyncResult.ok({ path: "daily/x.md", created: false }));
-    commandsRepo.create("cmd-1", makeCommand({ type: "same", context: "today", openMode: "split" }));
 
     host.commands.get("cmd-1")?.checkCallback?.(false);
 
@@ -256,13 +230,17 @@ describe("DynamicCommandRegistry execution", () => {
   });
 
   it("does not invoke OpenDateFlow when the resolved date is outside the timeline", async () => {
-    const { host, commandsRepo, journalsRepo, flows } = await build();
-    journalsRepo.create("daily", { type: "day" });
-    journalsRepo.update("daily", {
-      timeline: { start: anchor("2020-01-01"), end: { kind: "date", date: anchor("2020-12-31") } },
+    const { host, flows } = await buildRegistry({
+      journals: {
+        daily: fixedJournal(
+          "daily",
+          { type: "day" },
+          { timeline: { start: anchor("2020-01-01"), end: { kind: "date", date: anchor("2020-12-31") } } },
+        ),
+      },
+      commands: { "cmd-1": buildCommand() },
     });
     const invokeSpy = vi.spyOn(flows, "invoke");
-    commandsRepo.create("cmd-1", makeCommand({}));
 
     host.commands.get("cmd-1")?.checkCallback?.(false);
 
@@ -270,14 +248,18 @@ describe("DynamicCommandRegistry execution", () => {
   });
 
   it("passes only in-timeline journals to OpenDateFlow", async () => {
-    const { host, commandsRepo, journalsRepo, flows } = await build();
-    journalsRepo.create("daily", { type: "day" });
-    journalsRepo.create("archive", { type: "day" });
-    journalsRepo.update("archive", {
-      timeline: { start: anchor("2020-01-01"), end: { kind: "date", date: anchor("2020-12-31") } },
+    const { host, flows } = await buildRegistry({
+      journals: {
+        daily: fixedJournal("daily", { type: "day" }),
+        archive: fixedJournal(
+          "archive",
+          { type: "day" },
+          { timeline: { start: anchor("2020-01-01"), end: { kind: "date", date: anchor("2020-12-31") } } },
+        ),
+      },
+      commands: { "cmd-1": buildCommand() },
     });
     const invokeSpy = vi.spyOn(flows, "invoke").mockReturnValue(AsyncResult.ok({ path: "daily/x.md", created: false }));
-    commandsRepo.create("cmd-1", makeCommand({}));
 
     host.commands.get("cmd-1")?.checkCallback?.(false);
 
@@ -289,9 +271,8 @@ describe("DynamicCommandRegistry execution", () => {
   });
 
   it("does not invoke OpenDateFlow when the command is unavailable", async () => {
-    const { host, commandsRepo, flows } = await build();
+    const { host, flows } = await buildRegistry({ commands: { "cmd-1": buildCommand() } });
     const invokeSpy = vi.spyOn(flows, "invoke");
-    commandsRepo.create("cmd-1", makeCommand({}));
 
     host.commands.get("cmd-1")?.checkCallback?.(false);
 
@@ -299,13 +280,14 @@ describe("DynamicCommandRegistry execution", () => {
   });
 
   it("resolves the anchor from the active note for open_note context", async () => {
-    const { host, commandsRepo, journalsRepo, index, workspace, flows } = await build();
-    journalsRepo.create("daily", { type: "day" });
+    const { host, index, flows } = await buildRegistry({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      commands: { "cmd-1": buildCommand({ name: "Cmd", type: "same", context: "open_note" }) },
+    });
     const path = "daily/2026-05-10.md" as VaultPath;
     index.register({ journalName: "daily", anchor: anchor("2026-05-10"), path });
-    workspace.setActive(path);
+    activate(host, path);
     const invokeSpy = vi.spyOn(flows, "invoke").mockReturnValue(AsyncResult.ok({ path: "daily/x.md", created: false }));
-    commandsRepo.create("cmd-1", makeCommand({ type: "same", context: "open_note" }));
 
     host.commands.get("cmd-1")?.checkCallback?.(false);
 
@@ -322,19 +304,21 @@ describe("DynamicCommandRegistry execution", () => {
   });
 
   it("dates an open_note command from a note in a journal it does not target", async () => {
-    const { host, commandsRepo, journalsRepo, index, workspace, flows } = await build();
-    journalsRepo.create("daily", { type: "day" });
-    journalsRepo.create("monthly", { type: "month" });
+    const { host, index, flows } = await buildRegistry({
+      journals: {
+        daily: fixedJournal("daily", { type: "day" }),
+        monthly: fixedJournal("monthly", { type: "month" }),
+      },
+      commands: {
+        "cmd-1": buildCommand({ target: { kind: "all", writeType: "month" }, type: "next", context: "open_note" }),
+      },
+    });
     const path = "daily/2026-05-21.md" as VaultPath;
     index.register({ journalName: "daily", anchor: anchor("2026-05-21"), path });
-    workspace.setActive(path);
+    activate(host, path);
     const invokeSpy = vi
       .spyOn(flows, "invoke")
       .mockReturnValue(AsyncResult.ok({ path: "monthly/x.md", created: false }));
-    commandsRepo.create(
-      "cmd-1",
-      makeCommand({ target: { kind: "all", writeType: "month" }, type: "next", context: "open_note" }),
-    );
 
     host.commands.get("cmd-1")?.checkCallback?.(false);
 
@@ -346,19 +330,21 @@ describe("DynamicCommandRegistry execution", () => {
   });
 
   it("dates an only_open_note command from a note in a journal it does not target", async () => {
-    const { host, commandsRepo, journalsRepo, index, workspace, flows } = await build();
-    journalsRepo.create("daily", { type: "day" });
-    journalsRepo.create("monthly", { type: "month" });
+    const { host, index, flows } = await buildRegistry({
+      journals: {
+        daily: fixedJournal("daily", { type: "day" }),
+        monthly: fixedJournal("monthly", { type: "month" }),
+      },
+      commands: {
+        "cmd-1": buildCommand({ target: { kind: "all", writeType: "month" }, type: "next", context: "only_open_note" }),
+      },
+    });
     const path = "daily/2026-05-21.md" as VaultPath;
     index.register({ journalName: "daily", anchor: anchor("2026-05-21"), path });
-    workspace.setActive(path);
+    activate(host, path);
     const invokeSpy = vi
       .spyOn(flows, "invoke")
       .mockReturnValue(AsyncResult.ok({ path: "monthly/x.md", created: false }));
-    commandsRepo.create(
-      "cmd-1",
-      makeCommand({ target: { kind: "all", writeType: "month" }, type: "next", context: "only_open_note" }),
-    );
 
     host.commands.get("cmd-1")?.checkCallback?.(false);
 
@@ -370,10 +356,11 @@ describe("DynamicCommandRegistry execution", () => {
   });
 
   it("falls back to today for open_note context without an active journal note", async () => {
-    const { host, commandsRepo, journalsRepo, flows } = await build();
-    journalsRepo.create("daily", { type: "day" });
+    const { host, flows } = await buildRegistry({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      commands: { "cmd-1": buildCommand({ name: "Cmd", type: "same", context: "open_note" }) },
+    });
     const invokeSpy = vi.spyOn(flows, "invoke").mockReturnValue(AsyncResult.ok({ path: "daily/x.md", created: false }));
-    commandsRepo.create("cmd-1", makeCommand({ type: "same", context: "open_note" }));
 
     host.commands.get("cmd-1")?.checkCallback?.(false);
 
@@ -392,16 +379,17 @@ describe("DynamicCommandRegistry execution", () => {
 
 describe("DynamicCommandRegistry available types", () => {
   it("opens the nearest earlier existing note for a previous_available command", async () => {
-    const { host, commandsRepo, journalsRepo, index, workspace, flows } = await build();
-    journalsRepo.create("daily", { type: "day" });
+    const { host, index, flows } = await buildRegistry({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      commands: { "cmd-1": buildCommand({ name: "Cmd", type: "previous_available", context: "open_note" }) },
+    });
     const activePath = "daily/2030-03-12.md" as VaultPath;
     index.register({ journalName: "daily", anchor: anchor("2030-03-12"), path: activePath });
     index.register({ journalName: "daily", anchor: anchor("2030-03-10"), path: "daily/2030-03-10.md" as VaultPath });
-    workspace.setActive(activePath);
+    activate(host, activePath);
     const invokeSpy = vi
       .spyOn(flows, "invoke")
       .mockReturnValue(AsyncResult.ok({ path: "daily/2030-03-10.md", created: false }));
-    commandsRepo.create("cmd-1", makeCommand({ type: "previous_available", context: "open_note" }));
 
     host.commands.get("cmd-1")?.checkCallback?.(false);
 
@@ -418,13 +406,14 @@ describe("DynamicCommandRegistry available types", () => {
   });
 
   it("notices instead of opening when no earlier note exists for a previous_available command", async () => {
-    const { host, commandsRepo, journalsRepo, index, workspace, notices, flows } = await build();
-    journalsRepo.create("daily", { type: "day" });
+    const { host, index, notices, flows } = await buildRegistry({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      commands: { "cmd-1": buildCommand({ type: "previous_available", context: "open_note" }) },
+    });
     const activePath = "daily/2030-03-12.md" as VaultPath;
     index.register({ journalName: "daily", anchor: anchor("2030-03-12"), path: activePath });
-    workspace.setActive(activePath);
+    activate(host, activePath);
     const invokeSpy = vi.spyOn(flows, "invoke");
-    commandsRepo.create("cmd-1", makeCommand({ type: "previous_available", context: "open_note" }));
 
     host.commands.get("cmd-1")?.checkCallback?.(false);
 
@@ -433,21 +422,27 @@ describe("DynamicCommandRegistry available types", () => {
   });
 
   it("stays listed for a next_available command when the target has a journal but no note is found", async () => {
-    const { host, commandsRepo, journalsRepo } = await build();
-    journalsRepo.create("daily", { type: "day" });
-    commandsRepo.create("cmd-1", makeCommand({ type: "next_available", context: "today" }));
+    const { host } = await buildRegistry({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      commands: { "cmd-1": buildCommand({ type: "next_available", context: "today" }) },
+    });
 
     expect(host.commands.get("cmd-1")?.checkCallback?.(true)).toBe(true);
   });
 
   it("notices from the ribbon when the open note does not belong to the target journals", async () => {
-    const { host, commandsRepo, journalsRepo, workspace, notices } = await build();
-    journalsRepo.create("daily", { type: "day" });
-    workspace.setActive("inbox/scratch.md" as VaultPath);
-    commandsRepo.create(
-      "cmd-1",
-      makeCommand({ type: "next_available", context: "only_open_note", icon: "star", showInRibbon: true }),
-    );
+    const { host, notices } = await buildRegistry({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      commands: {
+        "cmd-1": buildCommand({
+          type: "next_available",
+          context: "only_open_note",
+          icon: "star",
+          showInRibbon: true,
+        }),
+      },
+    });
+    activate(host, "inbox/scratch.md" as VaultPath);
 
     host.ribbonIcons[0]?.callback(new MouseEvent("click"));
 
@@ -455,9 +450,10 @@ describe("DynamicCommandRegistry available types", () => {
   });
 
   it("notices when the target has no journal of the command's write type", async () => {
-    const { host, commandsRepo, journalsRepo, notices } = await build();
-    journalsRepo.create("daily", { type: "day" });
-    commandsRepo.create("cmd-1", makeCommand({ type: "next_available", target: { kind: "all", writeType: "week" } }));
+    const { host, notices } = await buildRegistry({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      commands: { "cmd-1": buildCommand({ type: "next_available", target: { kind: "all", writeType: "week" } }) },
+    });
 
     host.commands.get("cmd-1")?.checkCallback?.(false);
 
@@ -465,9 +461,10 @@ describe("DynamicCommandRegistry available types", () => {
   });
 
   it("notices when a same-period command cannot resolve a note", async () => {
-    const { host, commandsRepo, journalsRepo, notices } = await build();
-    journalsRepo.create("daily", { type: "day" });
-    commandsRepo.create("cmd-1", makeCommand({ type: "same", context: "only_open_note" }));
+    const { host, notices } = await buildRegistry({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      commands: { "cmd-1": buildCommand({ type: "same", context: "only_open_note" }) },
+    });
 
     host.commands.get("cmd-1")?.checkCallback?.(false);
 
@@ -477,13 +474,14 @@ describe("DynamicCommandRegistry available types", () => {
 
 describe("DynamicCommandRegistry journal cascade", () => {
   it("rewrites the journal name on rename and keeps the command registered", async () => {
-    const { host, commandsRepo, journalsRepo } = await build();
-    journalsRepo.create("daily", { type: "day" });
-    commandsRepo.create("cmd-1", makeCommand({ target: { kind: "journal", journalName: "daily" } }));
+    const { host, commandsRepo, journalsRepo } = await buildRegistry({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      commands: { "cmd-1": buildCommand({ target: { kind: "journal", journalName: "daily" } }) },
+    });
 
     journalsRepo.rename("daily", "morning");
 
-    expect(commandsRepo.get("cmd-1").getOr(makeCommand({}))?.target).toEqual({
+    expect(commandsRepo.get("cmd-1").getOr(buildCommand())?.target).toEqual({
       kind: "journal",
       journalName: "morning",
     });
@@ -491,23 +489,27 @@ describe("DynamicCommandRegistry journal cascade", () => {
   });
 
   it("leaves a journal-target command for an unrelated journal untouched on rename", async () => {
-    const { commandsRepo, journalsRepo } = await build();
-    journalsRepo.create("daily", { type: "day" });
-    journalsRepo.create("weekly", { type: "week" });
-    commandsRepo.create("cmd-1", makeCommand({ target: { kind: "journal", journalName: "weekly" } }));
+    const { commandsRepo, journalsRepo } = await buildRegistry({
+      journals: {
+        daily: fixedJournal("daily", { type: "day" }),
+        weekly: fixedJournal("weekly", { type: "week" }),
+      },
+      commands: { "cmd-1": buildCommand({ target: { kind: "journal", journalName: "weekly" } }) },
+    });
 
     journalsRepo.rename("daily", "morning");
 
-    expect(commandsRepo.get("cmd-1").getOr(makeCommand({}))?.target).toEqual({
+    expect(commandsRepo.get("cmd-1").getOr(buildCommand())?.target).toEqual({
       kind: "journal",
       journalName: "weekly",
     });
   });
 
   it("removes a journal-target command when its journal is deleted", async () => {
-    const { host, commandsRepo, journalsRepo } = await build();
-    journalsRepo.create("daily", { type: "day" });
-    commandsRepo.create("cmd-1", makeCommand({ target: { kind: "journal", journalName: "daily" } }));
+    const { host, commandsRepo, journalsRepo } = await buildRegistry({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      commands: { "cmd-1": buildCommand({ target: { kind: "journal", journalName: "daily" } }) },
+    });
 
     journalsRepo.delete("daily");
 
@@ -516,9 +518,10 @@ describe("DynamicCommandRegistry journal cascade", () => {
   });
 
   it("leaves an all-target command untouched when a journal is deleted", async () => {
-    const { commandsRepo, journalsRepo } = await build();
-    journalsRepo.create("daily", { type: "day" });
-    commandsRepo.create("cmd-1", makeCommand({ target: { kind: "all", writeType: "day" } }));
+    const { commandsRepo, journalsRepo } = await buildRegistry({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      commands: { "cmd-1": buildCommand({ target: { kind: "all", writeType: "day" } }) },
+    });
 
     journalsRepo.delete("daily");
 
@@ -534,24 +537,24 @@ function commandsTargeting(commandsRepo: CommandsRepository, journalName: string
 
 describe("DynamicCommandRegistry journal cloning", () => {
   it("copies a journal-target command onto the clone", async () => {
-    const { commandsRepo, journalsRepo } = await build();
-    journalsRepo.create("daily", { type: "day" });
-    commandsRepo.create(
-      "cmd-1",
-      makeCommand({
-        name: "Open today",
-        icon: "sun",
-        showInRibbon: true,
-        target: { kind: "journal", journalName: "daily" },
-      }),
-    );
+    const { commandsRepo, journalsRepo } = await buildRegistry({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      commands: {
+        "cmd-1": buildCommand({
+          name: "Open today",
+          icon: "sun",
+          showInRibbon: true,
+          target: { kind: "journal", journalName: "daily" },
+        }),
+      },
+    });
 
     journalsRepo.clone("daily", "daily copy");
 
     const copies = commandsTargeting(commandsRepo, "daily copy");
     expect(copies).toHaveLength(1);
     expect(copies.at(0)?.[1]).toEqual(
-      makeCommand({
+      buildCommand({
         name: "Open today",
         icon: "sun",
         showInRibbon: true,
@@ -561,9 +564,10 @@ describe("DynamicCommandRegistry journal cloning", () => {
   });
 
   it("gives the copied command its own id and leaves the source command in place", async () => {
-    const { commandsRepo, journalsRepo } = await build();
-    journalsRepo.create("daily", { type: "day" });
-    commandsRepo.create("cmd-1", makeCommand({ target: { kind: "journal", journalName: "daily" } }));
+    const { commandsRepo, journalsRepo } = await buildRegistry({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      commands: { "cmd-1": buildCommand({ target: { kind: "journal", journalName: "daily" } }) },
+    });
 
     journalsRepo.clone("daily", "daily copy");
 
@@ -572,9 +576,10 @@ describe("DynamicCommandRegistry journal cloning", () => {
   });
 
   it("registers the copied command with the host", async () => {
-    const { host, commandsRepo, journalsRepo } = await build();
-    journalsRepo.create("daily", { type: "day" });
-    commandsRepo.create("cmd-1", makeCommand({ target: { kind: "journal", journalName: "daily" } }));
+    const { host, commandsRepo, journalsRepo } = await buildRegistry({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      commands: { "cmd-1": buildCommand({ target: { kind: "journal", journalName: "daily" } }) },
+    });
 
     journalsRepo.clone("daily", "daily copy");
 
@@ -583,10 +588,13 @@ describe("DynamicCommandRegistry journal cloning", () => {
   });
 
   it("leaves commands targeting other journals alone", async () => {
-    const { commandsRepo, journalsRepo } = await build();
-    journalsRepo.create("daily", { type: "day" });
-    journalsRepo.create("weekly", { type: "week" });
-    commandsRepo.create("cmd-1", makeCommand({ target: { kind: "journal", journalName: "weekly" } }));
+    const { commandsRepo, journalsRepo } = await buildRegistry({
+      journals: {
+        daily: fixedJournal("daily", { type: "day" }),
+        weekly: fixedJournal("weekly", { type: "week" }),
+      },
+      commands: { "cmd-1": buildCommand({ target: { kind: "journal", journalName: "weekly" } }) },
+    });
 
     const before = commandsRepo.count();
     journalsRepo.clone("daily", "daily copy");
@@ -596,9 +604,10 @@ describe("DynamicCommandRegistry journal cloning", () => {
   });
 
   it("does not copy all-target commands", async () => {
-    const { commandsRepo, journalsRepo } = await build();
-    journalsRepo.create("daily", { type: "day" });
-    commandsRepo.create("cmd-1", makeCommand({ target: { kind: "all", writeType: "day" } }));
+    const { commandsRepo, journalsRepo } = await buildRegistry({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      commands: { "cmd-1": buildCommand({ target: { kind: "all", writeType: "day" } }) },
+    });
 
     const before = commandsRepo.count();
     journalsRepo.clone("daily", "daily copy");
@@ -609,52 +618,58 @@ describe("DynamicCommandRegistry journal cloning", () => {
 
 describe("DynamicCommandRegistry shelf targets", () => {
   it("registers a shelf-targeted command when the shelf has a matching journal", async () => {
-    const { host, commandsRepo, journalsRepo, shelvesRepo } = await build();
-    journalsRepo.create("daily", { type: "day" });
-    shelvesRepo.create("work");
-    shelvesRepo.update("work", { journals: ["daily"] });
-    commandsRepo.create(
-      "cmd-1",
-      makeCommand({ name: "Open work daily", target: { kind: "shelf", shelfName: "work", writeType: "day" } }),
-    );
+    const { host } = await buildRegistry({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      shelves: { work: buildShelf("work", { journals: ["daily"] }) },
+      commands: {
+        "cmd-1": buildCommand({
+          name: "Open work daily",
+          target: { kind: "shelf", shelfName: "work", writeType: "day" },
+        }),
+      },
+    });
     expect(host.commands.get("cmd-1")?.name).toBe("Shelf: work: Open work daily");
   });
 
   it("hides a shelf-targeted command when the shelf has no journal of the write type", async () => {
-    const { host, commandsRepo, journalsRepo, shelvesRepo } = await build();
-    journalsRepo.create("daily", { type: "day" });
-    shelvesRepo.create("work");
-    shelvesRepo.update("work", { journals: ["daily"] });
-    commandsRepo.create(
-      "cmd-1",
-      makeCommand({ name: "Open work weekly", target: { kind: "shelf", shelfName: "work", writeType: "week" } }),
-    );
+    const { host } = await buildRegistry({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      shelves: { work: buildShelf("work", { journals: ["daily"] }) },
+      commands: {
+        "cmd-1": buildCommand({
+          name: "Open work weekly",
+          target: { kind: "shelf", shelfName: "work", writeType: "week" },
+        }),
+      },
+    });
     expect(host.commands.get("cmd-1")?.checkCallback?.(true)).toBe(false);
   });
 
   it("updates the shelf name on a shelf-targeted command when its shelf is renamed", async () => {
-    const { commandsRepo, shelvesRepo } = await build();
-    shelvesRepo.create("work");
-    commandsRepo.create("cmd-1", makeCommand({ target: { kind: "shelf", shelfName: "work", writeType: "day" } }));
+    const { commandsRepo, shelvesRepo } = await buildRegistry({
+      shelves: { work: buildShelf("work") },
+      commands: { "cmd-1": buildCommand({ target: { kind: "shelf", shelfName: "work", writeType: "day" } }) },
+    });
     shelvesRepo.rename("work", "office");
-    const target = commandsRepo.get("cmd-1").getOr(makeCommand({}))?.target;
+    const target = commandsRepo.get("cmd-1").getOr(buildCommand())?.target;
     expect(target).toEqual({ kind: "shelf", shelfName: "office", writeType: "day" });
   });
 
   it("removes a shelf-targeted command when its shelf is deleted", async () => {
-    const { commandsRepo, shelvesRepo } = await build();
-    shelvesRepo.create("work");
-    commandsRepo.create("cmd-1", makeCommand({ target: { kind: "shelf", shelfName: "work", writeType: "day" } }));
+    const { commandsRepo, shelvesRepo } = await buildRegistry({
+      shelves: { work: buildShelf("work") },
+      commands: { "cmd-1": buildCommand({ target: { kind: "shelf", shelfName: "work", writeType: "day" } }) },
+    });
     shelvesRepo.deleteWith("work");
     expect(commandsRepo.get("cmd-1").isNone()).toBe(true);
   });
 
   it("keeps a renamed shelf's command operational", async () => {
-    const { host, commandsRepo, journalsRepo, shelvesRepo } = await build();
-    journalsRepo.create("daily", { type: "day" });
-    shelvesRepo.create("work");
-    shelvesRepo.update("work", { journals: ["daily"] });
-    commandsRepo.create("cmd-1", makeCommand({ target: { kind: "shelf", shelfName: "work", writeType: "day" } }));
+    const { host, shelvesRepo } = await buildRegistry({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      shelves: { work: buildShelf("work", { journals: ["daily"] }) },
+      commands: { "cmd-1": buildCommand({ target: { kind: "shelf", shelfName: "work", writeType: "day" } }) },
+    });
     shelvesRepo.rename("work", "office");
     expect(host.commands.get("cmd-1")).toBeDefined();
     expect(host.commands.get("cmd-1")?.checkCallback?.(true)).toBe(true);

--- a/src/commands/command-registry.test.ts
+++ b/src/commands/command-registry.test.ts
@@ -647,21 +647,41 @@ describe("DynamicCommandRegistry shelf targets", () => {
 
   it("updates the shelf name on a shelf-targeted command when its shelf is renamed", async () => {
     const { commandsRepo, shelvesRepo } = await buildRegistry({
-      shelves: { work: buildShelf("work") },
-      commands: { "cmd-1": buildCommand({ target: { kind: "shelf", shelfName: "work", writeType: "day" } }) },
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      shelves: { work: buildShelf("work"), other: buildShelf("other") },
+      commands: {
+        "cmd-1": buildCommand({ target: { kind: "shelf", shelfName: "work", writeType: "day" } }),
+        "cmd-2": buildCommand({ target: { kind: "shelf", shelfName: "other", writeType: "day" } }),
+        "cmd-3": buildCommand({ target: { kind: "journal", journalName: "daily" } }),
+      },
     });
     shelvesRepo.rename("work", "office");
     const target = commandsRepo.get("cmd-1").getOr(buildCommand())?.target;
     expect(target).toEqual({ kind: "shelf", shelfName: "office", writeType: "day" });
+    // Non-matching shelf and non-shelf targets are untouched by the cascade.
+    expect(commandsRepo.get("cmd-2").getOr(buildCommand())?.target).toEqual({
+      kind: "shelf",
+      shelfName: "other",
+      writeType: "day",
+    });
+    expect(commandsRepo.get("cmd-3").getOr(buildCommand())?.target).toEqual({ kind: "journal", journalName: "daily" });
   });
 
   it("removes a shelf-targeted command when its shelf is deleted", async () => {
     const { commandsRepo, shelvesRepo } = await buildRegistry({
-      shelves: { work: buildShelf("work") },
-      commands: { "cmd-1": buildCommand({ target: { kind: "shelf", shelfName: "work", writeType: "day" } }) },
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      shelves: { work: buildShelf("work"), other: buildShelf("other") },
+      commands: {
+        "cmd-1": buildCommand({ target: { kind: "shelf", shelfName: "work", writeType: "day" } }),
+        "cmd-2": buildCommand({ target: { kind: "shelf", shelfName: "other", writeType: "day" } }),
+        "cmd-3": buildCommand({ target: { kind: "journal", journalName: "daily" } }),
+      },
     });
     shelvesRepo.deleteWith("work");
     expect(commandsRepo.get("cmd-1").isNone()).toBe(true);
+    // Non-matching shelf and non-shelf targets survive the deletion cascade.
+    expect(commandsRepo.get("cmd-2").isSome()).toBe(true);
+    expect(commandsRepo.get("cmd-3").isSome()).toBe(true);
   });
 
   it("keeps a renamed shelf's command operational", async () => {

--- a/src/commands/flows/delete-command.flow.test.ts
+++ b/src/commands/flows/delete-command.flow.test.ts
@@ -1,47 +1,24 @@
-import { createNanoEvents } from "nanoevents";
 import { describe, expect, it } from "vitest";
 
 import { Flows, UserAborted } from "@/infrastructure/flows";
-import { NoticeService } from "@/infrastructure/host";
-import { ModalService } from "@/infrastructure/host/modals";
-import { FakeModalService } from "@/infrastructure/host/modals/testing";
-import { FakeNoticeService } from "@/infrastructure/host/testing";
-import { createSettingsService } from "@/settings/testing";
+import { testContainer } from "@/testing";
 
-import { commandCollection, type CommandConfig } from "../config";
+import { commandsCoreModule } from "../module";
 import { CommandsRepository } from "../repository";
-import { CommandsEventsToken } from "../tokens";
+import { buildCommand } from "../testing";
 
 import { DeleteCommandFlow } from "./delete-command.flow";
 
-function makeConfig(name: string): CommandConfig {
-  return {
-    name,
-    icon: "",
-    showInRibbon: false,
-    openMode: "active",
-    target: { kind: "all", writeType: "day" },
-    type: "same",
-    context: "today",
-  };
-}
-
 async function build() {
-  const raw = { version: 5, commands: { "cmd-1": makeConfig("Doomed") } };
-  const { service: settings, container } = createSettingsService({
-    collections: [commandCollection],
-    raw,
+  const harness = await testContainer({
+    modules: [commandsCoreModule],
+    data: { commands: { "cmd-1": buildCommand({ name: "Doomed" }) } },
   });
-  await settings.initialize();
-  const modals = new FakeModalService();
-  container.register(ModalService).useValue(modals as unknown as ModalService);
-  container.register(CommandsEventsToken).useFactory(() => createNanoEvents());
-  container.register(CommandsRepository).useClass(CommandsRepository);
-  container.register(NoticeService).useValue(new FakeNoticeService());
-  container.register(Flows).useClass(Flows);
-  container.register(DeleteCommandFlow).useClass(DeleteCommandFlow);
-  const repo = container.resolve(CommandsRepository);
-  return { repo, modals, flows: container.resolve(Flows) };
+  return {
+    repo: harness.resolve(CommandsRepository),
+    modals: harness.modals,
+    flows: harness.resolve(Flows),
+  };
 }
 
 describe("DeleteCommandFlow", () => {

--- a/src/commands/flows/edit-command.flow.test.ts
+++ b/src/commands/flows/edit-command.flow.test.ts
@@ -1,65 +1,44 @@
-import { createNanoEvents } from "nanoevents";
 import { describe, expect, it } from "vitest";
 
 import { Flows, UserAborted } from "@/infrastructure/flows";
-import { NoticeService } from "@/infrastructure/host";
-import { ModalService } from "@/infrastructure/host/modals";
-import { FakeModalService } from "@/infrastructure/host/modals/testing";
-import { FakeNoticeService } from "@/infrastructure/host/testing";
-import { createSettingsService } from "@/settings/testing";
+import { testContainer } from "@/testing";
 
-import { commandCollection, type CommandConfig } from "../config";
+import { commandsCoreModule } from "../module";
 import { CommandsRepository } from "../repository";
-import { CommandsEventsToken } from "../tokens";
+import { buildCommand } from "../testing";
 
 import { EditCommandFlow } from "./edit-command.flow";
 
-function makeConfig(name: string, target?: CommandConfig["target"]): CommandConfig {
-  return {
-    name,
-    icon: "",
-    showInRibbon: false,
-    openMode: "active",
-    target: target ?? { kind: "all", writeType: "day" },
-    type: "same",
-    context: "today",
-  };
-}
+import type { CommandConfig } from "../config";
 
-async function build(raw?: unknown) {
-  const { service: settings, container } = createSettingsService({
-    collections: [commandCollection],
-    raw,
+async function build(commands: Record<string, CommandConfig> = {}) {
+  const harness = await testContainer({
+    modules: [commandsCoreModule],
+    data: { commands },
   });
-  await settings.initialize();
-  const modals = new FakeModalService();
-  container.register(ModalService).useValue(modals as unknown as ModalService);
-  container.register(CommandsEventsToken).useFactory(() => createNanoEvents());
-  container.register(CommandsRepository).useClass(CommandsRepository);
-  container.register(NoticeService).useValue(new FakeNoticeService());
-  container.register(Flows).useClass(Flows);
-  container.register(EditCommandFlow).useClass(EditCommandFlow);
-  const repo = container.resolve(CommandsRepository);
-  return { repo, modals, flows: container.resolve(Flows) };
+  return {
+    repo: harness.resolve(CommandsRepository),
+    modals: harness.modals,
+    flows: harness.resolve(Flows),
+  };
 }
 
 describe("EditCommandFlow", () => {
   it("adds a new command to the collection on submit", async () => {
-    const { flows, modals, repo } = await build({ version: 5, commands: {} });
+    const { flows, modals, repo } = await build();
     const promise = flows.invoke(EditCommandFlow, { target: { kind: "all", writeType: "day" } });
-    modals.lastOpen<unknown, CommandConfig>().submit(makeConfig("Added"));
+    modals.lastOpen<unknown, CommandConfig>().submit(buildCommand({ name: "Added" }));
     await promise;
-    expect([...repo.find().list()]).toEqual([makeConfig("Added")]);
+    expect([...repo.find().list()]).toEqual([buildCommand({ name: "Added" })]);
   });
 
   it("overwrites the existing entry when editing", async () => {
-    const raw = { version: 5, commands: { "cmd-1": makeConfig("Old") } };
-    const { flows, modals, repo } = await build(raw);
+    const { flows, modals, repo } = await build({ "cmd-1": buildCommand({ name: "Old" }) });
     const promise = flows.invoke(EditCommandFlow, {
       commandId: "cmd-1",
       target: { kind: "all", writeType: "day" },
     });
-    modals.lastOpen<unknown, CommandConfig>().submit(makeConfig("New"));
+    modals.lastOpen<unknown, CommandConfig>().submit(buildCommand({ name: "New" }));
     await promise;
     expect(repo.get("cmd-1").getOr(undefined as never)?.name).toBe("New");
   });
@@ -67,18 +46,15 @@ describe("EditCommandFlow", () => {
   describe("takenNames scope", () => {
     // Commands live in one flat collection, but names collide only within the same owner —
     // two journals may each hold an "Open today's note" without conflict.
-    const raw = {
-      version: 5,
-      commands: {
-        a: makeConfig("Daily open", { kind: "journal", journalName: "daily" }),
-        b: makeConfig("Work open", { kind: "journal", journalName: "work" }),
-        c: makeConfig("Shelf open", { kind: "shelf", shelfName: "desk", writeType: "day" }),
-        d: makeConfig("Global open", { kind: "all", writeType: "week" }),
-      },
+    const owners: Record<string, CommandConfig> = {
+      a: buildCommand({ name: "Daily open", target: { kind: "journal", journalName: "daily" } }),
+      b: buildCommand({ name: "Work open", target: { kind: "journal", journalName: "work" } }),
+      c: buildCommand({ name: "Shelf open", target: { kind: "shelf", shelfName: "desk", writeType: "day" } }),
+      d: buildCommand({ name: "Global open", target: { kind: "all", writeType: "week" } }),
     };
 
     it("marks only same-journal command names as taken", async () => {
-      const { flows, modals } = await build(raw);
+      const { flows, modals } = await build(owners);
       const promise = flows.invoke(EditCommandFlow, { target: { kind: "journal", journalName: "daily" } });
       expect((modals.lastOpen().props as { takenNames: string[] }).takenNames).toEqual(["Daily open"]);
       modals.lastOpen().cancel();
@@ -86,7 +62,7 @@ describe("EditCommandFlow", () => {
     });
 
     it("marks only same-shelf command names as taken", async () => {
-      const { flows, modals } = await build(raw);
+      const { flows, modals } = await build(owners);
       const promise = flows.invoke(EditCommandFlow, {
         target: { kind: "shelf", shelfName: "desk", writeType: "week" },
       });
@@ -96,7 +72,7 @@ describe("EditCommandFlow", () => {
     });
 
     it("marks plugin-level command names as taken regardless of write type", async () => {
-      const { flows, modals } = await build(raw);
+      const { flows, modals } = await build(owners);
       const promise = flows.invoke(EditCommandFlow, { target: { kind: "all", writeType: "day" } });
       expect((modals.lastOpen().props as { takenNames: string[] }).takenNames).toEqual(["Global open"]);
       modals.lastOpen().cancel();
@@ -105,7 +81,7 @@ describe("EditCommandFlow", () => {
   });
 
   it("leaves the collection untouched when the modal is cancelled", async () => {
-    const { flows, modals, repo } = await build({ version: 5, commands: {} });
+    const { flows, modals, repo } = await build();
     const promise = flows.invoke(EditCommandFlow, { target: { kind: "all", writeType: "day" } });
     modals.lastOpen().cancel();
     const result = await promise;

--- a/src/commands/module.ts
+++ b/src/commands/module.ts
@@ -1,9 +1,7 @@
 import { createNanoEvents } from "nanoevents";
 
 import type { Module } from "@/infrastructure/di";
-import { JournalEditSectionToken, defineJournalEditSection } from "@/journals";
-import { CollectionDefinitionToken, DashboardBlockToken, defineDashboardBlock } from "@/settings";
-import { ShelfEditSectionToken, defineShelfEditSection } from "@/shelves";
+import { CollectionDefinitionToken } from "@/settings";
 
 import { DynamicCommandRegistry } from "./command-registry";
 import { commandCollection } from "./config";
@@ -11,28 +9,30 @@ import { DeleteCommandFlow } from "./flows/delete-command.flow";
 import { EditCommandFlow } from "./flows/edit-command.flow";
 import { CommandsRepository, type CommandsEvents } from "./repository";
 import { CommandsEventsToken } from "./tokens";
-import CommandsDashboardBlock from "./ui/CommandsDashboardBlock.vue";
-import JournalCommandsSection from "./ui/JournalCommandsSection.vue";
-import ShelfCommandsSection from "./ui/ShelfCommandsSection.vue";
+import { commandsUiModule } from "./ui-module";
 import { CommandsViewModel } from "./view-model";
 
-export const commandsModule: Module = {
+export const commandsCoreModule: Module = {
   register(c) {
     c.register(CollectionDefinitionToken).useValue(commandCollection);
-    c.register(DynamicCommandRegistry).useClass(DynamicCommandRegistry).eager();
-    c.register(EditCommandFlow).useClass(EditCommandFlow);
-    c.register(DeleteCommandFlow).useClass(DeleteCommandFlow);
-    c.register(DashboardBlockToken).useValue(
-      defineDashboardBlock({ key: "commands", component: CommandsDashboardBlock, order: 6 }),
-    );
-    c.register(JournalEditSectionToken).useValue(
-      defineJournalEditSection({ key: "commands", component: JournalCommandsSection, order: 70 }),
-    );
-    c.register(ShelfEditSectionToken).useValue(
-      defineShelfEditSection({ key: "commands", component: ShelfCommandsSection, order: 10 }),
-    );
     c.register(CommandsEventsToken).useFactory(() => createNanoEvents<CommandsEvents>());
     c.register(CommandsRepository).useClass(CommandsRepository).eager();
     c.register(CommandsViewModel).useClass(CommandsViewModel).eager();
+    c.register(EditCommandFlow).useClass(EditCommandFlow);
+    c.register(DeleteCommandFlow).useClass(DeleteCommandFlow);
+  },
+};
+
+export const commandsStartupModule: Module = {
+  register(c) {
+    c.register(DynamicCommandRegistry).useClass(DynamicCommandRegistry).eager();
+  },
+};
+
+export const commandsModule: Module = {
+  register(c) {
+    commandsCoreModule.register(c);
+    commandsUiModule.register(c);
+    commandsStartupModule.register(c);
   },
 };

--- a/src/commands/repository.test.ts
+++ b/src/commands/repository.test.ts
@@ -1,90 +1,94 @@
-import { createNanoEvents, type Emitter } from "nanoevents";
 import { describe, expect, it, vi } from "vitest";
-import { reactive } from "vue";
+
+import { testContainer } from "@/testing";
 
 import { commandCollection, type CommandConfig } from "./config";
 import { CommandIdTakenError, UnknownCommandError } from "./errors";
-import { CommandsRepository, type CommandsEvents } from "./repository";
+import { commandsCoreModule } from "./module";
+import { CommandsRepository } from "./repository";
+import { buildCommand } from "./testing";
+import { CommandsEventsToken } from "./tokens";
 
-function buildRepo(initial: Record<string, CommandConfig> = {}) {
-  const storage = reactive<Record<string, CommandConfig>>({ ...initial });
-  const events: Emitter<CommandsEvents> = createNanoEvents();
-  const repo = CommandsRepository.fromParts(storage, events);
-  return { repo, storage, events };
+async function buildRepo(initial: Record<string, CommandConfig> = {}) {
+  const harness = await testContainer({
+    modules: [commandsCoreModule],
+    data: { commands: initial },
+  });
+  return {
+    repo: harness.resolve(CommandsRepository),
+    storage: harness.settings.recordOf(commandCollection),
+    events: harness.resolve(CommandsEventsToken),
+  };
 }
-
-const sampleCommand = (): CommandConfig => commandCollection.defaultItem("ignored");
 
 describe("CommandsRepository", () => {
   describe("create", () => {
-    it("inserts a command at the given id", () => {
-      const { repo, storage } = buildRepo();
-      const cmd = sampleCommand();
-      repo.create("cmd-1", cmd);
-      expect(storage["cmd-1"]).toEqual(cmd);
+    it("inserts a command at the given id", async () => {
+      const { repo, storage } = await buildRepo();
+      const command = buildCommand();
+      repo.create("cmd-1", command);
+      expect(storage["cmd-1"]).toEqual(command);
     });
 
-    it("emits created with the id", () => {
-      const { repo, events } = buildRepo();
+    it("emits created with the id", async () => {
+      const { repo, events } = await buildRepo();
       const spy = vi.fn();
       events.on("created", spy);
-      repo.create("cmd-1", sampleCommand());
+      repo.create("cmd-1", buildCommand());
       expect(spy).toHaveBeenCalledWith("cmd-1");
     });
 
-    it("rejects a duplicate id with CommandIdTakenError", () => {
-      const { repo } = buildRepo({ "cmd-1": sampleCommand() });
-      const result = repo.create("cmd-1", sampleCommand());
+    it("rejects a duplicate id with CommandIdTakenError", async () => {
+      const { repo } = await buildRepo({ "cmd-1": buildCommand() });
+      const result = repo.create("cmd-1", buildCommand());
       expect(result.isErr() && result.error).toBeInstanceOf(CommandIdTakenError);
     });
   });
 
   describe("inherited update", () => {
-    it("merges changes into the stored command", () => {
-      const { repo, storage } = buildRepo({ "cmd-1": sampleCommand() });
+    it("merges changes into the stored command", async () => {
+      const { repo, storage } = await buildRepo({ "cmd-1": buildCommand() });
       repo.update("cmd-1", { name: "Renamed" });
       expect(storage["cmd-1"]?.name).toBe("Renamed");
     });
 
-    it("returns UnknownCommandError for an unknown id", () => {
-      const { repo } = buildRepo();
+    it("returns UnknownCommandError for an unknown id", async () => {
+      const { repo } = await buildRepo();
       const result = repo.update("nope", { name: "X" });
       expect(result.isErr() && result.error).toBeInstanceOf(UnknownCommandError);
     });
   });
 
   describe("inherited delete", () => {
-    it("removes the command from storage", () => {
-      const { repo, storage } = buildRepo({ "cmd-1": sampleCommand() });
+    it("removes the command from storage", async () => {
+      const { repo, storage } = await buildRepo({ "cmd-1": buildCommand() });
       repo.delete("cmd-1");
       expect(storage["cmd-1"]).toBeUndefined();
     });
 
-    it("emits deleted with the id", () => {
-      const { repo, events } = buildRepo({ "cmd-1": sampleCommand() });
+    it("emits deleted with the id", async () => {
+      const { repo, events } = await buildRepo({ "cmd-1": buildCommand() });
       const spy = vi.fn();
       events.on("deleted", spy);
       repo.delete("cmd-1");
       expect(spy).toHaveBeenCalledWith("cmd-1");
     });
 
-    it("returns UnknownCommandError for an unknown id", () => {
-      const { repo } = buildRepo();
+    it("returns UnknownCommandError for an unknown id", async () => {
+      const { repo } = await buildRepo();
       const result = repo.delete("nope");
       expect(result.isErr() && result.error).toBeInstanceOf(UnknownCommandError);
     });
   });
 
   describe("find", () => {
-    it("yields commands keyed by their record id", () => {
-      const { repo } = buildRepo({ a: sampleCommand(), b: sampleCommand() });
+    it("yields commands keyed by their record id", async () => {
+      const { repo } = await buildRepo({ a: buildCommand(), b: buildCommand() });
       expect([...repo.find().ids()]).toEqual(["a", "b"]);
     });
 
-    it("labels options by the name field", () => {
-      const a = { ...sampleCommand(), name: "Alpha" };
-      const b = { ...sampleCommand(), name: "Beta" };
-      const { repo } = buildRepo({ a, b });
+    it("labels options by the name field", async () => {
+      const { repo } = await buildRepo({ a: buildCommand({ name: "Alpha" }), b: buildCommand({ name: "Beta" }) });
       expect([...repo.find().options()]).toEqual([
         { value: "a", label: "Alpha" },
         { value: "b", label: "Beta" },

--- a/src/commands/testing.ts
+++ b/src/commands/testing.ts
@@ -1,0 +1,7 @@
+import { commandCollection } from "./config";
+
+import type { CommandConfig } from "./config";
+
+export function buildCommand(overrides: Partial<CommandConfig> = {}): CommandConfig {
+  return { ...commandCollection.defaultItem(""), ...overrides };
+}

--- a/src/commands/ui-module.ts
+++ b/src/commands/ui-module.ts
@@ -1,0 +1,22 @@
+import type { Module } from "@/infrastructure/di";
+import { JournalEditSectionToken, defineJournalEditSection } from "@/journals";
+import { DashboardBlockToken, defineDashboardBlock } from "@/settings";
+import { ShelfEditSectionToken, defineShelfEditSection } from "@/shelves";
+
+import CommandsDashboardBlock from "./ui/CommandsDashboardBlock.vue";
+import JournalCommandsSection from "./ui/JournalCommandsSection.vue";
+import ShelfCommandsSection from "./ui/ShelfCommandsSection.vue";
+
+export const commandsUiModule: Module = {
+  register(c) {
+    c.register(DashboardBlockToken).useValue(
+      defineDashboardBlock({ key: "commands", component: CommandsDashboardBlock, order: 6 }),
+    );
+    c.register(JournalEditSectionToken).useValue(
+      defineJournalEditSection({ key: "commands", component: JournalCommandsSection, order: 70 }),
+    );
+    c.register(ShelfEditSectionToken).useValue(
+      defineShelfEditSection({ key: "commands", component: ShelfCommandsSection, order: 10 }),
+    );
+  },
+};

--- a/src/commands/ui/CommandList.test.ts
+++ b/src/commands/ui/CommandList.test.ts
@@ -1,26 +1,12 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { afterEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
 
 import { m } from "@/i18n";
 
+import { buildCommand } from "../testing";
+
 import CommandList from "./CommandList.vue";
-
-import type { CommandConfig } from "../config";
-
-afterEach(() => cleanup());
-
-function makeCommand(name: string): CommandConfig {
-  return {
-    name,
-    icon: "",
-    showInRibbon: false,
-    openMode: "active",
-    target: { kind: "all", writeType: "day" },
-    type: "same",
-    context: "today",
-  };
-}
 
 describe("CommandList", () => {
   it("shows the empty-state text when there are no entries", () => {
@@ -30,14 +16,14 @@ describe("CommandList", () => {
 
   it("renders a row per command with its name", () => {
     render(CommandList, {
-      props: { entries: [["id-1", makeCommand("Open daily"), "day"]], emptyText: "x" },
+      props: { entries: [["id-1", buildCommand({ name: "Open daily" }), "day"]], emptyText: "x" },
     });
     expect(screen.getByText("Open daily")).toBeTruthy();
   });
 
   it("emits edit with the command id when the edit button is clicked", async () => {
     const { emitted } = render(CommandList, {
-      props: { entries: [["id-1", makeCommand("Open daily"), "day"]], emptyText: "x" },
+      props: { entries: [["id-1", buildCommand({ name: "Open daily" }), "day"]], emptyText: "x" },
     });
     await userEvent.click(screen.getByLabelText(m.command_edit_tooltip({ name: "Open daily" })));
     expect(emitted().edit).toEqual([["id-1"]]);
@@ -45,7 +31,7 @@ describe("CommandList", () => {
 
   it("emits delete with the command id when the delete button is clicked", async () => {
     const { emitted } = render(CommandList, {
-      props: { entries: [["id-1", makeCommand("Open daily"), "day"]], emptyText: "x" },
+      props: { entries: [["id-1", buildCommand({ name: "Open daily" }), "day"]], emptyText: "x" },
     });
     await userEvent.click(screen.getByLabelText(m.common_delete_name({ name: "Open daily" })));
     expect(emitted().delete).toEqual([["id-1"]]);

--- a/src/commands/ui/CommandsDashboardBlock.test.ts
+++ b/src/commands/ui/CommandsDashboardBlock.test.ts
@@ -1,83 +1,49 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { createNanoEvents } from "nanoevents";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/vue";
+import { describe, expect, it, vi } from "vitest";
 
 import { m } from "@/i18n";
-import { type Container, provideInjectorOnApp } from "@/infrastructure/di";
 import { Flows } from "@/infrastructure/flows";
-import { NoticeService } from "@/infrastructure/host";
-import { ModalService } from "@/infrastructure/host/modals";
-import { FakeModalService } from "@/infrastructure/host/modals/testing";
-import { FakeNoticeService } from "@/infrastructure/host/testing";
-import { createSettingsService } from "@/settings/testing";
+import { testContainer } from "@/testing";
 
-import { commandCollection, type CommandConfig } from "../config";
 import { DeleteCommandFlow } from "../flows/delete-command.flow";
 import { EditCommandFlow } from "../flows/edit-command.flow";
-import { CommandsRepository } from "../repository";
-import { CommandsEventsToken } from "../tokens";
+import { commandsCoreModule } from "../module";
+import { buildCommand } from "../testing";
 
 import CommandsDashboardBlock from "./CommandsDashboardBlock.vue";
 
-afterEach(() => cleanup());
-
-function makeConfig(name: string, kind: "all" | "journal"): CommandConfig {
-  return {
-    name,
-    icon: "",
-    showInRibbon: false,
-    openMode: "active",
-    target: kind === "all" ? { kind: "all", writeType: "day" } : { kind: "journal", journalName: "daily" },
-    type: "same",
-    context: "today",
-  };
-}
+import type { CommandConfig } from "../config";
 
 async function setup(commands: Record<string, CommandConfig> = {}) {
-  const { service: settings, container } = createSettingsService({
-    collections: [commandCollection],
-    raw: { version: 5, commands },
-  });
-  await settings.initialize();
-  container.register(ModalService).useValue(new FakeModalService() as unknown as ModalService);
-  container.register(CommandsEventsToken).useFactory(() => createNanoEvents());
-  container.register(CommandsRepository).useClass(CommandsRepository);
-  container.register(NoticeService).useValue(new FakeNoticeService());
-  container.register(Flows).useClass(Flows);
-  const flows = container.resolve(Flows);
+  const harness = await testContainer({ modules: [commandsCoreModule], data: { commands } });
+  const flows = harness.resolve(Flows);
   vi.spyOn(flows, "invoke").mockReturnValue({} as never);
-  return { container, flows };
-}
-
-function mount(container: Container) {
-  return render(CommandsDashboardBlock, {
-    global: { plugins: [{ install: (app) => provideInjectorOnApp(app, container) }] },
-  });
+  return { harness, flows };
 }
 
 describe("CommandsDashboardBlock", () => {
   it("shows the empty state when no global commands exist", async () => {
-    const { container } = await setup();
-    mount(container);
+    const { harness } = await setup();
+    harness.render(CommandsDashboardBlock);
     await userEvent.click(screen.getByText(m.command_section_title()));
     expect(screen.getByText(m.command_empty({ scope: "global" }))).toBeTruthy();
   });
 
   it("lists only all-target commands", async () => {
-    const { container } = await setup({
-      "c-1": makeConfig("Global one", "all"),
-      "c-2": makeConfig("Journal one", "journal"),
+    const { harness } = await setup({
+      "c-1": buildCommand({ name: "Global one", target: { kind: "all", writeType: "day" } }),
+      "c-2": buildCommand({ name: "Journal one", target: { kind: "journal", journalName: "daily" } }),
     });
-    mount(container);
+    harness.render(CommandsDashboardBlock);
     await userEvent.click(screen.getByText(m.command_section_title()));
     expect(screen.getByText("Global one")).toBeTruthy();
     expect(screen.queryByText("Journal one")).toBeNull();
   });
 
   it("invokes EditCommandFlow with an all target when add is clicked", async () => {
-    const { container, flows } = await setup();
-    mount(container);
+    const { harness, flows } = await setup();
+    harness.render(CommandsDashboardBlock);
     await userEvent.click(screen.getByLabelText(m.command_add()));
     expect(flows.invoke).toHaveBeenCalledWith(EditCommandFlow, {
       target: { kind: "all", writeType: "day" },
@@ -85,8 +51,10 @@ describe("CommandsDashboardBlock", () => {
   });
 
   it("invokes EditCommandFlow with the command id when edit is clicked", async () => {
-    const { container, flows } = await setup({ "c-1": makeConfig("Global one", "all") });
-    mount(container);
+    const { harness, flows } = await setup({
+      "c-1": buildCommand({ name: "Global one", target: { kind: "all", writeType: "day" } }),
+    });
+    harness.render(CommandsDashboardBlock);
     await userEvent.click(screen.getByText(m.command_section_title()));
     await userEvent.click(screen.getByLabelText(m.command_edit_tooltip({ name: "Global one" })));
     expect(flows.invoke).toHaveBeenCalledWith(EditCommandFlow, {
@@ -96,8 +64,10 @@ describe("CommandsDashboardBlock", () => {
   });
 
   it("invokes DeleteCommandFlow when delete is clicked", async () => {
-    const { container, flows } = await setup({ "c-1": makeConfig("Global one", "all") });
-    mount(container);
+    const { harness, flows } = await setup({
+      "c-1": buildCommand({ name: "Global one", target: { kind: "all", writeType: "day" } }),
+    });
+    harness.render(CommandsDashboardBlock);
     await userEvent.click(screen.getByText(m.command_section_title()));
     await userEvent.click(screen.getByLabelText(m.common_delete_name({ name: "Global one" })));
     expect(flows.invoke).toHaveBeenCalledWith(DeleteCommandFlow, { commandId: "c-1" });

--- a/src/commands/ui/DeleteCommandModal.test.ts
+++ b/src/commands/ui/DeleteCommandModal.test.ts
@@ -1,42 +1,34 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/vue";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import { m } from "@/i18n";
-import type { ModalApi } from "@/infrastructure/host/modals";
-import { provideModalApiOnApp } from "@/infrastructure/host/modals/testing";
+import { testContainer, type TestHarness } from "@/testing";
+
+import { commandsCoreModule } from "../module";
 
 import DeleteCommandModal from "./DeleteCommandModal.vue";
 
-afterEach(() => cleanup());
-
-function mountModal() {
-  const submit = vi.fn();
-  const cancel = vi.fn();
-  const api: ModalApi<void> = { submit, cancel };
-  render(DeleteCommandModal, {
-    props: { commandName: "Open today" },
-    global: {
-      plugins: [{ install: (app) => provideModalApiOnApp(app, api as ModalApi<unknown>) }],
-    },
-  });
-  return { submit, cancel };
-}
-
 describe("DeleteCommandModal", () => {
+  let harness: TestHarness;
+
+  beforeEach(async () => {
+    harness = await testContainer({ modules: [commandsCoreModule], data: { commands: {} } });
+  });
+
   it("names the command being deleted", () => {
-    mountModal();
+    harness.renderModal(DeleteCommandModal, { props: { commandName: "Open today" } });
     expect(screen.getByText(m.command_delete_modal_confirm({ name: "Open today" }))).toBeTruthy();
   });
 
   it("submits when Delete is clicked", async () => {
-    const { submit } = mountModal();
+    const { submit } = harness.renderModal(DeleteCommandModal, { props: { commandName: "Open today" } });
     await userEvent.click(screen.getByText(m.common_action_delete()));
     expect(submit).toHaveBeenCalledTimes(1);
   });
 
   it("cancels when Cancel is clicked", async () => {
-    const { cancel } = mountModal();
+    const { cancel } = harness.renderModal(DeleteCommandModal, { props: { commandName: "Open today" } });
     await userEvent.click(screen.getByText(m.common_action_cancel()));
     expect(cancel).toHaveBeenCalledTimes(1);
   });

--- a/src/commands/ui/EditCommandModal.test.ts
+++ b/src/commands/ui/EditCommandModal.test.ts
@@ -1,76 +1,33 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen, waitFor } from "@testing-library/vue";
-import { createNanoEvents } from "nanoevents";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
 
 import { m } from "@/i18n";
-import { provideInjectorOnApp } from "@/infrastructure/di";
-import { InputSuggestService } from "@/infrastructure/host";
-import { FakeInputSuggestService } from "@/infrastructure/host/input-suggests/testing";
-import type { ModalApi } from "@/infrastructure/host/modals";
-import { provideModalApiOnApp } from "@/infrastructure/host/modals/testing";
-import { journalConfigCollection } from "@/journals";
-import { JournalsRepository } from "@/journals/repository";
-import { JournalsEventsToken } from "@/journals/tokens";
-import { JournalsViewModel } from "@/journals/view-model";
-import { createSettingsService } from "@/settings/testing";
+import type { JournalConfig } from "@/journals";
+import { journalsCoreModule } from "@/journals/module";
+import { fixedJournal } from "@/journals/testing";
+import { testContainer } from "@/testing";
 
-import { commandCollection, type CommandConfig, type CommandTarget } from "../config";
+import { buildCommand } from "../testing";
 
 import EditCommandModal from "./EditCommandModal.vue";
 import { editCommandModal } from "./modals";
 
-afterEach(() => cleanup());
-
-function makeJournal(name: string, writeType: "day" | "week") {
-  return {
-    name,
-    write: { type: writeType },
-    timeline: { start: "", end: { kind: "never" as const } },
-    dateFormat: "YYYY-MM-DD",
-    frontmatter: {
-      dateField: "journal-date",
-      startDateField: "journal-start-date",
-      endDateField: "journal-end-date",
-      addStartDate: false,
-      addEndDate: false,
-    },
-    numbering: { enabled: false, anchorDate: "", allowBefore: false, sources: [] },
-  };
-}
+import type { CommandConfig, CommandTarget } from "../config";
 
 async function mountModal(options: {
   command?: CommandConfig;
   target: CommandTarget;
   takenNames?: string[];
-  journals?: Record<string, unknown>;
+  journals?: Record<string, JournalConfig>;
 }) {
-  const { service: settings, container } = createSettingsService({
-    collections: [commandCollection, journalConfigCollection],
-    raw: { version: 5, journals: options.journals ?? {} },
+  const harness = await testContainer({
+    modules: [journalsCoreModule],
+    data: { journals: options.journals ?? {} },
   });
-  await settings.initialize();
-  container.register(JournalsEventsToken).useFactory(() => createNanoEvents());
-  container.register(JournalsRepository).useClass(JournalsRepository);
-  container.register(JournalsViewModel).useClass(JournalsViewModel);
-  container.register(InputSuggestService).useValue(new FakeInputSuggestService() as unknown as InputSuggestService);
-  const submit = vi.fn();
-  const cancel = vi.fn();
-  const api: ModalApi<CommandConfig> = { submit, cancel };
-  render(EditCommandModal, {
+  return harness.renderModal<typeof EditCommandModal, CommandConfig>(EditCommandModal, {
     props: { command: options.command, target: options.target, takenNames: options.takenNames ?? [] },
-    global: {
-      plugins: [
-        {
-          install(app) {
-            provideInjectorOnApp(app, container);
-            provideModalApiOnApp(app, api as ModalApi<unknown>);
-          },
-        },
-      ],
-    },
   });
-  return { submit, cancel };
 }
 
 describe("editCommandModal definition", () => {
@@ -85,15 +42,7 @@ describe("editCommandModal definition", () => {
   });
 
   it("uses the edit title when a command is supplied", () => {
-    const command: CommandConfig = {
-      name: "Existing",
-      icon: "",
-      showInRibbon: false,
-      openMode: "active",
-      target: { kind: "all", writeType: "day" },
-      type: "same",
-      context: "today",
-    };
+    const command = buildCommand({ name: "Existing" });
     expect(editCommandModal.title({ command, target: { kind: "all", writeType: "day" }, takenNames: [] })).toBe(
       m.command_edit(),
     );
@@ -121,7 +70,7 @@ describe("EditCommandModal", () => {
   it("shows the auto-prefix hint for a journal-targeted command", async () => {
     await mountModal({
       target: { kind: "journal", journalName: "daily" },
-      journals: { daily: makeJournal("daily", "day") },
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
     });
     expect(screen.getByText(m.command_name_prefix_hint({ kind: "journal" }))).toBeTruthy();
   });
@@ -129,7 +78,7 @@ describe("EditCommandModal", () => {
   it("omits the note type field for a journal-targeted command", async () => {
     await mountModal({
       target: { kind: "journal", journalName: "daily" },
-      journals: { daily: makeJournal("daily", "day") },
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
     });
     expect(screen.queryByText(m.command_modal_write_type_label())).toBeNull();
   });
@@ -180,7 +129,7 @@ describe("EditCommandModal", () => {
   it("offers only the supported types for a weekly journal target", async () => {
     await mountModal({
       target: { kind: "journal", journalName: "weekly" },
-      journals: { weekly: makeJournal("weekly", "week") },
+      journals: { weekly: fixedJournal("weekly", { type: "week" }) },
     });
     const typeSelect = screen.getAllByRole("combobox")[0]; // the type dropdown is the first combobox
     const optionValues = [...typeSelect.querySelectorAll("option")].map((o) => o.getAttribute("value"));
@@ -188,16 +137,7 @@ describe("EditCommandModal", () => {
   });
 
   it("pre-populates the name from an existing command in edit mode", async () => {
-    const command: CommandConfig = {
-      name: "Existing",
-      icon: "",
-      showInRibbon: false,
-      openMode: "active",
-      target: { kind: "all", writeType: "day" },
-      type: "same",
-      context: "today",
-    };
-    await mountModal({ command, target: { kind: "all", writeType: "day" } });
+    await mountModal({ command: buildCommand({ name: "Existing" }), target: { kind: "all", writeType: "day" } });
     expect(screen.getByRole<HTMLInputElement>("textbox").value).toBe("Existing");
   });
 

--- a/src/commands/ui/JournalCommandsSection.test.ts
+++ b/src/commands/ui/JournalCommandsSection.test.ts
@@ -1,86 +1,40 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { createNanoEvents } from "nanoevents";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/vue";
+import { describe, expect, it, vi } from "vitest";
 
 import { m } from "@/i18n";
-import { type Container, provideInjectorOnApp } from "@/infrastructure/di";
 import { Flows } from "@/infrastructure/flows";
-import { NoticeService } from "@/infrastructure/host";
-import { ModalService } from "@/infrastructure/host/modals";
-import { FakeModalService } from "@/infrastructure/host/modals/testing";
-import { FakeNoticeService } from "@/infrastructure/host/testing";
-import { journalConfigCollection } from "@/journals";
-import { JournalsRepository } from "@/journals/repository";
-import { JournalsEventsToken } from "@/journals/tokens";
-import { JournalsViewModel } from "@/journals/view-model";
-import { createSettingsService } from "@/settings/testing";
+import { journalsCoreModule } from "@/journals/module";
+import { fixedJournal } from "@/journals/testing";
+import { testContainer } from "@/testing";
 
-import { commandCollection, type CommandConfig } from "../config";
 import { DeleteCommandFlow } from "../flows/delete-command.flow";
 import { EditCommandFlow } from "../flows/edit-command.flow";
-import { CommandsRepository } from "../repository";
-import { CommandsEventsToken } from "../tokens";
+import { commandsCoreModule } from "../module";
+import { buildCommand } from "../testing";
 
 import JournalCommandsSection from "./JournalCommandsSection.vue";
 
-afterEach(() => cleanup());
-
-function makeJournal(name: string) {
-  return {
-    name,
-    write: { type: "day" as const },
-    timeline: { start: "", end: { kind: "never" as const } },
-    dateFormat: "YYYY-MM-DD",
-    frontmatter: {
-      dateField: "journal-date",
-      startDateField: "journal-start-date",
-      endDateField: "journal-end-date",
-      addStartDate: false,
-      addEndDate: false,
-    },
-    numbering: { enabled: false, anchorDate: "", allowBefore: false, sources: [] },
-  };
-}
-
-function makeConfig(name: string, target: CommandConfig["target"]): CommandConfig {
-  return { name, icon: "", showInRibbon: false, openMode: "active", target, type: "same", context: "today" };
-}
+import type { CommandConfig } from "../config";
 
 async function setup(commands: Record<string, CommandConfig> = {}) {
-  const { service: settings, container } = createSettingsService({
-    collections: [commandCollection, journalConfigCollection],
-    raw: { version: 5, commands, journals: { daily: makeJournal("daily") } },
+  const harness = await testContainer({
+    modules: [journalsCoreModule, commandsCoreModule],
+    data: { journals: { daily: fixedJournal("daily", { type: "day" }) }, commands },
   });
-  await settings.initialize();
-  container.register(ModalService).useValue(new FakeModalService() as unknown as ModalService);
-  container.register(JournalsEventsToken).useFactory(() => createNanoEvents());
-  container.register(JournalsRepository).useClass(JournalsRepository);
-  container.register(JournalsViewModel).useClass(JournalsViewModel);
-  container.register(CommandsEventsToken).useFactory(() => createNanoEvents());
-  container.register(CommandsRepository).useClass(CommandsRepository);
-  container.register(NoticeService).useValue(new FakeNoticeService());
-  container.register(Flows).useClass(Flows);
-  const flows = container.resolve(Flows);
+  const flows = harness.resolve(Flows);
   vi.spyOn(flows, "invoke").mockReturnValue({} as never);
-  return { container, flows };
-}
-
-function mount(container: Container) {
-  return render(JournalCommandsSection, {
-    props: { journalName: "daily" },
-    global: { plugins: [{ install: (app) => provideInjectorOnApp(app, container) }] },
-  });
+  return { harness, flows };
 }
 
 describe("JournalCommandsSection", () => {
   it("lists only this journal's commands", async () => {
-    const { container } = await setup({
-      "c-1": makeConfig("Mine", { kind: "journal", journalName: "daily" }),
-      "c-2": makeConfig("Other journal", { kind: "journal", journalName: "weekly" }),
-      "c-3": makeConfig("Global", { kind: "all", writeType: "day" }),
+    const { harness } = await setup({
+      "c-1": buildCommand({ name: "Mine", target: { kind: "journal", journalName: "daily" } }),
+      "c-2": buildCommand({ name: "Other journal", target: { kind: "journal", journalName: "weekly" } }),
+      "c-3": buildCommand({ name: "Global", target: { kind: "all", writeType: "day" } }),
     });
-    mount(container);
+    harness.render(JournalCommandsSection, { props: { journalName: "daily" } });
     await userEvent.click(screen.getByText(m.command_section_title()));
     expect(screen.getByText("Mine")).toBeTruthy();
     expect(screen.queryByText("Other journal")).toBeNull();
@@ -88,8 +42,8 @@ describe("JournalCommandsSection", () => {
   });
 
   it("invokes EditCommandFlow with a journal target when add is clicked", async () => {
-    const { container, flows } = await setup();
-    mount(container);
+    const { harness, flows } = await setup();
+    harness.render(JournalCommandsSection, { props: { journalName: "daily" } });
     await userEvent.click(screen.getByLabelText(m.command_add()));
     expect(flows.invoke).toHaveBeenCalledWith(EditCommandFlow, {
       target: { kind: "journal", journalName: "daily" },
@@ -97,10 +51,10 @@ describe("JournalCommandsSection", () => {
   });
 
   it("invokes EditCommandFlow with the command id when edit is clicked", async () => {
-    const { container, flows } = await setup({
-      "c-1": makeConfig("Mine", { kind: "journal", journalName: "daily" }),
+    const { harness, flows } = await setup({
+      "c-1": buildCommand({ name: "Mine", target: { kind: "journal", journalName: "daily" } }),
     });
-    mount(container);
+    harness.render(JournalCommandsSection, { props: { journalName: "daily" } });
     await userEvent.click(screen.getByText(m.command_section_title()));
     await userEvent.click(screen.getByLabelText(m.command_edit_tooltip({ name: "Mine" })));
     expect(flows.invoke).toHaveBeenCalledWith(EditCommandFlow, {
@@ -110,10 +64,10 @@ describe("JournalCommandsSection", () => {
   });
 
   it("invokes DeleteCommandFlow when delete is clicked", async () => {
-    const { container, flows } = await setup({
-      "c-1": makeConfig("Mine", { kind: "journal", journalName: "daily" }),
+    const { harness, flows } = await setup({
+      "c-1": buildCommand({ name: "Mine", target: { kind: "journal", journalName: "daily" } }),
     });
-    mount(container);
+    harness.render(JournalCommandsSection, { props: { journalName: "daily" } });
     await userEvent.click(screen.getByText(m.command_section_title()));
     await userEvent.click(screen.getByLabelText(m.common_delete_name({ name: "Mine" })));
     expect(flows.invoke).toHaveBeenCalledWith(DeleteCommandFlow, { commandId: "c-1" });

--- a/src/commands/ui/ShelfCommandsSection.test.ts
+++ b/src/commands/ui/ShelfCommandsSection.test.ts
@@ -1,63 +1,35 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { createNanoEvents } from "nanoevents";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/vue";
+import { describe, expect, it, vi } from "vitest";
 
 import { m } from "@/i18n";
-import { type Container, provideInjectorOnApp } from "@/infrastructure/di";
 import { Flows } from "@/infrastructure/flows";
-import { NoticeService } from "@/infrastructure/host";
-import { ModalService } from "@/infrastructure/host/modals";
-import { FakeModalService } from "@/infrastructure/host/modals/testing";
-import { FakeNoticeService } from "@/infrastructure/host/testing";
-import { createSettingsService } from "@/settings/testing";
-import { shelvesCollection } from "@/shelves";
+import { testContainer } from "@/testing";
 
-import { commandCollection, type CommandConfig } from "../config";
 import { DeleteCommandFlow } from "../flows/delete-command.flow";
 import { EditCommandFlow } from "../flows/edit-command.flow";
-import { CommandsRepository } from "../repository";
-import { CommandsEventsToken } from "../tokens";
+import { commandsCoreModule } from "../module";
+import { buildCommand } from "../testing";
 
 import ShelfCommandsSection from "./ShelfCommandsSection.vue";
 
-afterEach(() => cleanup());
-
-function makeConfig(name: string, target: CommandConfig["target"]): CommandConfig {
-  return { name, icon: "", showInRibbon: false, openMode: "active", target, type: "same", context: "today" };
-}
+import type { CommandConfig } from "../config";
 
 async function setup(commands: Record<string, CommandConfig> = {}) {
-  const { service: settings, container } = createSettingsService({
-    collections: [commandCollection, shelvesCollection],
-    raw: { version: 5, commands, shelves: { work: { name: "work", journals: [] } } },
-  });
-  await settings.initialize();
-  container.register(ModalService).useValue(new FakeModalService() as unknown as ModalService);
-  container.register(CommandsEventsToken).useFactory(() => createNanoEvents());
-  container.register(CommandsRepository).useClass(CommandsRepository);
-  container.register(NoticeService).useValue(new FakeNoticeService());
-  container.register(Flows).useClass(Flows);
-  const flows = container.resolve(Flows);
+  const harness = await testContainer({ modules: [commandsCoreModule], data: { commands } });
+  const flows = harness.resolve(Flows);
   vi.spyOn(flows, "invoke").mockReturnValue({} as never);
-  return { container, flows };
-}
-
-function mount(container: Container) {
-  return render(ShelfCommandsSection, {
-    props: { shelfName: "work" },
-    global: { plugins: [{ install: (app) => provideInjectorOnApp(app, container) }] },
-  });
+  return { harness, flows };
 }
 
 describe("ShelfCommandsSection", () => {
   it("lists only this shelf's commands", async () => {
-    const { container } = await setup({
-      "c-1": makeConfig("Mine", { kind: "shelf", shelfName: "work", writeType: "day" }),
-      "c-2": makeConfig("Other shelf", { kind: "shelf", shelfName: "home", writeType: "day" }),
-      "c-3": makeConfig("Global", { kind: "all", writeType: "day" }),
+    const { harness } = await setup({
+      "c-1": buildCommand({ name: "Mine", target: { kind: "shelf", shelfName: "work", writeType: "day" } }),
+      "c-2": buildCommand({ name: "Other shelf", target: { kind: "shelf", shelfName: "home", writeType: "day" } }),
+      "c-3": buildCommand({ name: "Global", target: { kind: "all", writeType: "day" } }),
     });
-    mount(container);
+    harness.render(ShelfCommandsSection, { props: { shelfName: "work" } });
     await userEvent.click(screen.getByText(m.command_section_title()));
     expect(screen.getByText("Mine")).toBeTruthy();
     expect(screen.queryByText("Other shelf")).toBeNull();
@@ -65,8 +37,8 @@ describe("ShelfCommandsSection", () => {
   });
 
   it("invokes EditCommandFlow with a shelf target when add is clicked", async () => {
-    const { container, flows } = await setup();
-    mount(container);
+    const { harness, flows } = await setup();
+    harness.render(ShelfCommandsSection, { props: { shelfName: "work" } });
     await userEvent.click(screen.getByLabelText(m.command_add()));
     expect(flows.invoke).toHaveBeenCalledWith(EditCommandFlow, {
       target: { kind: "shelf", shelfName: "work", writeType: "day" },
@@ -74,10 +46,10 @@ describe("ShelfCommandsSection", () => {
   });
 
   it("invokes EditCommandFlow with the command id when edit is clicked", async () => {
-    const { container, flows } = await setup({
-      "c-1": makeConfig("Mine", { kind: "shelf", shelfName: "work", writeType: "day" }),
+    const { harness, flows } = await setup({
+      "c-1": buildCommand({ name: "Mine", target: { kind: "shelf", shelfName: "work", writeType: "day" } }),
     });
-    mount(container);
+    harness.render(ShelfCommandsSection, { props: { shelfName: "work" } });
     await userEvent.click(screen.getByText(m.command_section_title()));
     await userEvent.click(screen.getByLabelText(m.command_edit_tooltip({ name: "Mine" })));
     expect(flows.invoke).toHaveBeenCalledWith(EditCommandFlow, {
@@ -87,10 +59,10 @@ describe("ShelfCommandsSection", () => {
   });
 
   it("invokes DeleteCommandFlow when delete is clicked", async () => {
-    const { container, flows } = await setup({
-      "c-1": makeConfig("Mine", { kind: "shelf", shelfName: "work", writeType: "day" }),
+    const { harness, flows } = await setup({
+      "c-1": buildCommand({ name: "Mine", target: { kind: "shelf", shelfName: "work", writeType: "day" } }),
     });
-    mount(container);
+    harness.render(ShelfCommandsSection, { props: { shelfName: "work" } });
     await userEvent.click(screen.getByText(m.command_section_title()));
     await userEvent.click(screen.getByLabelText(m.common_delete_name({ name: "Mine" })));
     expect(flows.invoke).toHaveBeenCalledWith(DeleteCommandFlow, { commandId: "c-1" });

--- a/src/commands/view-model.test.ts
+++ b/src/commands/view-model.test.ts
@@ -1,54 +1,53 @@
-import { createNanoEvents } from "nanoevents";
 import { describe, expect, it } from "vitest";
-import { reactive } from "vue";
 
-import { commandCollection, type CommandConfig } from "./config";
-import { CommandsRepository, type CommandsEvents } from "./repository";
+import { testContainer } from "@/testing";
+
+import { commandsCoreModule } from "./module";
+import { buildCommand } from "./testing";
 import { CommandsViewModel } from "./view-model";
 
-function buildVM(initial: Record<string, CommandConfig> = {}) {
-  const storage = reactive<Record<string, CommandConfig>>({ ...initial });
-  const events = createNanoEvents<CommandsEvents>();
-  const repo = CommandsRepository.fromParts(storage, events);
-  const vm = CommandsViewModel.fromRepository(repo);
-  return { vm, repo };
+import type { CommandConfig } from "./config";
+
+async function resolveViewModel(initial: Record<string, CommandConfig> = {}): Promise<CommandsViewModel> {
+  const harness = await testContainer({
+    modules: [commandsCoreModule],
+    data: { commands: initial },
+  });
+  return harness.resolve(CommandsViewModel);
 }
 
 describe("CommandsViewModel", () => {
   describe("commands", () => {
-    it("yields the current commands", () => {
-      const cmd = commandCollection.defaultItem("ignored");
-      const { vm } = buildVM({ a: cmd });
-      expect(vm.commands.value).toEqual([cmd]);
+    it("yields the current commands", async () => {
+      const command = buildCommand();
+      const viewModel = await resolveViewModel({ a: command });
+      expect(viewModel.commands.value).toEqual([command]);
     });
   });
 
   describe("commandCount", () => {
-    it("returns the count", () => {
-      const { vm } = buildVM({ a: commandCollection.defaultItem("ignored") });
-      expect(vm.commandCount.value).toBe(1);
+    it("returns the count", async () => {
+      const viewModel = await resolveViewModel({ a: buildCommand() });
+      expect(viewModel.commandCount.value).toBe(1);
     });
   });
 
   describe("getCommand", () => {
-    it("returns Some for a known id", () => {
-      const { vm } = buildVM({ a: commandCollection.defaultItem("ignored") });
-      expect(vm.getCommand("a").isSome()).toBe(true);
+    it("returns Some for a known id", async () => {
+      const viewModel = await resolveViewModel({ a: buildCommand() });
+      expect(viewModel.getCommand("a").isSome()).toBe(true);
     });
 
-    it("returns None for an unknown id", () => {
-      const { vm } = buildVM();
-      expect(vm.getCommand("nope").isNone()).toBe(true);
+    it("returns None for an unknown id", async () => {
+      const viewModel = await resolveViewModel();
+      expect(viewModel.getCommand("nope").isNone()).toBe(true);
     });
   });
 
   describe("commandIds", () => {
-    it("yields the ids of all current commands", () => {
-      const { vm } = buildVM({
-        a: commandCollection.defaultItem("ignored"),
-        b: commandCollection.defaultItem("ignored"),
-      });
-      expect(vm.commandIds.value).toEqual(["a", "b"]);
+    it("yields the ids of all current commands", async () => {
+      const viewModel = await resolveViewModel({ a: buildCommand(), b: buildCommand() });
+      expect(viewModel.commandIds.value).toEqual(["a", "b"]);
     });
   });
 });

--- a/src/maintenance/module.ts
+++ b/src/maintenance/module.ts
@@ -1,20 +1,21 @@
 import type { Module } from "@/infrastructure/di";
-import { DashboardBlockToken, SubpageToken, defineDashboardBlock } from "@/settings";
 
 import { RepairService } from "./repair-service";
 import { ScanService } from "./scan-service";
 import { ScannedNoteResolver } from "./scanned-note";
-import { maintenanceSubpage } from "./ui/maintenance-subpage";
-import MaintenanceBlock from "./ui/MaintenanceBlock.vue";
+import { maintenanceUiModule } from "./ui-module";
 
-export const maintenanceModule: Module = {
+export const maintenanceCoreModule: Module = {
   register(c) {
-    c.register(SubpageToken).useValue(maintenanceSubpage);
-    c.register(DashboardBlockToken).useValue(
-      defineDashboardBlock({ key: "maintenance", component: MaintenanceBlock, order: 110 }),
-    );
     c.register(ScannedNoteResolver).useClass(ScannedNoteResolver);
     c.register(ScanService).useClass(ScanService);
     c.register(RepairService).useClass(RepairService);
+  },
+};
+
+export const maintenanceModule: Module = {
+  register(c) {
+    maintenanceCoreModule.register(c);
+    maintenanceUiModule.register(c);
   },
 };

--- a/src/maintenance/repair-service.test.ts
+++ b/src/maintenance/repair-service.test.ts
@@ -1,75 +1,45 @@
-import { createNanoEvents } from "nanoevents";
-import { describe, expect, it, vi, type Mock } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { anchor } from "@/calendar/testing";
-import { Container } from "@/infrastructure/di";
-import { NoteMetadataService, NotesService } from "@/infrastructure/host";
-import type { NotesEvents, VaultPath } from "@/infrastructure/host";
-import { FakeNoteMetadataService } from "@/infrastructure/host/testing";
-import { LoggerModule } from "@/infrastructure/logger";
-import { AsyncResult, Err, Ok } from "@/infrastructure/result";
+import type { VaultPath } from "@/infrastructure/host";
+import type { FakeHost } from "@/infrastructure/host/internal/testing";
+import { AsyncResult } from "@/infrastructure/result";
 import { expectOk } from "@/infrastructure/result/testing";
-import { FRONTMATTER_NAME_KEY } from "@/journals/config";
-import { JournalNotFoundError } from "@/journals/errors";
+import { FRONTMATTER_NAME_KEY, type JournalConfig } from "@/journals/config";
 import { FrontmatterService } from "@/journals/frontmatter";
 import { JournalsIndex } from "@/journals/journals-index";
+import { journalsCoreModule } from "@/journals/module";
 import { NoteConnectionService } from "@/journals/notes/note-connection";
+import { fixedJournal } from "@/journals/testing";
+import { testContainer } from "@/testing";
 
+import { maintenanceCoreModule } from "./module";
 import { RepairService } from "./repair-service";
 
 import type { RepairAction } from "./findings";
 
-function build(): {
-  service: RepairService;
-  index: JournalsIndex;
-  connection: {
-    reanchor: Mock<NoteConnectionService["reanchor"]>;
-    disconnect: Mock<NoteConnectionService["disconnect"]>;
-  };
-  notes: { updateFrontmatter: Mock<NotesService["updateFrontmatter"]> };
-  frontmatter: { clearMutator: Mock<FrontmatterService["clearMutator"]> };
-  emitMetadataChanged: (path: VaultPath) => void;
-  claim: (path: VaultPath, journalName: string | undefined) => void;
-} {
-  const connection = {
-    reanchor: vi.fn<NoteConnectionService["reanchor"]>(() => AsyncResult.ok(undefined)),
-    disconnect: vi.fn<NoteConnectionService["disconnect"]>(() => AsyncResult.ok(undefined)),
-  };
-  const notesEmitter = createNanoEvents<NotesEvents>();
-  const notes = {
-    events: notesEmitter,
-    updateFrontmatter: vi.fn<NotesService["updateFrontmatter"]>(() => AsyncResult.ok(undefined)),
-  };
-  // Defaults to "unknown journal" so every existing strip-claim test (journalName "gone") keeps
-  // exercising the disconnect() fallback unchanged; Fix-8 tests override this per case.
-  const frontmatter = {
-    clearMutator: vi.fn<FrontmatterService["clearMutator"]>(() => new Err(new JournalNotFoundError("gone"))),
-  };
-  const metadata = new FakeNoteMetadataService();
-  const c = new Container();
-  c.addModule(LoggerModule);
-  c.register(JournalsIndex).useClass(JournalsIndex);
-  c.register(NoteConnectionService).useValue(connection as unknown as NoteConnectionService);
-  c.register(NotesService).useValue(notes as unknown as NotesService);
-  c.register(NoteMetadataService).useValue(metadata as unknown as NoteMetadataService);
-  c.register(FrontmatterService).useValue(frontmatter as unknown as FrontmatterService);
-  c.register(RepairService).useClass(RepairService);
+const WEEKLY = { weekly: fixedJournal("weekly", { type: "week" }) };
+
+async function buildRepairs(journals: Record<string, JournalConfig> = WEEKLY) {
+  const harness = await testContainer({
+    modules: [journalsCoreModule, maintenanceCoreModule],
+    data: { journals },
+  });
+  const connection = harness.resolve(NoteConnectionService);
   return {
-    service: c.resolve(RepairService),
-    index: c.resolve(JournalsIndex),
-    connection,
-    notes,
-    frontmatter,
-    emitMetadataChanged: (path) => notesEmitter.emit("metadata-changed", path),
-    claim: (path, journalName) => {
-      metadata.setMetadata(path, {
-        title: path,
-        tags: [],
-        properties: journalName === undefined ? {} : { [FRONTMATTER_NAME_KEY]: journalName },
-        tasks: [],
-      });
-    },
+    host: harness.host,
+    service: harness.resolve(RepairService),
+    index: harness.resolve(JournalsIndex),
+    frontmatter: harness.resolve(FrontmatterService),
+    // Spied through rather than replaced: the default path writes to the fake vault for real,
+    // and only the tests that pin down timing or inject a failure override an implementation.
+    reanchor: vi.spyOn(connection, "reanchor"),
+    disconnect: vi.spyOn(connection, "disconnect"),
   };
+}
+
+function claim(host: FakeHost, path: string, journalName: string | undefined): void {
+  host.putFile(path, "", journalName === undefined ? {} : { [FRONTMATTER_NAME_KEY]: journalName });
 }
 
 function rewrite(path: string, to: string): RepairAction {
@@ -78,9 +48,9 @@ function rewrite(path: string, to: string): RepairAction {
 
 describe("RepairService", () => {
   it("reports a note repaired once it is indexed at the intended anchor", async () => {
-    const { service, index, connection } = build();
-    connection.reanchor.mockImplementation((journalName: string, path: VaultPath, target: { anchor: string }) => {
-      index.register({ journalName, anchor: target.anchor as never, path });
+    const { service, index, reanchor } = await buildRepairs();
+    reanchor.mockImplementation((journalName, path, target) => {
+      index.register({ journalName, anchor: target.anchor, path });
       return AsyncResult.ok(undefined);
     });
 
@@ -92,7 +62,8 @@ describe("RepairService", () => {
 
   it("reports a note that was written but never reached the index", async () => {
     vi.useFakeTimers();
-    const { service } = build();
+    const { service, host } = await buildRepairs();
+    claim(host, "a.md", "weekly");
 
     const running = service.apply([rewrite("a.md", "2026-01-12")]);
     await vi.runAllTimersAsync();
@@ -104,10 +75,10 @@ describe("RepairService", () => {
   });
 
   it("lets a stale-range rewrite reclaim the anchor its own note already occupies", async () => {
-    const { service, index, connection } = build();
+    const { service, index, reanchor } = await buildRepairs();
     index.register({ journalName: "weekly", anchor: anchor("2026-01-12"), path: "a.md" as VaultPath });
-    connection.reanchor.mockImplementation((journalName: string, path: VaultPath, target: { anchor: string }) => {
-      index.register({ journalName, anchor: target.anchor as never, path });
+    reanchor.mockImplementation((journalName, path, target) => {
+      index.register({ journalName, anchor: target.anchor, path });
       return AsyncResult.ok(undefined);
     });
 
@@ -115,88 +86,85 @@ describe("RepairService", () => {
 
     expectOk(result);
     expect(result.value.at(0)?.outcome).toEqual({ kind: "repaired" });
-    expect(connection.reanchor).toHaveBeenCalledTimes(1);
+    expect(reanchor).toHaveBeenCalledTimes(1);
   });
 
   it("refuses a second write onto an anchor this run already claimed", async () => {
-    const { service, connection } = build();
+    vi.useFakeTimers();
+    const { service, host, reanchor } = await buildRepairs();
+    claim(host, "a.md", "weekly");
+    claim(host, "b.md", "weekly");
 
-    const result = await service.apply([rewrite("a.md", "2026-01-12"), rewrite("b.md", "2026-01-12")]);
+    const running = service.apply([rewrite("a.md", "2026-01-12"), rewrite("b.md", "2026-01-12")]);
+    await vi.runAllTimersAsync();
+    const result = await running;
 
     expectOk(result);
     expect(result.value.at(1)?.outcome).toEqual({ kind: "failed", reason: "contested" });
-    expect(connection.reanchor).toHaveBeenCalledTimes(1);
+    expect(reanchor).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
   });
 
   it("records a write failure and keeps going", async () => {
-    const { service, connection } = build();
-    connection.reanchor.mockReturnValueOnce(AsyncResult.err(new Error("disk full") as never));
+    vi.useFakeTimers();
+    const { service, host, reanchor } = await buildRepairs();
+    claim(host, "b.md", "weekly");
+    reanchor.mockReturnValueOnce(AsyncResult.err(new Error("disk full") as never));
 
-    const result = await service.apply([rewrite("a.md", "2026-01-12"), rewrite("b.md", "2026-01-19")]);
+    const running = service.apply([rewrite("a.md", "2026-01-12"), rewrite("b.md", "2026-01-19")]);
+    await vi.runAllTimersAsync();
+    const result = await running;
 
     expectOk(result);
     expect(result.value.at(0)?.outcome.kind).toBe("failed");
-    expect(connection.reanchor).toHaveBeenCalledTimes(2);
+    expect(reanchor).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
   });
 
   it("strips a claim through the existing disconnect path", async () => {
-    vi.useFakeTimers();
-    const { service, connection, emitMetadataChanged, claim } = build();
-    claim("old.md" as VaultPath, "gone");
-    connection.disconnect.mockImplementation((path: VaultPath) => {
-      window.setTimeout(() => {
-        claim(path, undefined);
-        emitMetadataChanged(path);
-      }, 0);
-      return AsyncResult.ok(undefined);
-    });
+    const { service, host, disconnect } = await buildRepairs();
+    claim(host, "old.md", "gone");
 
-    const running = service.apply([
+    const result = await service.apply([
       { path: "old.md" as VaultPath, journalName: "gone", repair: { kind: "strip-claim" } },
     ]);
-    await vi.advanceTimersByTimeAsync(0);
-    const result = await running;
 
     expectOk(result);
-    expect(connection.disconnect).toHaveBeenCalledWith("old.md");
+    expect(disconnect).toHaveBeenCalledWith("old.md");
+    expect(host.files.get("old.md")?.frontmatter).toEqual({});
     expect(result.value.at(0)?.outcome).toEqual({ kind: "repaired" });
-    vi.useRealTimers();
   });
 
   it("strips through the journal's own configured fields when the journal still exists", async () => {
-    vi.useFakeTimers();
-    const { service, connection, notes, frontmatter, emitMetadataChanged, claim } = build();
-    claim("loser.md" as VaultPath, "weekly");
-    const mutator = vi.fn((fm: Record<string, unknown>) => {
-      delete fm["custom-date"];
+    const { service, host, frontmatter, disconnect } = await buildRepairs({
+      weekly: fixedJournal(
+        "weekly",
+        { type: "week" },
+        { frontmatter: { ...WEEKLY.weekly.frontmatter, dateField: "custom-date" } },
+      ),
     });
-    frontmatter.clearMutator.mockReturnValueOnce(new Ok(mutator));
-    notes.updateFrontmatter.mockImplementation((path: VaultPath) => {
-      window.setTimeout(() => {
-        claim(path, undefined);
-        emitMetadataChanged(path);
-      }, 0);
-      return AsyncResult.ok(undefined);
-    });
+    const clearMutator = vi.spyOn(frontmatter, "clearMutator");
+    host.putFile("loser.md", "", { [FRONTMATTER_NAME_KEY]: "weekly", "custom-date": "2026-01-12", keep: "me" });
 
-    const running = service.apply([
+    const result = await service.apply([
       { path: "loser.md" as VaultPath, journalName: "weekly", repair: { kind: "strip-claim" } },
     ]);
-    await vi.advanceTimersByTimeAsync(0);
-    const result = await running;
 
     expectOk(result);
-    expect(frontmatter.clearMutator).toHaveBeenCalledWith("weekly");
-    expect(notes.updateFrontmatter).toHaveBeenCalledWith("loser.md", mutator);
-    expect(connection.disconnect).not.toHaveBeenCalled();
+    expect(clearMutator).toHaveBeenCalledWith("weekly");
+    // The journal's configured date field, not the default "journal-date", is what has to go.
+    expect(host.files.get("loser.md")?.frontmatter).toEqual({ keep: "me" });
+    expect(disconnect).not.toHaveBeenCalled();
     expect(result.value.at(0)?.outcome).toEqual({ kind: "repaired" });
-    vi.useRealTimers();
   });
 
   it("does not settle a strip until the stripped note's metadata has actually changed", async () => {
     vi.useFakeTimers();
-    const { service, emitMetadataChanged, claim } = build();
-    claim("old.md" as VaultPath, "gone");
+    const { service, host, disconnect } = await buildRepairs();
+    claim(host, "old.md", "gone");
+    // A write that reported success while the claim is still readable — metadataCache lags the
+    // vault, so "the write returned" and "the note stopped claiming the journal" are two moments.
+    disconnect.mockReturnValue(AsyncResult.ok(undefined));
 
     let settled = false;
     const running = service
@@ -211,8 +179,8 @@ describe("RepairService", () => {
     await vi.advanceTimersByTimeAsync(1000);
     expect(settled).toBe(false);
 
-    claim("old.md" as VaultPath, undefined);
-    emitMetadataChanged("old.md" as VaultPath);
+    claim(host, "old.md", undefined);
+    host.emitMetadata("old.md");
     await running;
 
     expect(settled).toBe(true);
@@ -221,8 +189,9 @@ describe("RepairService", () => {
 
   it("reports a strip failed when the claim is still in place after the wait", async () => {
     vi.useFakeTimers();
-    const { service, claim } = build();
-    claim("old.md" as VaultPath, "gone");
+    const { service, host, disconnect } = await buildRepairs();
+    claim(host, "old.md", "gone");
+    disconnect.mockReturnValue(AsyncResult.ok(undefined));
 
     const running = service.apply([
       { path: "old.md" as VaultPath, journalName: "gone", repair: { kind: "strip-claim" } },
@@ -237,8 +206,8 @@ describe("RepairService", () => {
 
   it("settles a strip whose metadata already dropped the claim before the listener attached", async () => {
     vi.useFakeTimers();
-    const { service, claim } = build();
-    claim("old.md" as VaultPath, undefined);
+    const { service, host } = await buildRepairs();
+    claim(host, "old.md", undefined);
 
     let settled = false;
     const running = service
@@ -258,7 +227,7 @@ describe("RepairService", () => {
   });
 
   it("does nothing for an undecidable action", async () => {
-    const { service, connection } = build();
+    const { service, reanchor } = await buildRepairs();
 
     await service.apply([
       {
@@ -268,14 +237,14 @@ describe("RepairService", () => {
       },
     ]);
 
-    expect(connection.reanchor).not.toHaveBeenCalled();
+    expect(reanchor).not.toHaveBeenCalled();
   });
 
   it("verifies each entry against its own intent when the same path appears twice in a batch", async () => {
     vi.useFakeTimers();
-    const { service, index, connection } = build();
-    connection.reanchor.mockImplementation((journalName: string, path: VaultPath, target: { anchor: string }) => {
-      index.register({ journalName, anchor: target.anchor as never, path });
+    const { service, index, reanchor } = await buildRepairs();
+    reanchor.mockImplementation((journalName, path, target) => {
+      index.register({ journalName, anchor: target.anchor, path });
       return AsyncResult.ok(undefined);
     });
 
@@ -291,10 +260,10 @@ describe("RepairService", () => {
 
   it("resolves through the entryChanged event without waiting out the settle timeout", async () => {
     vi.useFakeTimers();
-    const { service, index, connection } = build();
-    connection.reanchor.mockImplementation((journalName: string, path: VaultPath, target: { anchor: string }) => {
+    const { service, index, reanchor } = await buildRepairs();
+    reanchor.mockImplementation((journalName, path, target) => {
       window.setTimeout(() => {
-        index.register({ journalName, anchor: target.anchor as never, path });
+        index.register({ journalName, anchor: target.anchor, path });
       }, 0);
       return AsyncResult.ok(undefined);
     });

--- a/src/maintenance/scan-service.test.ts
+++ b/src/maintenance/scan-service.test.ts
@@ -1,22 +1,17 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { anchor, installTestCalendar } from "@/calendar/testing";
-import { Container } from "@/infrastructure/di";
-import { NoteMetadataService, NotesService } from "@/infrastructure/host";
+import { anchor } from "@/calendar/testing";
 import type { VaultPath } from "@/infrastructure/host";
-import { FakeNoteMetadataService, FakeNotesService } from "@/infrastructure/host/testing";
-import { LoggerModule } from "@/infrastructure/logger";
+import type { FakeHost } from "@/infrastructure/host/internal/testing";
 import type { JournalConfig } from "@/journals/config";
-import { CycleService } from "@/journals/cycle";
-import { FrontmatterService } from "@/journals/frontmatter";
 import { JournalsIndex } from "@/journals/journals-index";
-import { NotePathService } from "@/journals/notes/note-path";
-import { NumberingService } from "@/journals/numbering";
+import { journalsCoreModule } from "@/journals/module";
 import { JournalsRepository } from "@/journals/repository";
-import { customJournal, fakeRepo, fixedJournal } from "@/journals/testing";
-import { SettingsService } from "@/settings";
-import { TemplateEngine } from "@/templates";
+import { customJournal, fixedJournal } from "@/journals/testing";
+import { legacyMigrationsModule, pendingNoteMigrationSlice } from "@/settings/legacy";
+import { testContainer } from "@/testing";
 
+import { maintenanceCoreModule } from "./module";
 import { gateCollisions, orphanFindings, pendingOldIdsOf, ScanService } from "./scan-service";
 import { ScannedNoteResolver } from "./scanned-note";
 
@@ -168,59 +163,33 @@ describe("pendingOldIdsOf", () => {
   });
 });
 
-function buildScan(journals: Record<string, JournalConfig>): {
-  service: ScanService;
-  index: JournalsIndex;
-  notes: FakeNotesService;
-  metadata: FakeNoteMetadataService;
-  resolver: ScannedNoteResolver;
-} {
-  const notes = new FakeNotesService();
-  const metadata = new FakeNoteMetadataService();
-  const c = new Container();
-  c.addModule(LoggerModule);
-  c.register(JournalsRepository).useValue(fakeRepo(journals));
-  c.register(JournalsIndex).useClass(JournalsIndex);
-  c.register(CycleService).useClass(CycleService);
-  c.register(NumberingService).useClass(NumberingService);
-  c.register(FrontmatterService).useClass(FrontmatterService);
-  c.register(TemplateEngine).useClass(TemplateEngine);
-  c.register(NotePathService).useClass(NotePathService);
-  c.register(NotesService).useValue(notes as unknown as NotesService);
-  c.register(NoteMetadataService).useValue(metadata as unknown as NoteMetadataService);
-  c.register(ScannedNoteResolver).useClass(ScannedNoteResolver);
-  c.register(SettingsService).useValue({ getSlice: () => ({ state: [] }) } as unknown as SettingsService);
-  c.register(ScanService).useClass(ScanService);
+async function buildScan(journals: Record<string, JournalConfig>) {
+  const harness = await testContainer({
+    modules: [journalsCoreModule, maintenanceCoreModule, legacyMigrationsModule],
+    // ScanService reads the pending-migration slice, and legacyMigrationsModule is what
+    // registers it — a seed without the key parses as a slice reset rather than an empty list.
+    data: { journals, [pendingNoteMigrationSlice.key]: [] },
+  });
   return {
-    service: c.resolve(ScanService),
-    index: c.resolve(JournalsIndex),
-    notes,
-    metadata,
-    resolver: c.resolve(ScannedNoteResolver),
+    host: harness.host,
+    service: harness.resolve(ScanService),
+    index: harness.resolve(JournalsIndex),
+    repository: harness.resolve(JournalsRepository),
+    resolver: harness.resolve(ScannedNoteResolver),
   };
 }
 
-function seed(
-  notes: FakeNotesService,
-  metadata: FakeNoteMetadataService,
-  path: string,
-  frontmatter: Record<string, unknown>,
-): void {
-  notes.seed(path as VaultPath, "", frontmatter, { size: 100, mtime: 5 });
-  metadata.setMetadata(path as VaultPath, { title: path, tags: [], properties: frontmatter, tasks: [] });
+// A file in the vault that Obsidian has not parsed yet. getFileCache answers null until the
+// metadataCache resolves it, which is what the resolver reads as "unparsed".
+function leaveUnparsed(host: FakeHost, path: string): void {
+  const cache = host.app.metadataCache;
+  const parsed = cache.getFileCache.bind(cache);
+  vi.spyOn(cache, "getFileCache").mockImplementation((file) => (file.path === path ? null : parsed(file)));
 }
 
 describe("ScanService", () => {
-  let teardown: () => void;
-  beforeEach(() => {
-    teardown = installTestCalendar({ dow: 1, doy: 4 }).teardown;
-  });
-  afterEach(() => {
-    teardown();
-  });
-
   it("waits for the index before reporting anything", async () => {
-    const { service, index } = buildScan({ weekly: fixedJournal("weekly", { type: "week" }) });
+    const { service, index } = await buildScan({ weekly: fixedJournal("weekly", { type: "week" }) });
     let settled = false;
     const running = service.scan().then((report) => {
       settled = true;
@@ -236,9 +205,10 @@ describe("ScanService", () => {
   });
 
   it("counts notes it could not analyze", async () => {
-    const { service, index, notes, metadata } = buildScan({ weekly: fixedJournal("weekly", { type: "week" }) });
-    seed(notes, metadata, "good.md", { journal: "weekly", "journal-date": "2026-01-12" });
-    notes.seed("pending.md" as VaultPath, "", { journal: "weekly" });
+    const { service, index, host } = await buildScan({ weekly: fixedJournal("weekly", { type: "week" }) });
+    host.putFile("good.md", "", { journal: "weekly", "journal-date": "2026-01-12" });
+    host.putFile("pending.md", "", { journal: "weekly" });
+    leaveUnparsed(host, "pending.md");
     index.markReady();
 
     const report = await service.scan();
@@ -249,10 +219,10 @@ describe("ScanService", () => {
   });
 
   it("finds a stranded note and offers a repair", async () => {
-    const { service, index, notes, metadata } = buildScan({
+    const { service, index, host } = await buildScan({
       weekly: fixedJournal("weekly", { type: "week" }, { nameTemplate: "{{date:YYYY-[W]ww}}" }),
     });
-    seed(notes, metadata, "2026-W03.md", { journal: "weekly", "journal-date": "2026-01-14" });
+    host.putFile("2026-W03.md", "", { journal: "weekly", "journal-date": "2026-01-14" });
     index.markReady();
 
     const report = await service.scan();
@@ -262,11 +232,11 @@ describe("ScanService", () => {
   });
 
   it("reports a note whose resolution threw without losing the rest of the scan", async () => {
-    const { service, index, notes, metadata, resolver } = buildScan({
+    const { service, index, host, resolver } = await buildScan({
       weekly: fixedJournal("weekly", { type: "week" }),
     });
-    seed(notes, metadata, "good.md", { journal: "weekly", "journal-date": "2026-01-12" });
-    seed(notes, metadata, "bad.md", { journal: "weekly", "journal-date": "2026-01-12" });
+    host.putFile("good.md", "", { journal: "weekly", "journal-date": "2026-01-12" });
+    host.putFile("bad.md", "", { journal: "weekly", "journal-date": "2026-01-12" });
     vi.spyOn(resolver, "resolve").mockImplementationOnce(() => ({ kind: "unreadable", message: "boom" }));
     index.markReady();
 
@@ -277,9 +247,9 @@ describe("ScanService", () => {
   });
 
   it("withdraws two rewrites that would land on the same anchor and reports the collision", async () => {
-    const { service, index, notes, metadata } = buildScan({ weekly: fixedJournal("weekly", { type: "week" }) });
-    seed(notes, metadata, "a.md", { journal: "weekly", "journal-date": "2026-01-13" });
-    seed(notes, metadata, "b.md", { journal: "weekly", "journal-date": "2026-01-14" });
+    const { service, index, host } = await buildScan({ weekly: fixedJournal("weekly", { type: "week" }) });
+    host.putFile("a.md", "", { journal: "weekly", "journal-date": "2026-01-13" });
+    host.putFile("b.md", "", { journal: "weekly", "journal-date": "2026-01-14" });
     index.markReady();
 
     const report = await service.scan();
@@ -289,8 +259,8 @@ describe("ScanService", () => {
   });
 
   it("finds a note whose period range collapsed and offers a rewrite at its own anchor", async () => {
-    const { service, index, notes, metadata } = buildScan({ weekly: fixedJournal("weekly", { type: "week" }) });
-    seed(notes, metadata, "2026-W03.md", {
+    const { service, index, host } = await buildScan({ weekly: fixedJournal("weekly", { type: "week" }) });
+    host.putFile("2026-W03.md", "", {
       journal: "weekly",
       "journal-date": "2026-01-12",
       "journal-end-date": "2026-01-12",
@@ -305,23 +275,24 @@ describe("ScanService", () => {
   });
 
   it("stops using a stale path inverter after the journal's name template changes between scans", async () => {
-    const weekly = fixedJournal("weekly", { type: "week" }, { nameTemplate: "Nope" });
-    const { service, index, notes, metadata } = buildScan({ weekly });
-    seed(notes, metadata, "2026-W03.md", { journal: "weekly", "journal-date": "not-a-date" });
+    const { service, index, host, repository } = await buildScan({
+      weekly: fixedJournal("weekly", { type: "week" }, { nameTemplate: "Nope" }),
+    });
+    host.putFile("2026-W03.md", "", { journal: "weekly", "journal-date": "not-a-date" });
     index.markReady();
 
     const first = await service.scan();
     expect(first.findings.at(0)?.repair).toEqual({ kind: "undecidable", reason: "path-not-invertible" });
 
-    weekly.nameTemplate = "{{date:YYYY-[W]ww}}";
+    repository.update("weekly", { nameTemplate: "{{date:YYYY-[W]ww}}" });
     const second = await service.scan();
 
     expect(second.findings.at(0)?.repair).toEqual({ kind: "rewrite", anchor: anchor("2026-01-12") });
   });
 
   it("reports a note whose journal no longer exists", async () => {
-    const { service, index, notes, metadata } = buildScan({ weekly: fixedJournal("weekly", { type: "week" }) });
-    seed(notes, metadata, "old.md", { journal: "gone", "journal-date": "2026-01-12" });
+    const { service, index, host } = await buildScan({ weekly: fixedJournal("weekly", { type: "week" }) });
+    host.putFile("old.md", "", { journal: "gone", "journal-date": "2026-01-12" });
     index.markReady();
 
     const report = await service.scan();
@@ -331,13 +302,13 @@ describe("ScanService", () => {
   });
 
   it("excludes notes with no journal claim and custom-journal notes from every counter", async () => {
-    const { service, index, notes, metadata } = buildScan({
+    const { service, index, host } = await buildScan({
       weekly: fixedJournal("weekly", { type: "week" }),
       sprint: customJournal("sprint", "day", 14, "2026-01-05"),
     });
-    seed(notes, metadata, "good.md", { journal: "weekly", "journal-date": "2026-01-12" });
-    seed(notes, metadata, "Plain.md", { title: "hello" });
-    seed(notes, metadata, "Sprints/1.md", { journal: "sprint", "journal-date": "2026-01-05" });
+    host.putFile("good.md", "", { journal: "weekly", "journal-date": "2026-01-12" });
+    host.putFile("Plain.md", "", { title: "hello" });
+    host.putFile("Sprints/1.md", "", { journal: "sprint", "journal-date": "2026-01-05" });
     index.markReady();
 
     const report = await service.scan();

--- a/src/maintenance/scanned-note.test.ts
+++ b/src/maintenance/scanned-note.test.ts
@@ -1,95 +1,62 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { anchor, installTestCalendar } from "@/calendar/testing";
-import { Container } from "@/infrastructure/di";
-import { NoteMetadataService, NotesService } from "@/infrastructure/host";
+import { anchor } from "@/calendar/testing";
+import { NoteMetadataService } from "@/infrastructure/host";
 import type { VaultPath } from "@/infrastructure/host";
-import { FakeNoteMetadataService, FakeNotesService } from "@/infrastructure/host/testing";
-import { LoggerModule } from "@/infrastructure/logger";
 import type { JournalConfig } from "@/journals/config";
-import { CycleService } from "@/journals/cycle";
-import { FrontmatterService } from "@/journals/frontmatter";
-import { JournalsIndex } from "@/journals/journals-index";
+import { journalsCoreModule } from "@/journals/module";
 import { NotePathService } from "@/journals/notes/note-path";
-import { NumberingService } from "@/journals/numbering";
-import { JournalsRepository } from "@/journals/repository";
-import { customJournal, fakeRepo, fixedJournal } from "@/journals/testing";
-import { TemplateEngine } from "@/templates";
+import { customJournal, fixedJournal } from "@/journals/testing";
+import { testContainer } from "@/testing";
 
+import { maintenanceCoreModule } from "./module";
 import { ScannedNoteResolver } from "./scanned-note";
 
-function build(journals: Record<string, JournalConfig>): {
-  resolver: ScannedNoteResolver;
-  notes: FakeNotesService;
-  metadata: FakeNoteMetadataService;
-  notePath: NotePathService;
-} {
-  const notes = new FakeNotesService();
-  const metadata = new FakeNoteMetadataService();
-  const c = new Container();
-  c.addModule(LoggerModule);
-  c.register(JournalsRepository).useValue(fakeRepo(journals));
-  c.register(JournalsIndex).useClass(JournalsIndex);
-  c.register(CycleService).useClass(CycleService);
-  c.register(NumberingService).useClass(NumberingService);
-  c.register(FrontmatterService).useClass(FrontmatterService);
-  c.register(TemplateEngine).useClass(TemplateEngine);
-  c.register(NotePathService).useClass(NotePathService);
-  c.register(NotesService).useValue(notes as unknown as NotesService);
-  c.register(NoteMetadataService).useValue(metadata as unknown as NoteMetadataService);
-  c.register(ScannedNoteResolver).useClass(ScannedNoteResolver);
-  const resolver = c.resolve(ScannedNoteResolver);
-  // Same container-scoped instance the resolver injected — resolving it again after
-  // the resolver returns the cached singleton, not a fresh one.
-  const notePath = c.resolve(NotePathService);
-  return { resolver, notes, metadata, notePath };
-}
-
-function seed(
-  notes: FakeNotesService,
-  metadata: FakeNoteMetadataService,
-  path: string,
-  frontmatter: Record<string, unknown>,
-): void {
-  notes.seed(path as VaultPath, "", frontmatter, { size: 100, mtime: 5 });
-  metadata.setMetadata(path as VaultPath, { title: path, tags: [], properties: frontmatter, tasks: [] });
+async function buildResolver(journals: Record<string, JournalConfig>) {
+  const harness = await testContainer({
+    modules: [journalsCoreModule, maintenanceCoreModule],
+    data: { journals },
+  });
+  return {
+    host: harness.host,
+    resolver: harness.resolve(ScannedNoteResolver),
+    metadata: harness.resolve(NoteMetadataService),
+    // Same container-scoped instance the resolver injected — resolving it again after
+    // the resolver returns the cached singleton, not a fresh one.
+    notePath: harness.resolve(NotePathService),
+  };
 }
 
 describe("ScannedNoteResolver", () => {
-  let teardown: () => void;
-  beforeEach(() => {
-    teardown = installTestCalendar({ dow: 1, doy: 4 }).teardown;
-  });
-  afterEach(() => {
-    teardown();
-  });
-
-  it("ignores a note that claims no journal", () => {
-    const { resolver, notes, metadata } = build({ daily: fixedJournal("daily", { type: "day" }) });
-    seed(notes, metadata, "Plain.md", { title: "hello" });
+  it("ignores a note that claims no journal", async () => {
+    const { resolver, host } = await buildResolver({ daily: fixedJournal("daily", { type: "day" }) });
+    host.putFile("Plain.md", "", { title: "hello" });
 
     expect(resolver.resolve("Plain.md" as VaultPath).kind).toBe("not-a-claim");
   });
 
-  it("reports a note whose metadata has not been parsed yet", () => {
-    const { resolver, notes } = build({ daily: fixedJournal("daily", { type: "day" }) });
-    notes.seed("Unparsed.md" as VaultPath, "", { journal: "daily" });
+  it("reports a note whose metadata has not been parsed yet", async () => {
+    const { resolver, host } = await buildResolver({ daily: fixedJournal("daily", { type: "day" }) });
+    host.putFile("Unparsed.md", "", { journal: "daily" });
+    // A file landing in the vault and Obsidian having parsed it are two separate moments;
+    // only the second one makes its frontmatter readable.
+    vi.spyOn(host.app.metadataCache, "getFileCache").mockReturnValue(null);
 
     expect(resolver.resolve("Unparsed.md" as VaultPath).kind).toBe("unparsed");
   });
 
-  it("skips a note belonging to a custom-interval journal", () => {
-    const { resolver, notes, metadata } = build({
+  it("skips a note belonging to a custom-interval journal", async () => {
+    const { resolver, host } = await buildResolver({
       sprint: customJournal("sprint", "day", 14, "2026-01-05"),
     });
-    seed(notes, metadata, "Sprints/1.md", { journal: "sprint", "journal-date": "2026-01-05" });
+    host.putFile("Sprints/1.md", "", { journal: "sprint", "journal-date": "2026-01-05" });
 
     expect(resolver.resolve("Sprints/1.md" as VaultPath).kind).toBe("custom");
   });
 
-  it("resolves a healthy note without inverting its path", () => {
-    const { resolver, notes, metadata } = build({ weekly: fixedJournal("weekly", { type: "week" }) });
-    seed(notes, metadata, "2026-W03.md", { journal: "weekly", "journal-date": "2026-01-12" });
+  it("resolves a healthy note without inverting its path", async () => {
+    const { resolver, host } = await buildResolver({ weekly: fixedJournal("weekly", { type: "week" }) });
+    host.putFile("2026-W03.md", "", { journal: "weekly", "journal-date": "2026-01-12" });
 
     const outcome = resolver.resolve("2026-W03.md" as VaultPath);
 
@@ -100,11 +67,11 @@ describe("ScannedNoteResolver", () => {
     expect(outcome.note.pathAnchor).toBeUndefined();
   });
 
-  it("inverts the path of a note whose stored date is not the period's anchor", () => {
-    const { resolver, notes, metadata } = build({
+  it("inverts the path of a note whose stored date is not the period's anchor", async () => {
+    const { resolver, host } = await buildResolver({
       weekly: fixedJournal("weekly", { type: "week" }, { nameTemplate: "{{date:YYYY-[W]ww}}" }),
     });
-    seed(notes, metadata, "2026-W03.md", { journal: "weekly", "journal-date": "2026-01-14" });
+    host.putFile("2026-W03.md", "", { journal: "weekly", "journal-date": "2026-01-14" });
 
     const outcome = resolver.resolve("2026-W03.md" as VaultPath);
 
@@ -115,11 +82,11 @@ describe("ScannedNoteResolver", () => {
     expect(outcome.note.pathAnchor).toBe(anchor("2026-01-12"));
   });
 
-  it("inverts the path of a note whose date field holds no readable date", () => {
-    const { resolver, notes, metadata } = build({
+  it("inverts the path of a note whose date field holds no readable date", async () => {
+    const { resolver, host } = await buildResolver({
       weekly: fixedJournal("weekly", { type: "week" }, { nameTemplate: "{{date:YYYY-[W]ww}}" }),
     });
-    seed(notes, metadata, "2026-W03.md", { journal: "weekly", "journal-date": "[[2026-01-12]]" });
+    host.putFile("2026-W03.md", "", { journal: "weekly", "journal-date": "[[2026-01-12]]" });
 
     const outcome = resolver.resolve("2026-W03.md" as VaultPath);
 
@@ -129,9 +96,9 @@ describe("ScannedNoteResolver", () => {
     expect(outcome.note.pathAnchor).toBe(anchor("2026-01-12"));
   });
 
-  it("marks a note claiming a journal that no longer exists", () => {
-    const { resolver, notes, metadata } = build({ weekly: fixedJournal("weekly", { type: "week" }) });
-    seed(notes, metadata, "Old.md", { journal: "gone", "journal-date": "2026-01-12" });
+  it("marks a note claiming a journal that no longer exists", async () => {
+    const { resolver, host } = await buildResolver({ weekly: fixedJournal("weekly", { type: "week" }) });
+    host.putFile("Old.md", "", { journal: "gone", "journal-date": "2026-01-12" });
 
     const outcome = resolver.resolve("Old.md" as VaultPath);
 
@@ -141,14 +108,14 @@ describe("ScannedNoteResolver", () => {
     expect(outcome.note.claimedJournal).toBe("gone");
   });
 
-  it("prepares a journal's path inverter only once across multiple stranded notes", () => {
-    const { resolver, notes, metadata, notePath } = build({
+  it("prepares a journal's path inverter only once across multiple stranded notes", async () => {
+    const { resolver, host, notePath } = await buildResolver({
       weekly: fixedJournal("weekly", { type: "week" }, { nameTemplate: "{{date:YYYY-[W]ww}}" }),
     });
     // Both notes must be suspect — a healthy note never calls inverterFor at all,
     // so it would not exercise the cache either way.
-    seed(notes, metadata, "2026-W03.md", { journal: "weekly", "journal-date": "2026-01-14" });
-    seed(notes, metadata, "2026-W04.md", { journal: "weekly", "journal-date": "2026-01-21" });
+    host.putFile("2026-W03.md", "", { journal: "weekly", "journal-date": "2026-01-14" });
+    host.putFile("2026-W04.md", "", { journal: "weekly", "journal-date": "2026-01-21" });
     const inverterForSpy = vi.spyOn(notePath, "inverterFor");
 
     const first = resolver.resolve("2026-W03.md" as VaultPath);
@@ -164,9 +131,9 @@ describe("ScannedNoteResolver", () => {
     expect(inverterForSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("reports a note as unreadable when a collaborator throws", () => {
-    const { resolver, notes, metadata } = build({ weekly: fixedJournal("weekly", { type: "week" }) });
-    seed(notes, metadata, "2026-W03.md", { journal: "weekly", "journal-date": "2026-01-12" });
+  it("reports a note as unreadable when a collaborator throws", async () => {
+    const { resolver, host, metadata } = await buildResolver({ weekly: fixedJournal("weekly", { type: "week" }) });
+    host.putFile("2026-W03.md", "", { journal: "weekly", "journal-date": "2026-01-12" });
     vi.spyOn(metadata, "get").mockImplementationOnce(() => {
       throw new Error("boom");
     });

--- a/src/maintenance/scanned-note.test.ts
+++ b/src/maintenance/scanned-note.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { anchor } from "@/calendar/testing";
 import { NoteMetadataService } from "@/infrastructure/host";
 import type { VaultPath } from "@/infrastructure/host";
+import type { FakeHost } from "@/infrastructure/host/internal/testing";
 import type { JournalConfig } from "@/journals/config";
 import { journalsCoreModule } from "@/journals/module";
 import { NotePathService } from "@/journals/notes/note-path";
@@ -27,6 +28,12 @@ async function buildResolver(journals: Record<string, JournalConfig>) {
   };
 }
 
+function leaveUnparsed(host: FakeHost, path: string) {
+  const cache = host.app.metadataCache;
+  const parsed = cache.getFileCache.bind(cache);
+  return vi.spyOn(cache, "getFileCache").mockImplementation((file) => (file.path === path ? null : parsed(file)));
+}
+
 describe("ScannedNoteResolver", () => {
   it("ignores a note that claims no journal", async () => {
     const { resolver, host } = await buildResolver({ daily: fixedJournal("daily", { type: "day" }) });
@@ -40,9 +47,12 @@ describe("ScannedNoteResolver", () => {
     host.putFile("Unparsed.md", "", { journal: "daily" });
     // A file landing in the vault and Obsidian having parsed it are two separate moments;
     // only the second one makes its frontmatter readable.
-    vi.spyOn(host.app.metadataCache, "getFileCache").mockReturnValue(null);
+    const cache = leaveUnparsed(host, "Unparsed.md");
 
     expect(resolver.resolve("Unparsed.md" as VaultPath).kind).toBe("unparsed");
+    // A missing file reports "unparsed" too, so the verdict alone proves nothing: the cache
+    // read is what pins this to a note that is present in the vault but not yet parsed.
+    expect(cache).toHaveBeenCalled();
   });
 
   it("skips a note belonging to a custom-interval journal", async () => {

--- a/src/maintenance/ui-module.ts
+++ b/src/maintenance/ui-module.ts
@@ -1,0 +1,14 @@
+import type { Module } from "@/infrastructure/di";
+import { DashboardBlockToken, SubpageToken, defineDashboardBlock } from "@/settings";
+
+import { maintenanceSubpage } from "./ui/maintenance-subpage";
+import MaintenanceBlock from "./ui/MaintenanceBlock.vue";
+
+export const maintenanceUiModule: Module = {
+  register(c) {
+    c.register(SubpageToken).useValue(maintenanceSubpage);
+    c.register(DashboardBlockToken).useValue(
+      defineDashboardBlock({ key: "maintenance", component: MaintenanceBlock, order: 110 }),
+    );
+  },
+};

--- a/src/maintenance/ui/MaintenanceSubpage.test.ts
+++ b/src/maintenance/ui/MaintenanceSubpage.test.ts
@@ -1,28 +1,28 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen, waitFor, within } from "@testing-library/vue";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { screen, waitFor, within } from "@testing-library/vue";
+import { describe, expect, it, vi } from "vitest";
 
 import { localMoment } from "@/calendar";
 import { anchor } from "@/calendar/testing";
 import { m } from "@/i18n";
-import { type Container, provideInjectorOnApp } from "@/infrastructure/di";
-import { NoticeService, PluginDataIOError } from "@/infrastructure/host";
+import { PluginDataIOError } from "@/infrastructure/host";
 import type { VaultPath } from "@/infrastructure/host";
-import { FakeNoticeService } from "@/infrastructure/host/testing";
 import { AsyncResult } from "@/infrastructure/result";
 import { JournalsIndex } from "@/journals/journals-index";
+import { journalsCoreModule } from "@/journals/module";
 import { CURRENT_VERSION } from "@/settings";
-import { createSettingsService } from "@/settings/testing";
+import { legacyMigrationsModule, pendingNoteMigrationSlice } from "@/settings/legacy";
+import { testContainer, type TestHarness } from "@/testing";
 
+import { maintenanceCoreModule } from "../module";
 import { RepairService } from "../repair-service";
 import { ScanService } from "../scan-service";
+import { maintenanceUiModule } from "../ui-module";
 
 import MaintenanceSubpage from "./MaintenanceSubpage.vue";
 
 import type { RepairAction, ScanReport } from "../findings";
 import type { RepairLogEntry } from "../repair-service";
-
-afterEach(() => cleanup());
 
 function flushPromises(): Promise<void> {
   return new Promise((resolve) => window.setTimeout(resolve, 0));
@@ -30,61 +30,37 @@ function flushPromises(): Promise<void> {
 
 const EMPTY_REPORT: ScanReport = { findings: [], analyzed: 0, unreadable: [], unparsed: 0, pendingMigration: false };
 
-function fakeScanService(scan: () => Promise<ScanReport>): ScanService {
-  return { scan } as unknown as ScanService;
-}
-
-function fakeRepairService(
-  apply: (actions: readonly RepairAction[]) => AsyncResult<RepairLogEntry[], never>,
-): RepairService {
-  return { apply } as unknown as RepairService;
-}
-
-// A ready-by-default index: the maintenance page's own "still indexing" state is exercised at
-// the JournalsIndex level (journals-index.test.ts); these fixtures only need scans to settle
-// promptly so they aren't about proving that behavior.
-function readyIndex(): JournalsIndex {
-  const index = new JournalsIndex();
-  index.markReady();
-  return index;
-}
-
 interface StubOptions {
+  files?: Record<string, string>;
   scan?: ScanReport;
   scanFn?: () => Promise<ScanReport>;
   apply?: (actions: readonly RepairAction[]) => AsyncResult<RepairLogEntry[], never>;
 }
 
-function registerStubs(container: Container, stubs: StubOptions, notices: FakeNoticeService): void {
-  container.register(NoticeService).useValue(notices);
-  container.register(JournalsIndex).useValue(readyIndex());
-  container
-    .register(ScanService)
-    .useValue(fakeScanService(stubs.scanFn ?? (() => Promise.resolve(stubs.scan ?? EMPTY_REPORT))));
-  container.register(RepairService).useValue(fakeRepairService(stubs.apply ?? (() => AsyncResult.ok([]))));
-}
-
-async function setup(files: Record<string, string> = {}, stubs: StubOptions = {}) {
-  const { service: settings, data, container } = createSettingsService({ raw: { version: CURRENT_VERSION } });
-  await settings.initialize();
-  for (const [name, contents] of Object.entries(files)) data.files.set(name, contents);
-  const notices = new FakeNoticeService();
-  registerStubs(container, stubs, notices);
-  return { container, settings, data, notices };
+async function setup(stubs: StubOptions = {}): Promise<TestHarness> {
+  const harness = await testContainer({
+    modules: [journalsCoreModule, maintenanceCoreModule, maintenanceUiModule, legacyMigrationsModule],
+    data: { journals: {}, [pendingNoteMigrationSlice.key]: [] },
+  });
+  const files = Object.entries(stubs.files ?? {});
+  for (const [name, contents] of files) harness.data.files.set(name, contents);
+  // A ready-by-default index: the maintenance page's own "still indexing" state is exercised at
+  // the JournalsIndex level (journals-index.test.ts); these fixtures only need scans to settle
+  // promptly so they aren't about proving that behavior.
+  harness.resolve(JournalsIndex).markReady();
+  vi.spyOn(harness.resolve(ScanService), "scan").mockImplementation(
+    stubs.scanFn ?? (() => Promise.resolve(stubs.scan ?? EMPTY_REPORT)),
+  );
+  vi.spyOn(harness.resolve(RepairService), "apply").mockImplementation(stubs.apply ?? (() => AsyncResult.ok([])));
+  return harness;
 }
 
 function makeNav() {
   return { back: vi.fn(), push: vi.fn(), replace: vi.fn() };
 }
 
-function mount(container: Container, nav = makeNav()) {
-  return {
-    ...render(MaintenanceSubpage, {
-      props: { nav },
-      global: { plugins: [{ install: (app) => provideInjectorOnApp(app, container) }] },
-    }),
-    nav,
-  };
+function mount(harness: TestHarness, nav = makeNav()) {
+  return { ...harness.render(MaintenanceSubpage, { props: { nav } }), nav };
 }
 
 function row(label: string): HTMLElement {
@@ -98,11 +74,9 @@ function row(label: string): HTMLElement {
 // component test naturally wants, without pulling in a second test-rendering library. Also
 // hands back the raw DOM root for tests that need to target one row among several identical
 // ones (e.g. two "Keep this one" buttons that read the same but belong to different findings).
-function mountSubpage(stubs: StubOptions = {}) {
-  const { container } = createSettingsService({ raw: { version: CURRENT_VERSION } });
-  registerStubs(container, stubs, new FakeNoticeService());
-
-  const { container: root } = mount(container);
+async function mountSubpage(stubs: StubOptions = {}) {
+  const harness = await setup(stubs);
+  const { container: root } = mount(harness);
 
   const wrapper = {
     text: () => root.textContent ?? "",
@@ -118,36 +92,36 @@ function mountSubpage(stubs: StubOptions = {}) {
 
 describe("MaintenanceSubpage", () => {
   it("lists a snapshot with the version it was taken before", async () => {
-    const { container } = await setup({ "backup-v3-2026-08-16T10-20-30.json": '{"version":3}' });
+    const harness = await setup({ files: { "backup-v3-2026-08-16T10-20-30.json": '{"version":3}' } });
 
-    mount(container);
+    mount(harness);
 
     expect(await screen.findByText(m.maintenance_snapshot_row({ version: 3 }))).toBeTruthy();
   });
 
   it("says so when there are no snapshots", async () => {
-    const { container } = await setup();
+    const harness = await setup();
 
-    mount(container);
+    mount(harness);
 
     expect(await screen.findByText(m.maintenance_snapshots_empty())).toBeTruthy();
   });
 
   it("shows a distinct error state, not the empty state, when snapshots cannot be listed", async () => {
-    const { container, data } = await setup();
-    vi.spyOn(data, "listFiles").mockReturnValueOnce(
+    const harness = await setup();
+    vi.spyOn(harness.data, "listFiles").mockReturnValueOnce(
       AsyncResult.err(new PluginDataIOError("list", new Error("permission denied"))),
     );
 
-    mount(container);
+    mount(harness);
 
     expect(await screen.findByText(m.maintenance_snapshots_load_failed())).toBeTruthy();
     expect(screen.queryByText(m.maintenance_snapshots_empty())).toBeNull();
   });
 
   it("calls nav.back when the back breadcrumb is clicked", async () => {
-    const { container } = await setup();
-    const { nav } = mount(container);
+    const harness = await setup();
+    const { nav } = mount(harness);
 
     await userEvent.click(screen.getByRole("button", { name: m.common_label_back() }));
 
@@ -155,59 +129,61 @@ describe("MaintenanceSubpage", () => {
   });
 
   it("restores settings and shows a notice when Restore is clicked", async () => {
-    const { container, notices } = await setup({
-      "backup-v3-2026-08-16T10-20-30.json": JSON.stringify({ version: CURRENT_VERSION, journals: {} }),
+    const harness = await setup({
+      files: { "backup-v3-2026-08-16T10-20-30.json": JSON.stringify({ version: CURRENT_VERSION, journals: {} }) },
     });
-    mount(container);
+    mount(harness);
     await screen.findByText(m.maintenance_snapshot_row({ version: 3 }));
 
     await userEvent.click(
       within(row("2026-08-16T10:20:30Z")).getByRole("button", { name: m.maintenance_snapshot_restore() }),
     );
 
-    expect(notices.messages).toContain(m.maintenance_snapshot_restored({ takenAt: "2026-08-16T10:20:30Z" }));
+    expect(harness.notices.messages).toContain(m.maintenance_snapshot_restored({ takenAt: "2026-08-16T10:20:30Z" }));
   });
 
   it("shows a failure notice when the snapshot cannot be read", async () => {
-    const { container, notices } = await setup({ "backup-v3-2026-08-16T10-20-30.json": "not json" });
-    mount(container);
+    const harness = await setup({ files: { "backup-v3-2026-08-16T10-20-30.json": "not json" } });
+    mount(harness);
     await screen.findByText(m.maintenance_snapshot_row({ version: 3 }));
 
     await userEvent.click(
       within(row("2026-08-16T10:20:30Z")).getByRole("button", { name: m.maintenance_snapshot_restore() }),
     );
 
-    expect(notices.messages).toContain(m.maintenance_snapshot_failed());
+    expect(harness.notices.messages).toContain(m.maintenance_snapshot_failed());
   });
 
   it("shows a failure notice when the snapshot reads fine but cannot be applied", async () => {
-    const { container, data, notices } = await setup({
-      "backup-v3-2026-08-16T10-20-30.json": JSON.stringify({ version: CURRENT_VERSION, journals: {} }),
+    const harness = await setup({
+      files: { "backup-v3-2026-08-16T10-20-30.json": JSON.stringify({ version: CURRENT_VERSION, journals: {} }) },
     });
-    vi.spyOn(data, "save").mockReturnValueOnce(AsyncResult.err(new PluginDataIOError("save", new Error("disk full"))));
-    mount(container);
+    vi.spyOn(harness.data, "save").mockReturnValueOnce(
+      AsyncResult.err(new PluginDataIOError("save", new Error("disk full"))),
+    );
+    mount(harness);
     await screen.findByText(m.maintenance_snapshot_row({ version: 3 }));
 
     await userEvent.click(
       within(row("2026-08-16T10:20:30Z")).getByRole("button", { name: m.maintenance_snapshot_restore() }),
     );
 
-    expect(notices.messages).toContain(m.maintenance_snapshot_failed());
+    expect(harness.notices.messages).toContain(m.maintenance_snapshot_failed());
   });
 
   it("disables the Restore button while a restore is in flight", async () => {
-    const { container, data } = await setup({
-      "backup-v3-2026-08-16T10-20-30.json": JSON.stringify({ version: CURRENT_VERSION, journals: {} }),
+    const harness = await setup({
+      files: { "backup-v3-2026-08-16T10-20-30.json": JSON.stringify({ version: CURRENT_VERSION, journals: {} }) },
     });
     const { promise: gate, resolve: releaseRead } = Promise.withResolvers<void>();
-    const content = data.files.get("backup-v3-2026-08-16T10-20-30.json") ?? "";
-    vi.spyOn(data, "readFile").mockReturnValueOnce(
+    const content = harness.data.files.get("backup-v3-2026-08-16T10-20-30.json") ?? "";
+    vi.spyOn(harness.data, "readFile").mockReturnValueOnce(
       AsyncResult.fromPromise(
         gate.then(() => content),
         () => new PluginDataIOError("read-file", new Error("unused")),
       ),
     );
-    mount(container);
+    mount(harness);
     await screen.findByText(m.maintenance_snapshot_row({ version: 3 }));
 
     const restoreButton = within(row("2026-08-16T10:20:30Z")).getByRole<HTMLButtonElement>("button", {
@@ -243,11 +219,11 @@ describe("MaintenanceSubpage", () => {
       .mockResolvedValueOnce(staleReport)
       .mockResolvedValueOnce(EMPTY_REPORT);
 
-    const { container } = await setup(
-      { "backup-v3-2026-08-16T10-20-30.json": JSON.stringify({ version: CURRENT_VERSION, journals: {} }) },
-      { scanFn: scan },
-    );
-    mount(container);
+    const harness = await setup({
+      files: { "backup-v3-2026-08-16T10-20-30.json": JSON.stringify({ version: CURRENT_VERSION, journals: {} }) },
+      scanFn: scan,
+    });
+    mount(harness);
     await screen.findByText(m.maintenance_check_group_stale({ journal: "weekly" }));
     expect(scan).toHaveBeenCalledTimes(1);
 
@@ -263,7 +239,7 @@ describe("MaintenanceSubpage", () => {
   });
 
   it("shows the completeness line even when nothing is wrong", async () => {
-    const { wrapper } = mountSubpage({
+    const { wrapper } = await mountSubpage({
       scan: { findings: [], analyzed: 12, unreadable: [], unparsed: 0, pendingMigration: false },
     });
     await flushPromises();
@@ -273,7 +249,7 @@ describe("MaintenanceSubpage", () => {
   });
 
   it("offers no fix for a finding it cannot decide", async () => {
-    const { wrapper } = mountSubpage({
+    const { wrapper } = await mountSubpage({
       scan: {
         findings: [
           {
@@ -298,7 +274,7 @@ describe("MaintenanceSubpage", () => {
 
   it("applies only rewrites when fixing everything safe", async () => {
     const apply = vi.fn(() => AsyncResult.ok([]));
-    const { wrapper } = mountSubpage({
+    const { wrapper } = await mountSubpage({
       apply,
       scan: {
         findings: [
@@ -337,7 +313,7 @@ describe("MaintenanceSubpage", () => {
 
   it("keeps two independent duplicate collisions in the same journal as separate groups", async () => {
     const apply = vi.fn(() => AsyncResult.ok([]));
-    const { wrapper, dom } = mountSubpage({
+    const { wrapper, dom } = await mountSubpage({
       apply,
       scan: {
         findings: [
@@ -400,7 +376,7 @@ describe("MaintenanceSubpage", () => {
   });
 
   it("explains why a rewrite withdrawn by the collision gate has no Fix button", async () => {
-    const { wrapper } = mountSubpage({
+    const { wrapper } = await mountSubpage({
       scan: {
         findings: [
           {
@@ -425,7 +401,7 @@ describe("MaintenanceSubpage", () => {
 
   it("formats a duplicate's mtime instead of showing the raw epoch", async () => {
     const mtime = Date.UTC(2026, 5, 15, 8, 30);
-    const { wrapper } = mountSubpage({
+    const { wrapper } = await mountSubpage({
       scan: {
         findings: [
           {
@@ -449,7 +425,7 @@ describe("MaintenanceSubpage", () => {
   });
 
   it("disables fix everything safe when the scan could not read every note", async () => {
-    const { dom } = mountSubpage({
+    const { dom } = await mountSubpage({
       scan: {
         findings: [
           {
@@ -475,7 +451,7 @@ describe("MaintenanceSubpage", () => {
   });
 
   it("disables every fix action while the legacy note migration is pending", async () => {
-    const { dom } = mountSubpage({
+    const { dom } = await mountSubpage({
       scan: {
         findings: [
           {

--- a/src/shelves/config.test.ts
+++ b/src/shelves/config.test.ts
@@ -1,21 +1,31 @@
-import * as v from "valibot";
 import { describe, expect, it } from "vitest";
 
+import { journalsCoreModule } from "@/journals/module";
+import { testContainer } from "@/testing";
+
 import { shelvesCollection } from "./config";
+import { shelvesCoreModule } from "./module";
 
 describe("shelvesCollection", () => {
-  it("loads a shelf saved before decorations existed with an empty decoration list", () => {
-    const parsed = v.parse(shelvesCollection.itemSchema, { name: "work", journals: [] });
-    expect(parsed.decorations).toEqual([]);
+  it("loads a shelf saved before decorations existed with an empty decoration list", async () => {
+    const harness = await testContainer({
+      modules: [journalsCoreModule, shelvesCoreModule],
+      data: { shelves: { work: { name: "work", journals: [] } } },
+    });
+
+    expect(harness.settings.recordOf(shelvesCollection).work.decorations).toEqual([]);
   });
 
-  it("keeps a shelf's journals when its decorations fail to parse", () => {
-    const parsed = v.parse(shelvesCollection.itemSchema, {
-      name: "work",
-      journals: ["daily"],
-      decorations: [{ type: "not-a-decoration" }],
+  it("keeps a shelf's journals when its decorations fail to parse", async () => {
+    const harness = await testContainer({
+      modules: [journalsCoreModule, shelvesCoreModule],
+      data: {
+        shelves: { work: { name: "work", journals: ["daily"], decorations: [{ type: "not-a-decoration" }] } },
+      },
     });
-    expect(parsed.journals).toEqual(["daily"]);
-    expect(parsed.decorations).toEqual([]);
+
+    const shelf = harness.settings.recordOf(shelvesCollection).work;
+    expect(shelf.journals).toEqual(["daily"]);
+    expect(shelf.decorations).toEqual([]);
   });
 });

--- a/src/shelves/config.test.ts
+++ b/src/shelves/config.test.ts
@@ -1,31 +1,21 @@
+import * as v from "valibot";
 import { describe, expect, it } from "vitest";
-
-import { createSettingsService } from "@/settings/testing";
-import { CURRENT_VERSION } from "@/settings/version";
 
 import { shelvesCollection } from "./config";
 
 describe("shelvesCollection", () => {
-  it("loads a shelf saved before decorations existed with an empty decoration list", async () => {
-    const { service } = createSettingsService({
-      raw: { version: CURRENT_VERSION, shelves: { work: { name: "work", journals: [] } } },
-      collections: [shelvesCollection],
-    });
-    await service.initialize();
-    expect(service.recordOf(shelvesCollection).work.decorations).toEqual([]);
+  it("loads a shelf saved before decorations existed with an empty decoration list", () => {
+    const parsed = v.parse(shelvesCollection.itemSchema, { name: "work", journals: [] });
+    expect(parsed.decorations).toEqual([]);
   });
 
-  it("keeps a shelf's journals when its decorations fail to parse", async () => {
-    const { service } = createSettingsService({
-      raw: {
-        version: CURRENT_VERSION,
-        shelves: { work: { name: "work", journals: ["daily"], decorations: [{ type: "not-a-decoration" }] } },
-      },
-      collections: [shelvesCollection],
+  it("keeps a shelf's journals when its decorations fail to parse", () => {
+    const parsed = v.parse(shelvesCollection.itemSchema, {
+      name: "work",
+      journals: ["daily"],
+      decorations: [{ type: "not-a-decoration" }],
     });
-    await service.initialize();
-    const shelf = service.recordOf(shelvesCollection).work;
-    expect(shelf.journals).toEqual(["daily"]);
-    expect(shelf.decorations).toEqual([]);
+    expect(parsed.journals).toEqual(["daily"]);
+    expect(parsed.decorations).toEqual([]);
   });
 });

--- a/src/shelves/flows/delete-shelf.flow.test.ts
+++ b/src/shelves/flows/delete-shelf.flow.test.ts
@@ -1,60 +1,47 @@
-import { createNanoEvents } from "nanoevents";
 import { describe, expect, it } from "vitest";
 
 import { Flows, UserAborted } from "@/infrastructure/flows";
-import { NoticeService } from "@/infrastructure/host";
-import { ModalService } from "@/infrastructure/host/modals";
-import { FakeModalService } from "@/infrastructure/host/modals/testing";
-import { FakeNoticeService } from "@/infrastructure/host/testing";
-import { createSettingsService } from "@/settings/testing";
+import { journalsCoreModule } from "@/journals/module";
+import { testContainer } from "@/testing";
 
-import { shelvesCollection } from "../config";
+import { shelvesCoreModule } from "../module";
 import { ShelvesRepository } from "../repository";
-import { ShelvesEventsToken } from "../tokens";
+import { buildShelf } from "../testing";
 
 import { DeleteShelfFlow } from "./delete-shelf.flow";
 
-async function build(raw?: unknown) {
-  const { service: settings, container } = createSettingsService({
-    collections: [shelvesCollection],
-    raw,
-  });
-  await settings.initialize();
-  const modals = new FakeModalService();
-  container.register(ModalService).useValue(modals as unknown as ModalService);
-  container.register(ShelvesEventsToken).useFactory(() => createNanoEvents());
-  container.register(ShelvesRepository).useClass(ShelvesRepository);
-  container.register(NoticeService).useValue(new FakeNoticeService());
-  container.register(Flows).useClass(Flows);
-  container.register(DeleteShelfFlow).useClass(DeleteShelfFlow);
-  const repo = container.resolve(ShelvesRepository);
-  return { repo, modals, flows: container.resolve(Flows) };
-}
-
 describe("DeleteShelfFlow", () => {
   it("removes the shelf and moves its journals to the chosen destination", async () => {
-    const raw = {
-      version: 5,
-      shelves: {
-        Work: { name: "Work", journals: ["daily"] },
-        Personal: { name: "Personal", journals: [] },
+    const harness = await testContainer({
+      modules: [journalsCoreModule, shelvesCoreModule],
+      data: {
+        shelves: {
+          Work: buildShelf("Work", { journals: ["daily"] }),
+          Personal: buildShelf("Personal"),
+        },
       },
-    };
-    const { flows, modals, repo } = await build(raw);
-    const promise = flows.invoke(DeleteShelfFlow, { shelfName: "Work" });
-    modals.lastOpen<unknown, string>().submit("Personal");
+    });
+
+    const promise = harness.resolve(Flows).invoke(DeleteShelfFlow, { shelfName: "Work" });
+    harness.modals.lastOpen<unknown, string>().submit("Personal");
     await promise;
+
+    const repo = harness.resolve(ShelvesRepository);
     expect(repo.get("Work").isNone()).toBe(true);
     expect(repo.get("Personal").getOr(undefined as never)?.journals).toEqual(["daily"]);
   });
 
   it("leaves the shelf in place when the modal is cancelled", async () => {
-    const raw = { version: 5, shelves: { Work: { name: "Work", journals: [] } } };
-    const { flows, modals, repo } = await build(raw);
-    const promise = flows.invoke(DeleteShelfFlow, { shelfName: "Work" });
-    modals.lastOpen().cancel();
+    const harness = await testContainer({
+      modules: [journalsCoreModule, shelvesCoreModule],
+      data: { shelves: { Work: buildShelf("Work") } },
+    });
+
+    const promise = harness.resolve(Flows).invoke(DeleteShelfFlow, { shelfName: "Work" });
+    harness.modals.lastOpen().cancel();
     const result = await promise;
+
     expect(result.kind === "err" && result.error).toBeInstanceOf(UserAborted);
-    expect(repo.get("Work").isSome()).toBe(true);
+    expect(harness.resolve(ShelvesRepository).get("Work").isSome()).toBe(true);
   });
 });

--- a/src/shelves/flows/edit-shelf-name.flow.test.ts
+++ b/src/shelves/flows/edit-shelf-name.flow.test.ts
@@ -1,65 +1,60 @@
-import { createNanoEvents } from "nanoevents";
 import { describe, expect, it } from "vitest";
 
 import { Flows, UserAborted } from "@/infrastructure/flows";
-import { NoticeService } from "@/infrastructure/host";
-import { ModalService } from "@/infrastructure/host/modals";
-import { FakeModalService } from "@/infrastructure/host/modals/testing";
-import { FakeNoticeService } from "@/infrastructure/host/testing";
-import { createSettingsService } from "@/settings/testing";
+import { journalsCoreModule } from "@/journals/module";
+import { testContainer } from "@/testing";
 
-import { shelvesCollection } from "../config";
+import { shelvesCoreModule } from "../module";
 import { ShelvesRepository } from "../repository";
-import { ShelvesEventsToken } from "../tokens";
+import { buildShelf } from "../testing";
 
 import { EditShelfNameFlow } from "./edit-shelf-name.flow";
 
-async function build(raw?: unknown) {
-  const { service: settings, container } = createSettingsService({
-    collections: [shelvesCollection],
-    raw,
-  });
-  await settings.initialize();
-  const modals = new FakeModalService();
-  container.register(ModalService).useValue(modals as unknown as ModalService);
-  container.register(ShelvesEventsToken).useFactory(() => createNanoEvents());
-  container.register(ShelvesRepository).useClass(ShelvesRepository);
-  container.register(NoticeService).useValue(new FakeNoticeService());
-  container.register(Flows).useClass(Flows);
-  container.register(EditShelfNameFlow).useClass(EditShelfNameFlow);
-  const repo = container.resolve(ShelvesRepository);
-  return { repo, modals, flows: container.resolve(Flows) };
-}
-
 describe("EditShelfNameFlow", () => {
   it("creates a shelf when no shelf name is given", async () => {
-    const { flows, modals, repo } = await build();
-    const promise = flows.invoke(EditShelfNameFlow, {});
-    modals.lastOpen<unknown, string>().submit("Work");
+    const harness = await testContainer({
+      modules: [journalsCoreModule, shelvesCoreModule],
+      data: { shelves: {} },
+    });
+
+    const promise = harness.resolve(Flows).invoke(EditShelfNameFlow, {});
+    harness.modals.lastOpen<unknown, string>().submit("Work");
     await promise;
-    expect(repo.get("Work").getOr(undefined as never)).toEqual({ name: "Work", journals: [], decorations: [] });
+
+    expect(
+      harness
+        .resolve(ShelvesRepository)
+        .get("Work")
+        .getOr(undefined as never),
+    ).toEqual(buildShelf("Work"));
   });
 
   it("renames an existing shelf and keeps its journals", async () => {
-    const raw = { version: 5, shelves: { Work: { name: "Work", journals: ["daily"] } } };
-    const { flows, modals, repo } = await build(raw);
-    const promise = flows.invoke(EditShelfNameFlow, { shelfName: "Work" });
-    modals.lastOpen<unknown, string>().submit("Office");
-    await promise;
-    expect(repo.get("Work").isNone()).toBe(true);
-    expect(repo.get("Office").getOr(undefined as never)).toEqual({
-      name: "Office",
-      journals: ["daily"],
-      decorations: [],
+    const harness = await testContainer({
+      modules: [journalsCoreModule, shelvesCoreModule],
+      data: { shelves: { Work: buildShelf("Work", { journals: ["daily"] }) } },
     });
+
+    const promise = harness.resolve(Flows).invoke(EditShelfNameFlow, { shelfName: "Work" });
+    harness.modals.lastOpen<unknown, string>().submit("Office");
+    await promise;
+
+    const repo = harness.resolve(ShelvesRepository);
+    expect(repo.get("Work").isNone()).toBe(true);
+    expect(repo.get("Office").getOr(undefined as never)).toEqual(buildShelf("Office", { journals: ["daily"] }));
   });
 
   it("leaves the collection untouched when the modal is cancelled", async () => {
-    const { flows, modals, repo } = await build();
-    const promise = flows.invoke(EditShelfNameFlow, {});
-    modals.lastOpen().cancel();
+    const harness = await testContainer({
+      modules: [journalsCoreModule, shelvesCoreModule],
+      data: { shelves: {} },
+    });
+
+    const promise = harness.resolve(Flows).invoke(EditShelfNameFlow, {});
+    harness.modals.lastOpen().cancel();
     const result = await promise;
+
     expect(result.kind === "err" && result.error).toBeInstanceOf(UserAborted);
-    expect(repo.count()).toBe(0);
+    expect(harness.resolve(ShelvesRepository).count()).toBe(0);
   });
 });

--- a/src/shelves/flows/place-journal.flow.test.ts
+++ b/src/shelves/flows/place-journal.flow.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import { Flows, UserAborted } from "@/infrastructure/flows";
 import { journalsCoreModule } from "@/journals/module";
 import { fixedJournal } from "@/journals/testing";
-import { testContainer } from "@/testing";
+import { testContainer, type TestHarness } from "@/testing";
 
 import { shelvesCoreModule } from "../module";
 import { ShelvesRepository } from "../repository";
@@ -12,15 +12,19 @@ import { buildShelf } from "../testing";
 import { PlaceJournalFlow } from "./place-journal.flow";
 
 describe("PlaceJournalFlow", () => {
-  it("assigns the journal to the chosen shelf", async () => {
-    const harness = await testContainer({
+  let harness: TestHarness;
+
+  beforeEach(async () => {
+    harness = await testContainer({
       modules: [journalsCoreModule, shelvesCoreModule],
       data: {
         journals: { daily: fixedJournal("daily", { type: "day" }) },
         shelves: { Work: buildShelf("Work") },
       },
     });
+  });
 
+  it("assigns the journal to the chosen shelf", async () => {
     const promise = harness.resolve(Flows).invoke(PlaceJournalFlow, { journalName: "daily" });
     harness.modals.lastOpen<unknown, string>().submit("Work");
     await promise;
@@ -34,14 +38,6 @@ describe("PlaceJournalFlow", () => {
   });
 
   it("leaves shelf membership unchanged when the modal is cancelled", async () => {
-    const harness = await testContainer({
-      modules: [journalsCoreModule, shelvesCoreModule],
-      data: {
-        journals: { daily: fixedJournal("daily", { type: "day" }) },
-        shelves: { Work: buildShelf("Work") },
-      },
-    });
-
     const promise = harness.resolve(Flows).invoke(PlaceJournalFlow, { journalName: "daily" });
     harness.modals.lastOpen().cancel();
     const result = await promise;

--- a/src/shelves/flows/place-journal.flow.test.ts
+++ b/src/shelves/flows/place-journal.flow.test.ts
@@ -1,85 +1,57 @@
-import { createNanoEvents } from "nanoevents";
 import { describe, expect, it } from "vitest";
 
 import { Flows, UserAborted } from "@/infrastructure/flows";
-import { NoticeService } from "@/infrastructure/host";
-import { ModalService } from "@/infrastructure/host/modals";
-import { FakeModalService } from "@/infrastructure/host/modals/testing";
-import { FakeNoticeService } from "@/infrastructure/host/testing";
-import { journalConfigCollection } from "@/journals";
-import { JournalsRepository } from "@/journals/repository";
-import { JournalsEventsToken } from "@/journals/tokens";
-import { createSettingsService } from "@/settings/testing";
+import { journalsCoreModule } from "@/journals/module";
+import { fixedJournal } from "@/journals/testing";
+import { testContainer } from "@/testing";
 
-import { shelvesCollection } from "../config";
+import { shelvesCoreModule } from "../module";
 import { ShelvesRepository } from "../repository";
-import { ShelvesService } from "../service";
-import { ShelvesEventsToken } from "../tokens";
+import { buildShelf } from "../testing";
 
 import { PlaceJournalFlow } from "./place-journal.flow";
 
-function makeJournal(name: string) {
-  return {
-    name,
-    write: { type: "day" as const },
-    timeline: { start: "2024-01-01", end: { kind: "never" as const } },
-    dateFormat: "YYYY-MM-DD",
-    frontmatter: {
-      dateField: "journal-date",
-      startDateField: "journal-start-date",
-      endDateField: "journal-end-date",
-      addStartDate: false,
-      addEndDate: false,
-    },
-    numbering: { enabled: false, anchorDate: "2024-01-01", allowBefore: false, sources: [] },
-    nameTemplate: "{{date}}",
-    folder: "",
-    templates: [],
-    confirmCreation: false,
-    autoCreate: false,
-  };
-}
-
-async function build() {
-  const raw = {
-    version: 5,
-    journals: { daily: makeJournal("daily") },
-    shelves: { Work: { name: "Work", journals: [] } },
-  };
-  const { service: settings, container } = createSettingsService({
-    collections: [journalConfigCollection, shelvesCollection],
-    raw,
-  });
-  await settings.initialize();
-  const modals = new FakeModalService();
-  container.register(ModalService).useValue(modals as unknown as ModalService);
-  container.register(JournalsEventsToken).useFactory(() => createNanoEvents());
-  container.register(JournalsRepository).useClass(JournalsRepository);
-  container.register(ShelvesEventsToken).useFactory(() => createNanoEvents());
-  container.register(ShelvesRepository).useClass(ShelvesRepository);
-  container.register(ShelvesService).useClass(ShelvesService);
-  container.register(NoticeService).useValue(new FakeNoticeService());
-  container.register(Flows).useClass(Flows);
-  container.register(PlaceJournalFlow).useClass(PlaceJournalFlow);
-  const shelvesRepo = container.resolve(ShelvesRepository);
-  return { shelvesRepo, modals, flows: container.resolve(Flows) };
-}
-
 describe("PlaceJournalFlow", () => {
   it("assigns the journal to the chosen shelf", async () => {
-    const { flows, modals, shelvesRepo } = await build();
-    const promise = flows.invoke(PlaceJournalFlow, { journalName: "daily" });
-    modals.lastOpen<unknown, string>().submit("Work");
+    const harness = await testContainer({
+      modules: [journalsCoreModule, shelvesCoreModule],
+      data: {
+        journals: { daily: fixedJournal("daily", { type: "day" }) },
+        shelves: { Work: buildShelf("Work") },
+      },
+    });
+
+    const promise = harness.resolve(Flows).invoke(PlaceJournalFlow, { journalName: "daily" });
+    harness.modals.lastOpen<unknown, string>().submit("Work");
     await promise;
-    expect(shelvesRepo.get("Work").getOr(undefined as never)?.journals).toEqual(["daily"]);
+
+    expect(
+      harness
+        .resolve(ShelvesRepository)
+        .get("Work")
+        .getOr(undefined as never)?.journals,
+    ).toEqual(["daily"]);
   });
 
   it("leaves shelf membership unchanged when the modal is cancelled", async () => {
-    const { flows, modals, shelvesRepo } = await build();
-    const promise = flows.invoke(PlaceJournalFlow, { journalName: "daily" });
-    modals.lastOpen().cancel();
+    const harness = await testContainer({
+      modules: [journalsCoreModule, shelvesCoreModule],
+      data: {
+        journals: { daily: fixedJournal("daily", { type: "day" }) },
+        shelves: { Work: buildShelf("Work") },
+      },
+    });
+
+    const promise = harness.resolve(Flows).invoke(PlaceJournalFlow, { journalName: "daily" });
+    harness.modals.lastOpen().cancel();
     const result = await promise;
+
     expect(result.kind === "err" && result.error).toBeInstanceOf(UserAborted);
-    expect(shelvesRepo.get("Work").getOr(undefined as never)?.journals).toEqual([]);
+    expect(
+      harness
+        .resolve(ShelvesRepository)
+        .get("Work")
+        .getOr(undefined as never)?.journals,
+    ).toEqual([]);
   });
 });

--- a/src/shelves/module.ts
+++ b/src/shelves/module.ts
@@ -1,8 +1,7 @@
 import { createNanoEvents } from "nanoevents";
 
 import type { Module } from "@/infrastructure/di";
-import { JournalEditSectionToken, defineJournalEditSection } from "@/journals";
-import { CollectionDefinitionToken, DashboardBlockToken, SubpageToken, defineDashboardBlock } from "@/settings";
+import { CollectionDefinitionToken } from "@/settings";
 
 import { shelvesCollection } from "./config";
 import { DeleteShelfFlow } from "./flows/delete-shelf.flow";
@@ -11,13 +10,10 @@ import { PlaceJournalFlow } from "./flows/place-journal.flow";
 import { ShelvesRepository, type ShelvesEvents } from "./repository";
 import { ShelvesService } from "./service";
 import { ShelvesEventsToken } from "./tokens";
-import JournalsDashboardBlock from "./ui/JournalsDashboardBlock.vue";
-import JournalShelfSection from "./ui/JournalShelfSection.vue";
-import { shelfEditSubpage } from "./ui/shelf-edit-subpage";
-import ShelvesDashboardBlock from "./ui/ShelvesDashboardBlock.vue";
+import { shelvesUiModule } from "./ui-module";
 import { ShelvesViewModel } from "./view-model";
 
-export const shelvesModule: Module = {
+export const shelvesCoreModule: Module = {
   register(c) {
     c.register(CollectionDefinitionToken).useValue(shelvesCollection);
     c.register(ShelvesEventsToken).useFactory(() => createNanoEvents<ShelvesEvents>());
@@ -27,15 +23,12 @@ export const shelvesModule: Module = {
     c.register(EditShelfNameFlow).useClass(EditShelfNameFlow);
     c.register(DeleteShelfFlow).useClass(DeleteShelfFlow);
     c.register(PlaceJournalFlow).useClass(PlaceJournalFlow);
-    c.register(DashboardBlockToken).useValue(
-      defineDashboardBlock({ key: "shelves", component: ShelvesDashboardBlock, order: 4 }),
-    );
-    c.register(DashboardBlockToken).useValue(
-      defineDashboardBlock({ key: "journals", component: JournalsDashboardBlock, order: 5 }),
-    );
-    c.register(SubpageToken).useValue(shelfEditSubpage);
-    c.register(JournalEditSectionToken).useValue(
-      defineJournalEditSection({ key: "shelf", component: JournalShelfSection, order: 10 }),
-    );
+  },
+};
+
+export const shelvesModule: Module = {
+  register(c) {
+    shelvesCoreModule.register(c);
+    shelvesUiModule.register(c);
   },
 };

--- a/src/shelves/repository.test.ts
+++ b/src/shelves/repository.test.ts
@@ -1,54 +1,59 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { journalsCoreModule } from "@/journals/module";
-import { testContainer, type TestHarness } from "@/testing";
+import { testContainer } from "@/testing";
 
-import { shelvesCollection } from "./config";
+import { shelvesCollection, type ShelfConfig } from "./config";
 import { InvalidShelfNameError, InvalidShelfUpdateError, ShelfNameTakenError, UnknownShelfError } from "./errors";
 import { shelvesCoreModule } from "./module";
 import { ShelvesRepository } from "./repository";
 import { buildShelf } from "./testing";
 import { ShelvesEventsToken } from "./tokens";
 
+async function buildRepo(initial: Record<string, ShelfConfig> = {}) {
+  const harness = await testContainer({
+    modules: [journalsCoreModule, shelvesCoreModule],
+    data: { shelves: initial },
+  });
+  return {
+    repo: harness.resolve(ShelvesRepository),
+    storage: harness.settings.recordOf(shelvesCollection),
+    events: harness.resolve(ShelvesEventsToken),
+  };
+}
+
 describe("ShelvesRepository", () => {
   describe("create", () => {
-    let harness: TestHarness;
+    it("inserts a shelf with empty journals list", async () => {
+      const { repo, storage } = await buildRepo();
 
-    beforeEach(async () => {
-      harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: { shelves: {} },
-      });
+      repo.create("Personal");
+
+      expect(storage.Personal).toEqual(buildShelf("Personal"));
     });
 
-    it("inserts a shelf with empty journals list", () => {
-      harness.resolve(ShelvesRepository).create("Personal");
-
-      expect(harness.settings.recordOf(shelvesCollection).Personal).toEqual(buildShelf("Personal"));
-    });
-
-    it("emits created", () => {
+    it("emits created", async () => {
+      const { repo, events } = await buildRepo();
       const spy = vi.fn();
-      harness.resolve(ShelvesEventsToken).on("created", spy);
+      events.on("created", spy);
 
-      harness.resolve(ShelvesRepository).create("Personal");
+      repo.create("Personal");
 
       expect(spy).toHaveBeenCalledWith("Personal");
     });
 
-    it("rejects an empty name", () => {
-      const result = harness.resolve(ShelvesRepository).create("");
+    it("rejects an empty name", async () => {
+      const { repo } = await buildRepo();
+
+      const result = repo.create("");
 
       expect(result.isErr() && result.error).toBeInstanceOf(InvalidShelfNameError);
     });
 
     it("rejects a name in use", async () => {
-      harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: { shelves: { Personal: buildShelf("Personal") } },
-      });
+      const { repo } = await buildRepo({ Personal: buildShelf("Personal") });
 
-      const result = harness.resolve(ShelvesRepository).create("Personal");
+      const result = repo.create("Personal");
 
       expect(result.isErr() && result.error).toBeInstanceOf(ShelfNameTakenError);
     });
@@ -56,81 +61,59 @@ describe("ShelvesRepository", () => {
 
   describe("rename", () => {
     it("stores the entry under the new key with the new name field", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: { shelves: { Personal: buildShelf("Personal", { journals: ["daily"] }) } },
-      });
+      const { repo, storage } = await buildRepo({ Personal: buildShelf("Personal", { journals: ["daily"] }) });
 
-      harness.resolve(ShelvesRepository).rename("Personal", "Home");
+      repo.rename("Personal", "Home");
 
-      expect(harness.settings.recordOf(shelvesCollection).Home).toEqual({
-        name: "Home",
-        journals: ["daily"],
-        decorations: [],
-      });
+      expect(storage.Home).toEqual({ name: "Home", journals: ["daily"], decorations: [] });
     });
 
     it("removes the old key on rename", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: { shelves: { Personal: buildShelf("Personal", { journals: ["daily"] }) } },
-      });
+      const { repo, storage } = await buildRepo({ Personal: buildShelf("Personal", { journals: ["daily"] }) });
 
-      harness.resolve(ShelvesRepository).rename("Personal", "Home");
+      repo.rename("Personal", "Home");
 
-      expect(harness.settings.recordOf(shelvesCollection).Personal).toBeUndefined();
+      expect(storage.Personal).toBeUndefined();
     });
 
-    describe("with a lone Personal shelf", () => {
-      let harness: TestHarness;
+    it("emits renamed", async () => {
+      const { repo, events } = await buildRepo({ Personal: buildShelf("Personal") });
+      const spy = vi.fn();
+      events.on("renamed", spy);
 
-      beforeEach(async () => {
-        harness = await testContainer({
-          modules: [journalsCoreModule, shelvesCoreModule],
-          data: { shelves: { Personal: buildShelf("Personal") } },
-        });
-      });
+      repo.rename("Personal", "Home");
 
-      it("emits renamed", () => {
-        const spy = vi.fn();
-        harness.resolve(ShelvesEventsToken).on("renamed", spy);
+      expect(spy).toHaveBeenCalledWith("Personal", "Home");
+    });
 
-        harness.resolve(ShelvesRepository).rename("Personal", "Home");
+    it("rejects empty new name", async () => {
+      const { repo } = await buildRepo({ Personal: buildShelf("Personal") });
 
-        expect(spy).toHaveBeenCalledWith("Personal", "Home");
-      });
+      const result = repo.rename("Personal", "");
 
-      it("rejects empty new name", () => {
-        const result = harness.resolve(ShelvesRepository).rename("Personal", "");
+      expect(result.isErr() && result.error).toBeInstanceOf(InvalidShelfNameError);
+    });
 
-        expect(result.isErr() && result.error).toBeInstanceOf(InvalidShelfNameError);
-      });
+    it("rejects newName equal to oldName", async () => {
+      const { repo } = await buildRepo({ Personal: buildShelf("Personal") });
 
-      it("rejects newName equal to oldName", () => {
-        const result = harness.resolve(ShelvesRepository).rename("Personal", "Personal");
+      const result = repo.rename("Personal", "Personal");
 
-        expect(result.isErr() && result.error).toBeInstanceOf(InvalidShelfNameError);
-      });
+      expect(result.isErr() && result.error).toBeInstanceOf(InvalidShelfNameError);
     });
 
     it("rejects unknown old name", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: { shelves: {} },
-      });
+      const { repo } = await buildRepo();
 
-      const result = harness.resolve(ShelvesRepository).rename("nope", "Home");
+      const result = repo.rename("nope", "Home");
 
       expect(result.isErr() && result.error).toBeInstanceOf(UnknownShelfError);
     });
 
     it("rejects newName already in use", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: { shelves: { Personal: buildShelf("Personal"), Home: buildShelf("Home") } },
-      });
+      const { repo } = await buildRepo({ Personal: buildShelf("Personal"), Home: buildShelf("Home") });
 
-      const result = harness.resolve(ShelvesRepository).rename("Personal", "Home");
+      const result = repo.rename("Personal", "Home");
 
       expect(result.isErr() && result.error).toBeInstanceOf(ShelfNameTakenError);
     });
@@ -138,89 +121,67 @@ describe("ShelvesRepository", () => {
 
   describe("deleteWith", () => {
     it("removes the shelf when destination is omitted", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: { shelves: { Personal: buildShelf("Personal", { journals: ["a"] }) } },
-      });
+      const { repo, storage } = await buildRepo({ Personal: buildShelf("Personal", { journals: ["a"] }) });
 
-      harness.resolve(ShelvesRepository).deleteWith("Personal");
+      repo.deleteWith("Personal");
 
-      expect(harness.settings.recordOf(shelvesCollection).Personal).toBeUndefined();
+      expect(storage.Personal).toBeUndefined();
     });
 
     it("appends source journals to destination before removing", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: {
-          shelves: {
-            Personal: buildShelf("Personal", { journals: ["a"] }),
-            Home: buildShelf("Home", { journals: ["b"] }),
-          },
-        },
+      const { repo, storage } = await buildRepo({
+        Personal: buildShelf("Personal", { journals: ["a"] }),
+        Home: buildShelf("Home", { journals: ["b"] }),
       });
 
-      harness.resolve(ShelvesRepository).deleteWith("Personal", "Home");
+      repo.deleteWith("Personal", "Home");
 
-      expect(harness.settings.recordOf(shelvesCollection).Home?.journals).toEqual(["b", "a"]);
-      expect(harness.settings.recordOf(shelvesCollection).Personal).toBeUndefined();
+      expect(storage.Home?.journals).toEqual(["b", "a"]);
+      expect(storage.Personal).toBeUndefined();
     });
 
     it("emits deleted", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: { shelves: { Personal: buildShelf("Personal") } },
-      });
+      const { repo, events } = await buildRepo({ Personal: buildShelf("Personal") });
       const spy = vi.fn();
-      harness.resolve(ShelvesEventsToken).on("deleted", spy);
+      events.on("deleted", spy);
 
-      harness.resolve(ShelvesRepository).deleteWith("Personal");
+      repo.deleteWith("Personal");
 
       expect(spy).toHaveBeenCalledWith("Personal");
     });
 
     it("rejects unknown source", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: { shelves: {} },
-      });
+      const { repo } = await buildRepo();
 
-      const result = harness.resolve(ShelvesRepository).deleteWith("nope");
+      const result = repo.deleteWith("nope");
 
       expect(result.isErr() && result.error).toBeInstanceOf(UnknownShelfError);
     });
 
     it("rejects provided-but-unknown destination", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: { shelves: { Personal: buildShelf("Personal") } },
-      });
+      const { repo } = await buildRepo({ Personal: buildShelf("Personal") });
 
-      const result = harness.resolve(ShelvesRepository).deleteWith("Personal", "ghost");
+      const result = repo.deleteWith("Personal", "ghost");
 
       expect(result.isErr() && result.error).toBeInstanceOf(UnknownShelfError);
     });
   });
 
   describe("inherited update", () => {
-    let harness: TestHarness;
+    it("rejects a name change with InvalidShelfUpdateError", async () => {
+      const { repo } = await buildRepo({ Personal: buildShelf("Personal") });
 
-    beforeEach(async () => {
-      harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: { shelves: { Personal: buildShelf("Personal") } },
-      });
-    });
-
-    it("rejects a name change with InvalidShelfUpdateError", () => {
-      const result = harness.resolve(ShelvesRepository).update("Personal", { name: "Home" });
+      const result = repo.update("Personal", { name: "Home" });
 
       expect(result.isErr() && result.error).toBeInstanceOf(InvalidShelfUpdateError);
     });
 
-    it("accepts journal-list updates", () => {
-      harness.resolve(ShelvesRepository).update("Personal", { journals: ["daily"] });
+    it("accepts journal-list updates", async () => {
+      const { repo, storage } = await buildRepo({ Personal: buildShelf("Personal") });
 
-      expect(harness.settings.recordOf(shelvesCollection).Personal?.journals).toEqual(["daily"]);
+      repo.update("Personal", { journals: ["daily"] });
+
+      expect(storage.Personal?.journals).toEqual(["daily"]);
     });
   });
 });

--- a/src/shelves/repository.test.ts
+++ b/src/shelves/repository.test.ts
@@ -1,145 +1,226 @@
-import { createNanoEvents, type Emitter } from "nanoevents";
-import { describe, expect, it, vi } from "vitest";
-import { reactive } from "vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { journalsCoreModule } from "@/journals/module";
+import { testContainer, type TestHarness } from "@/testing";
+
+import { shelvesCollection } from "./config";
 import { InvalidShelfNameError, InvalidShelfUpdateError, ShelfNameTakenError, UnknownShelfError } from "./errors";
-import { ShelvesRepository, type ShelvesEvents } from "./repository";
-
-import type { ShelfConfig } from "./config";
-
-function buildRepo(initial: Record<string, ShelfConfig> = {}) {
-  const storage = reactive<Record<string, ShelfConfig>>({ ...initial });
-  const events: Emitter<ShelvesEvents> = createNanoEvents();
-  const repo = ShelvesRepository.fromParts(storage, events);
-  return { repo, storage, events };
-}
-
-const shelf = (name: string, journals: string[] = []): ShelfConfig => ({ name, journals, decorations: [] });
+import { shelvesCoreModule } from "./module";
+import { ShelvesRepository } from "./repository";
+import { buildShelf } from "./testing";
+import { ShelvesEventsToken } from "./tokens";
 
 describe("ShelvesRepository", () => {
   describe("create", () => {
+    let harness: TestHarness;
+
+    beforeEach(async () => {
+      harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: { shelves: {} },
+      });
+    });
+
     it("inserts a shelf with empty journals list", () => {
-      const { repo, storage } = buildRepo();
-      repo.create("Personal");
-      expect(storage.Personal).toEqual({ name: "Personal", journals: [], decorations: [] });
+      harness.resolve(ShelvesRepository).create("Personal");
+
+      expect(harness.settings.recordOf(shelvesCollection).Personal).toEqual(buildShelf("Personal"));
     });
 
     it("emits created", () => {
-      const { repo, events } = buildRepo();
       const spy = vi.fn();
-      events.on("created", spy);
-      repo.create("Personal");
+      harness.resolve(ShelvesEventsToken).on("created", spy);
+
+      harness.resolve(ShelvesRepository).create("Personal");
+
       expect(spy).toHaveBeenCalledWith("Personal");
     });
 
     it("rejects an empty name", () => {
-      const { repo } = buildRepo();
-      const result = repo.create("");
+      const result = harness.resolve(ShelvesRepository).create("");
+
       expect(result.isErr() && result.error).toBeInstanceOf(InvalidShelfNameError);
     });
 
-    it("rejects a name in use", () => {
-      const { repo } = buildRepo({ Personal: shelf("Personal") });
-      const result = repo.create("Personal");
+    it("rejects a name in use", async () => {
+      harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: { shelves: { Personal: buildShelf("Personal") } },
+      });
+
+      const result = harness.resolve(ShelvesRepository).create("Personal");
+
       expect(result.isErr() && result.error).toBeInstanceOf(ShelfNameTakenError);
     });
   });
 
   describe("rename", () => {
-    it("stores the entry under the new key with the new name field", () => {
-      const { repo, storage } = buildRepo({ Personal: shelf("Personal", ["daily"]) });
-      repo.rename("Personal", "Home");
-      expect(storage.Home).toEqual({ name: "Home", journals: ["daily"], decorations: [] });
+    it("stores the entry under the new key with the new name field", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: { shelves: { Personal: buildShelf("Personal", { journals: ["daily"] }) } },
+      });
+
+      harness.resolve(ShelvesRepository).rename("Personal", "Home");
+
+      expect(harness.settings.recordOf(shelvesCollection).Home).toEqual({
+        name: "Home",
+        journals: ["daily"],
+        decorations: [],
+      });
     });
 
-    it("removes the old key on rename", () => {
-      const { repo, storage } = buildRepo({ Personal: shelf("Personal", ["daily"]) });
-      repo.rename("Personal", "Home");
-      expect(storage.Personal).toBeUndefined();
+    it("removes the old key on rename", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: { shelves: { Personal: buildShelf("Personal", { journals: ["daily"] }) } },
+      });
+
+      harness.resolve(ShelvesRepository).rename("Personal", "Home");
+
+      expect(harness.settings.recordOf(shelvesCollection).Personal).toBeUndefined();
     });
 
-    it("emits renamed", () => {
-      const { repo, events } = buildRepo({ Personal: shelf("Personal") });
-      const spy = vi.fn();
-      events.on("renamed", spy);
-      repo.rename("Personal", "Home");
-      expect(spy).toHaveBeenCalledWith("Personal", "Home");
+    describe("with a lone Personal shelf", () => {
+      let harness: TestHarness;
+
+      beforeEach(async () => {
+        harness = await testContainer({
+          modules: [journalsCoreModule, shelvesCoreModule],
+          data: { shelves: { Personal: buildShelf("Personal") } },
+        });
+      });
+
+      it("emits renamed", () => {
+        const spy = vi.fn();
+        harness.resolve(ShelvesEventsToken).on("renamed", spy);
+
+        harness.resolve(ShelvesRepository).rename("Personal", "Home");
+
+        expect(spy).toHaveBeenCalledWith("Personal", "Home");
+      });
+
+      it("rejects empty new name", () => {
+        const result = harness.resolve(ShelvesRepository).rename("Personal", "");
+
+        expect(result.isErr() && result.error).toBeInstanceOf(InvalidShelfNameError);
+      });
+
+      it("rejects newName equal to oldName", () => {
+        const result = harness.resolve(ShelvesRepository).rename("Personal", "Personal");
+
+        expect(result.isErr() && result.error).toBeInstanceOf(InvalidShelfNameError);
+      });
     });
 
-    it("rejects empty new name", () => {
-      const { repo } = buildRepo({ Personal: shelf("Personal") });
-      const result = repo.rename("Personal", "");
-      expect(result.isErr() && result.error).toBeInstanceOf(InvalidShelfNameError);
-    });
+    it("rejects unknown old name", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: { shelves: {} },
+      });
 
-    it("rejects newName equal to oldName", () => {
-      const { repo } = buildRepo({ Personal: shelf("Personal") });
-      const result = repo.rename("Personal", "Personal");
-      expect(result.isErr() && result.error).toBeInstanceOf(InvalidShelfNameError);
-    });
+      const result = harness.resolve(ShelvesRepository).rename("nope", "Home");
 
-    it("rejects unknown old name", () => {
-      const { repo } = buildRepo();
-      const result = repo.rename("nope", "Home");
       expect(result.isErr() && result.error).toBeInstanceOf(UnknownShelfError);
     });
 
-    it("rejects newName already in use", () => {
-      const { repo } = buildRepo({ Personal: shelf("Personal"), Home: shelf("Home") });
-      const result = repo.rename("Personal", "Home");
+    it("rejects newName already in use", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: { shelves: { Personal: buildShelf("Personal"), Home: buildShelf("Home") } },
+      });
+
+      const result = harness.resolve(ShelvesRepository).rename("Personal", "Home");
+
       expect(result.isErr() && result.error).toBeInstanceOf(ShelfNameTakenError);
     });
   });
 
   describe("deleteWith", () => {
-    it("removes the shelf when destination is omitted", () => {
-      const { repo, storage } = buildRepo({ Personal: shelf("Personal", ["a"]) });
-      repo.deleteWith("Personal");
-      expect(storage.Personal).toBeUndefined();
-    });
-
-    it("appends source journals to destination before removing", () => {
-      const { repo, storage } = buildRepo({
-        Personal: shelf("Personal", ["a"]),
-        Home: shelf("Home", ["b"]),
+    it("removes the shelf when destination is omitted", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: { shelves: { Personal: buildShelf("Personal", { journals: ["a"] }) } },
       });
-      repo.deleteWith("Personal", "Home");
-      expect(storage.Home?.journals).toEqual(["b", "a"]);
-      expect(storage.Personal).toBeUndefined();
+
+      harness.resolve(ShelvesRepository).deleteWith("Personal");
+
+      expect(harness.settings.recordOf(shelvesCollection).Personal).toBeUndefined();
     });
 
-    it("emits deleted", () => {
-      const { repo, events } = buildRepo({ Personal: shelf("Personal") });
+    it("appends source journals to destination before removing", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: {
+          shelves: {
+            Personal: buildShelf("Personal", { journals: ["a"] }),
+            Home: buildShelf("Home", { journals: ["b"] }),
+          },
+        },
+      });
+
+      harness.resolve(ShelvesRepository).deleteWith("Personal", "Home");
+
+      expect(harness.settings.recordOf(shelvesCollection).Home?.journals).toEqual(["b", "a"]);
+      expect(harness.settings.recordOf(shelvesCollection).Personal).toBeUndefined();
+    });
+
+    it("emits deleted", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: { shelves: { Personal: buildShelf("Personal") } },
+      });
       const spy = vi.fn();
-      events.on("deleted", spy);
-      repo.deleteWith("Personal");
+      harness.resolve(ShelvesEventsToken).on("deleted", spy);
+
+      harness.resolve(ShelvesRepository).deleteWith("Personal");
+
       expect(spy).toHaveBeenCalledWith("Personal");
     });
 
-    it("rejects unknown source", () => {
-      const { repo } = buildRepo();
-      const result = repo.deleteWith("nope");
+    it("rejects unknown source", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: { shelves: {} },
+      });
+
+      const result = harness.resolve(ShelvesRepository).deleteWith("nope");
+
       expect(result.isErr() && result.error).toBeInstanceOf(UnknownShelfError);
     });
 
-    it("rejects provided-but-unknown destination", () => {
-      const { repo } = buildRepo({ Personal: shelf("Personal") });
-      const result = repo.deleteWith("Personal", "ghost");
+    it("rejects provided-but-unknown destination", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: { shelves: { Personal: buildShelf("Personal") } },
+      });
+
+      const result = harness.resolve(ShelvesRepository).deleteWith("Personal", "ghost");
+
       expect(result.isErr() && result.error).toBeInstanceOf(UnknownShelfError);
     });
   });
 
   describe("inherited update", () => {
+    let harness: TestHarness;
+
+    beforeEach(async () => {
+      harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: { shelves: { Personal: buildShelf("Personal") } },
+      });
+    });
+
     it("rejects a name change with InvalidShelfUpdateError", () => {
-      const { repo } = buildRepo({ Personal: shelf("Personal") });
-      const result = repo.update("Personal", { name: "Home" });
+      const result = harness.resolve(ShelvesRepository).update("Personal", { name: "Home" });
+
       expect(result.isErr() && result.error).toBeInstanceOf(InvalidShelfUpdateError);
     });
 
     it("accepts journal-list updates", () => {
-      const { repo, storage } = buildRepo({ Personal: shelf("Personal") });
-      repo.update("Personal", { journals: ["daily"] });
-      expect(storage.Personal?.journals).toEqual(["daily"]);
+      harness.resolve(ShelvesRepository).update("Personal", { journals: ["daily"] });
+
+      expect(harness.settings.recordOf(shelvesCollection).Personal?.journals).toEqual(["daily"]);
     });
   });
 });

--- a/src/shelves/service.test.ts
+++ b/src/shelves/service.test.ts
@@ -1,93 +1,92 @@
 import { describe, expect, it } from "vitest";
 
-import { JournalsRepository, UnknownJournalError } from "@/journals";
+import { JournalsRepository, UnknownJournalError, type JournalConfig } from "@/journals";
 import { journalsCoreModule } from "@/journals/module";
 import { fixedJournal } from "@/journals/testing";
 import { testContainer } from "@/testing";
 
-import { shelvesCollection } from "./config";
+import { shelvesCollection, type ShelfConfig } from "./config";
 import { UnknownShelfError } from "./errors";
 import { shelvesCoreModule } from "./module";
 import { ShelvesService } from "./service";
 import { buildShelf } from "./testing";
 
+async function buildShelves(
+  initial: {
+    journals?: Record<string, JournalConfig>;
+    shelves?: Record<string, ShelfConfig>;
+  } = {},
+) {
+  const harness = await testContainer({
+    modules: [journalsCoreModule, shelvesCoreModule],
+    data: { journals: initial.journals ?? {}, shelves: initial.shelves ?? {} },
+  });
+  return {
+    service: harness.resolve(ShelvesService),
+    journalsRepo: harness.resolve(JournalsRepository),
+    shelvesStorage: harness.settings.recordOf(shelvesCollection),
+  };
+}
+
 describe("ShelvesService", () => {
   describe("assign", () => {
     it("appends the journal to the target shelf", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: {
-          journals: { daily: fixedJournal("daily", { type: "day" }) },
-          shelves: { Personal: buildShelf("Personal") },
-        },
+      const { service, shelvesStorage } = await buildShelves({
+        journals: { daily: fixedJournal("daily", { type: "day" }) },
+        shelves: { Personal: buildShelf("Personal") },
       });
 
-      harness.resolve(ShelvesService).assign("daily", "Personal");
+      service.assign("daily", "Personal");
 
-      expect(harness.settings.recordOf(shelvesCollection).Personal?.journals).toEqual(["daily"]);
+      expect(shelvesStorage.Personal?.journals).toEqual(["daily"]);
     });
 
     it("moves a journal off its current shelf", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: {
-          journals: { daily: fixedJournal("daily", { type: "day" }) },
-          shelves: { Old: buildShelf("Old", { journals: ["daily"] }), New: buildShelf("New") },
-        },
+      const { service, shelvesStorage } = await buildShelves({
+        journals: { daily: fixedJournal("daily", { type: "day" }) },
+        shelves: { Old: buildShelf("Old", { journals: ["daily"] }), New: buildShelf("New") },
       });
 
-      harness.resolve(ShelvesService).assign("daily", "New");
+      service.assign("daily", "New");
 
-      expect(harness.settings.recordOf(shelvesCollection).Old?.journals).toEqual([]);
-      expect(harness.settings.recordOf(shelvesCollection).New?.journals).toEqual(["daily"]);
+      expect(shelvesStorage.Old?.journals).toEqual([]);
+      expect(shelvesStorage.New?.journals).toEqual(["daily"]);
     });
 
     it("removes the journal from its current shelf when shelfName is empty", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: {
-          journals: { daily: fixedJournal("daily", { type: "day" }) },
-          shelves: { Personal: buildShelf("Personal", { journals: ["daily"] }) },
-        },
+      const { service, shelvesStorage } = await buildShelves({
+        journals: { daily: fixedJournal("daily", { type: "day" }) },
+        shelves: { Personal: buildShelf("Personal", { journals: ["daily"] }) },
       });
 
-      harness.resolve(ShelvesService).assign("daily", "");
+      service.assign("daily", "");
 
-      expect(harness.settings.recordOf(shelvesCollection).Personal?.journals).toEqual([]);
+      expect(shelvesStorage.Personal?.journals).toEqual([]);
     });
 
     it("does not duplicate when assigning to the same shelf the journal is already on", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: {
-          journals: { daily: fixedJournal("daily", { type: "day" }) },
-          shelves: { Personal: buildShelf("Personal", { journals: ["daily"] }) },
-        },
+      const { service, shelvesStorage } = await buildShelves({
+        journals: { daily: fixedJournal("daily", { type: "day" }) },
+        shelves: { Personal: buildShelf("Personal", { journals: ["daily"] }) },
       });
 
-      harness.resolve(ShelvesService).assign("daily", "Personal");
+      service.assign("daily", "Personal");
 
-      expect(harness.settings.recordOf(shelvesCollection).Personal?.journals).toEqual(["daily"]);
+      expect(shelvesStorage.Personal?.journals).toEqual(["daily"]);
     });
 
     it("rejects unknown journal", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: { journals: {}, shelves: { Personal: buildShelf("Personal") } },
-      });
+      const { service } = await buildShelves({ shelves: { Personal: buildShelf("Personal") } });
 
-      const result = harness.resolve(ShelvesService).assign("nope", "Personal");
+      const result = service.assign("nope", "Personal");
 
       expect(result.isErr() && result.error).toBeInstanceOf(UnknownJournalError);
     });
 
     it("rejects unknown shelf", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: { journals: { daily: fixedJournal("daily", { type: "day" }) }, shelves: {} },
-      });
+      const { service } = await buildShelves({ journals: { daily: fixedJournal("daily", { type: "day" }) } });
 
-      const result = harness.resolve(ShelvesService).assign("daily", "ghost");
+      const result = service.assign("daily", "ghost");
 
       expect(result.isErr() && result.error).toBeInstanceOf(UnknownShelfError);
     });
@@ -95,134 +94,107 @@ describe("ShelvesService", () => {
 
   describe("shelfOf", () => {
     it("returns the name of the shelf containing the journal", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: {
-          journals: { daily: fixedJournal("daily", { type: "day" }) },
-          shelves: { Personal: buildShelf("Personal", { journals: ["daily"] }) },
-        },
+      const { service } = await buildShelves({
+        journals: { daily: fixedJournal("daily", { type: "day" }) },
+        shelves: { Personal: buildShelf("Personal", { journals: ["daily"] }) },
       });
 
-      expect(harness.resolve(ShelvesService).shelfOf("daily")).toBe("Personal");
+      expect(service.shelfOf("daily")).toBe("Personal");
     });
 
     it("returns an empty string when the journal is on no shelf", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: {
-          journals: { daily: fixedJournal("daily", { type: "day" }) },
-          shelves: { Personal: buildShelf("Personal") },
-        },
+      const { service } = await buildShelves({
+        journals: { daily: fixedJournal("daily", { type: "day" }) },
+        shelves: { Personal: buildShelf("Personal") },
       });
 
-      expect(harness.resolve(ShelvesService).shelfOf("daily")).toBe("");
+      expect(service.shelfOf("daily")).toBe("");
     });
   });
 
   describe("cascade on journal rename", () => {
     it("replaces the old name with the new one in every shelf", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: {
-          journals: { daily: fixedJournal("daily", { type: "day" }) },
-          shelves: {
-            Personal: buildShelf("Personal", { journals: ["daily"] }),
-            Home: buildShelf("Home", { journals: ["daily"] }),
-          },
+      const { journalsRepo, shelvesStorage } = await buildShelves({
+        journals: { daily: fixedJournal("daily", { type: "day" }) },
+        shelves: {
+          Personal: buildShelf("Personal", { journals: ["daily"] }),
+          Home: buildShelf("Home", { journals: ["daily"] }),
         },
       });
 
-      harness.resolve(JournalsRepository).rename("daily", "renamed");
+      journalsRepo.rename("daily", "renamed");
 
-      expect(harness.settings.recordOf(shelvesCollection).Personal?.journals).toEqual(["renamed"]);
-      expect(harness.settings.recordOf(shelvesCollection).Home?.journals).toEqual(["renamed"]);
+      expect(shelvesStorage.Personal?.journals).toEqual(["renamed"]);
+      expect(shelvesStorage.Home?.journals).toEqual(["renamed"]);
     });
   });
 
   describe("cascade on journal clone", () => {
     it("adds the copy beside the source on every shelf holding it", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: {
-          journals: { daily: fixedJournal("daily", { type: "day" }) },
-          shelves: {
-            Personal: buildShelf("Personal", { journals: ["daily"] }),
-            Home: buildShelf("Home", { journals: ["other", "daily"] }),
-          },
+      const { journalsRepo, shelvesStorage } = await buildShelves({
+        journals: { daily: fixedJournal("daily", { type: "day" }) },
+        shelves: {
+          Personal: buildShelf("Personal", { journals: ["daily"] }),
+          Home: buildShelf("Home", { journals: ["other", "daily"] }),
         },
       });
 
-      harness.resolve(JournalsRepository).clone("daily", "daily copy");
+      journalsRepo.clone("daily", "daily copy");
 
-      expect(harness.settings.recordOf(shelvesCollection).Personal?.journals).toEqual(["daily", "daily copy"]);
-      expect(harness.settings.recordOf(shelvesCollection).Home?.journals).toEqual(["other", "daily", "daily copy"]);
+      expect(shelvesStorage.Personal?.journals).toEqual(["daily", "daily copy"]);
+      expect(shelvesStorage.Home?.journals).toEqual(["other", "daily", "daily copy"]);
     });
 
     it("leaves shelves that do not hold the source untouched", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: {
-          journals: { daily: fixedJournal("daily", { type: "day" }) },
-          shelves: {
-            Personal: buildShelf("Personal", { journals: ["daily"] }),
-            Work: buildShelf("Work", { journals: ["other"] }),
-          },
+      const { journalsRepo, shelvesStorage } = await buildShelves({
+        journals: { daily: fixedJournal("daily", { type: "day" }) },
+        shelves: {
+          Personal: buildShelf("Personal", { journals: ["daily"] }),
+          Work: buildShelf("Work", { journals: ["other"] }),
         },
       });
 
-      harness.resolve(JournalsRepository).clone("daily", "daily copy");
+      journalsRepo.clone("daily", "daily copy");
 
-      expect(harness.settings.recordOf(shelvesCollection).Work?.journals).toEqual(["other"]);
+      expect(shelvesStorage.Work?.journals).toEqual(["other"]);
     });
 
     it("adds the copy to no shelf when the source is on none", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: {
-          journals: { daily: fixedJournal("daily", { type: "day" }) },
-          shelves: { Personal: buildShelf("Personal", { journals: ["other"] }) },
-        },
+      const { journalsRepo, shelvesStorage } = await buildShelves({
+        journals: { daily: fixedJournal("daily", { type: "day" }) },
+        shelves: { Personal: buildShelf("Personal", { journals: ["other"] }) },
       });
 
-      harness.resolve(JournalsRepository).clone("daily", "daily copy");
+      journalsRepo.clone("daily", "daily copy");
 
-      expect(harness.settings.recordOf(shelvesCollection).Personal?.journals).toEqual(["other"]);
+      expect(shelvesStorage.Personal?.journals).toEqual(["other"]);
     });
   });
 
   describe("cascade on journal delete", () => {
     it("removes the journal name from every shelf", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: {
-          journals: { daily: fixedJournal("daily", { type: "day" }) },
-          shelves: { Personal: buildShelf("Personal", { journals: ["daily", "other"] }) },
-        },
+      const { journalsRepo, shelvesStorage } = await buildShelves({
+        journals: { daily: fixedJournal("daily", { type: "day" }) },
+        shelves: { Personal: buildShelf("Personal", { journals: ["daily", "other"] }) },
       });
 
-      harness.resolve(JournalsRepository).delete("daily");
+      journalsRepo.delete("daily");
 
-      expect(harness.settings.recordOf(shelvesCollection).Personal?.journals).toEqual(["other"]);
+      expect(shelvesStorage.Personal?.journals).toEqual(["other"]);
     });
   });
 
   describe("hasShelves", () => {
     it("returns false when no shelves exist", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: { shelves: {} },
-      });
+      const { service } = await buildShelves({ shelves: {} });
 
-      expect(harness.resolve(ShelvesService).hasShelves()).toBe(false);
+      expect(service.hasShelves()).toBe(false);
     });
 
     it("returns true when at least one shelf exists", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: { shelves: { Personal: buildShelf("Personal") } },
-      });
+      const { service } = await buildShelves({ shelves: { Personal: buildShelf("Personal") } });
 
-      expect(harness.resolve(ShelvesService).hasShelves()).toBe(true);
+      expect(service.hasShelves()).toBe(true);
     });
   });
 });

--- a/src/shelves/service.test.ts
+++ b/src/shelves/service.test.ts
@@ -1,186 +1,228 @@
-import { createNanoEvents } from "nanoevents";
 import { describe, expect, it } from "vitest";
-import { reactive } from "vue";
 
-import {
-  journalDefaultsFor,
-  JournalsRepository,
-  UnknownJournalError,
-  type JournalConfig,
-  type JournalsEvents,
-} from "@/journals";
+import { JournalsRepository, UnknownJournalError } from "@/journals";
+import { journalsCoreModule } from "@/journals/module";
+import { fixedJournal } from "@/journals/testing";
+import { testContainer } from "@/testing";
 
+import { shelvesCollection } from "./config";
 import { UnknownShelfError } from "./errors";
-import { ShelvesRepository, type ShelvesEvents } from "./repository";
+import { shelvesCoreModule } from "./module";
 import { ShelvesService } from "./service";
-
-import type { ShelfConfig } from "./config";
-
-function setup(
-  initial: {
-    journals?: Record<string, JournalConfig>;
-    shelves?: Record<string, ShelfConfig>;
-  } = {},
-) {
-  const journalsStorage = reactive<Record<string, JournalConfig>>({ ...initial.journals });
-  const shelvesStorage = reactive<Record<string, ShelfConfig>>({ ...initial.shelves });
-  const journalsEvents = createNanoEvents<JournalsEvents>();
-  const shelvesEvents = createNanoEvents<ShelvesEvents>();
-  const journalsRepo = JournalsRepository.fromParts(journalsStorage, journalsEvents);
-  const shelvesRepo = ShelvesRepository.fromParts(shelvesStorage, shelvesEvents);
-  const service = ShelvesService.fromParts(shelvesRepo, journalsRepo, journalsEvents);
-  return {
-    service,
-    journalsRepo,
-    shelvesRepo,
-    journalsEvents,
-    shelvesEvents,
-    journalsStorage,
-    shelvesStorage,
-  };
-}
-
-const shelf = (name: string, journals: string[] = []): ShelfConfig => ({ name, journals, decorations: [] });
-const journalConfig = (name: string) => journalDefaultsFor({ type: "day" }, name);
+import { buildShelf } from "./testing";
 
 describe("ShelvesService", () => {
   describe("assign", () => {
-    it("appends the journal to the target shelf", () => {
-      const { service, shelvesStorage } = setup({
-        journals: { daily: journalConfig("daily") },
-        shelves: { Personal: shelf("Personal") },
+    it("appends the journal to the target shelf", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: {
+          journals: { daily: fixedJournal("daily", { type: "day" }) },
+          shelves: { Personal: buildShelf("Personal") },
+        },
       });
-      service.assign("daily", "Personal");
-      expect(shelvesStorage.Personal?.journals).toEqual(["daily"]);
+
+      harness.resolve(ShelvesService).assign("daily", "Personal");
+
+      expect(harness.settings.recordOf(shelvesCollection).Personal?.journals).toEqual(["daily"]);
     });
 
-    it("moves a journal off its current shelf", () => {
-      const { service, shelvesStorage } = setup({
-        journals: { daily: journalConfig("daily") },
-        shelves: { Old: shelf("Old", ["daily"]), New: shelf("New") },
+    it("moves a journal off its current shelf", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: {
+          journals: { daily: fixedJournal("daily", { type: "day" }) },
+          shelves: { Old: buildShelf("Old", { journals: ["daily"] }), New: buildShelf("New") },
+        },
       });
-      service.assign("daily", "New");
-      expect(shelvesStorage.Old?.journals).toEqual([]);
-      expect(shelvesStorage.New?.journals).toEqual(["daily"]);
+
+      harness.resolve(ShelvesService).assign("daily", "New");
+
+      expect(harness.settings.recordOf(shelvesCollection).Old?.journals).toEqual([]);
+      expect(harness.settings.recordOf(shelvesCollection).New?.journals).toEqual(["daily"]);
     });
 
-    it("removes the journal from its current shelf when shelfName is empty", () => {
-      const { service, shelvesStorage } = setup({
-        journals: { daily: journalConfig("daily") },
-        shelves: { Personal: shelf("Personal", ["daily"]) },
+    it("removes the journal from its current shelf when shelfName is empty", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: {
+          journals: { daily: fixedJournal("daily", { type: "day" }) },
+          shelves: { Personal: buildShelf("Personal", { journals: ["daily"] }) },
+        },
       });
-      service.assign("daily", "");
-      expect(shelvesStorage.Personal?.journals).toEqual([]);
+
+      harness.resolve(ShelvesService).assign("daily", "");
+
+      expect(harness.settings.recordOf(shelvesCollection).Personal?.journals).toEqual([]);
     });
 
-    it("does not duplicate when assigning to the same shelf the journal is already on", () => {
-      const { service, shelvesStorage } = setup({
-        journals: { daily: journalConfig("daily") },
-        shelves: { Personal: shelf("Personal", ["daily"]) },
+    it("does not duplicate when assigning to the same shelf the journal is already on", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: {
+          journals: { daily: fixedJournal("daily", { type: "day" }) },
+          shelves: { Personal: buildShelf("Personal", { journals: ["daily"] }) },
+        },
       });
-      service.assign("daily", "Personal");
-      expect(shelvesStorage.Personal?.journals).toEqual(["daily"]);
+
+      harness.resolve(ShelvesService).assign("daily", "Personal");
+
+      expect(harness.settings.recordOf(shelvesCollection).Personal?.journals).toEqual(["daily"]);
     });
 
-    it("rejects unknown journal", () => {
-      const { service } = setup({ shelves: { Personal: shelf("Personal") } });
-      const result = service.assign("nope", "Personal");
+    it("rejects unknown journal", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: { journals: {}, shelves: { Personal: buildShelf("Personal") } },
+      });
+
+      const result = harness.resolve(ShelvesService).assign("nope", "Personal");
+
       expect(result.isErr() && result.error).toBeInstanceOf(UnknownJournalError);
     });
 
-    it("rejects unknown shelf", () => {
-      const { service } = setup({ journals: { daily: journalConfig("daily") } });
-      const result = service.assign("daily", "ghost");
+    it("rejects unknown shelf", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }) }, shelves: {} },
+      });
+
+      const result = harness.resolve(ShelvesService).assign("daily", "ghost");
+
       expect(result.isErr() && result.error).toBeInstanceOf(UnknownShelfError);
     });
   });
 
   describe("shelfOf", () => {
-    it("returns the name of the shelf containing the journal", () => {
-      const { service } = setup({
-        journals: { daily: journalConfig("daily") },
-        shelves: { Personal: shelf("Personal", ["daily"]) },
+    it("returns the name of the shelf containing the journal", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: {
+          journals: { daily: fixedJournal("daily", { type: "day" }) },
+          shelves: { Personal: buildShelf("Personal", { journals: ["daily"] }) },
+        },
       });
-      expect(service.shelfOf("daily")).toBe("Personal");
+
+      expect(harness.resolve(ShelvesService).shelfOf("daily")).toBe("Personal");
     });
 
-    it("returns an empty string when the journal is on no shelf", () => {
-      const { service } = setup({
-        journals: { daily: journalConfig("daily") },
-        shelves: { Personal: shelf("Personal") },
+    it("returns an empty string when the journal is on no shelf", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: {
+          journals: { daily: fixedJournal("daily", { type: "day" }) },
+          shelves: { Personal: buildShelf("Personal") },
+        },
       });
-      expect(service.shelfOf("daily")).toBe("");
+
+      expect(harness.resolve(ShelvesService).shelfOf("daily")).toBe("");
     });
   });
 
   describe("cascade on journal rename", () => {
-    it("replaces the old name with the new one in every shelf", () => {
-      const { journalsRepo, shelvesStorage } = setup({
-        journals: { daily: journalConfig("daily") },
-        shelves: {
-          Personal: shelf("Personal", ["daily"]),
-          Home: shelf("Home", ["daily"]),
+    it("replaces the old name with the new one in every shelf", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: {
+          journals: { daily: fixedJournal("daily", { type: "day" }) },
+          shelves: {
+            Personal: buildShelf("Personal", { journals: ["daily"] }),
+            Home: buildShelf("Home", { journals: ["daily"] }),
+          },
         },
       });
-      journalsRepo.rename("daily", "renamed");
-      expect(shelvesStorage.Personal?.journals).toEqual(["renamed"]);
-      expect(shelvesStorage.Home?.journals).toEqual(["renamed"]);
+
+      harness.resolve(JournalsRepository).rename("daily", "renamed");
+
+      expect(harness.settings.recordOf(shelvesCollection).Personal?.journals).toEqual(["renamed"]);
+      expect(harness.settings.recordOf(shelvesCollection).Home?.journals).toEqual(["renamed"]);
     });
   });
 
   describe("cascade on journal clone", () => {
-    it("adds the copy beside the source on every shelf holding it", () => {
-      const { journalsRepo, shelvesStorage } = setup({
-        journals: { daily: journalConfig("daily") },
-        shelves: {
-          Personal: shelf("Personal", ["daily"]),
-          Home: shelf("Home", ["other", "daily"]),
+    it("adds the copy beside the source on every shelf holding it", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: {
+          journals: { daily: fixedJournal("daily", { type: "day" }) },
+          shelves: {
+            Personal: buildShelf("Personal", { journals: ["daily"] }),
+            Home: buildShelf("Home", { journals: ["other", "daily"] }),
+          },
         },
       });
-      journalsRepo.clone("daily", "daily copy");
-      expect(shelvesStorage.Personal?.journals).toEqual(["daily", "daily copy"]);
-      expect(shelvesStorage.Home?.journals).toEqual(["other", "daily", "daily copy"]);
+
+      harness.resolve(JournalsRepository).clone("daily", "daily copy");
+
+      expect(harness.settings.recordOf(shelvesCollection).Personal?.journals).toEqual(["daily", "daily copy"]);
+      expect(harness.settings.recordOf(shelvesCollection).Home?.journals).toEqual(["other", "daily", "daily copy"]);
     });
 
-    it("leaves shelves that do not hold the source untouched", () => {
-      const { journalsRepo, shelvesStorage } = setup({
-        journals: { daily: journalConfig("daily") },
-        shelves: { Personal: shelf("Personal", ["daily"]), Work: shelf("Work", ["other"]) },
+    it("leaves shelves that do not hold the source untouched", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: {
+          journals: { daily: fixedJournal("daily", { type: "day" }) },
+          shelves: {
+            Personal: buildShelf("Personal", { journals: ["daily"] }),
+            Work: buildShelf("Work", { journals: ["other"] }),
+          },
+        },
       });
-      journalsRepo.clone("daily", "daily copy");
-      expect(shelvesStorage.Work?.journals).toEqual(["other"]);
+
+      harness.resolve(JournalsRepository).clone("daily", "daily copy");
+
+      expect(harness.settings.recordOf(shelvesCollection).Work?.journals).toEqual(["other"]);
     });
 
-    it("adds the copy to no shelf when the source is on none", () => {
-      const { journalsRepo, shelvesStorage } = setup({
-        journals: { daily: journalConfig("daily") },
-        shelves: { Personal: shelf("Personal", ["other"]) },
+    it("adds the copy to no shelf when the source is on none", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: {
+          journals: { daily: fixedJournal("daily", { type: "day" }) },
+          shelves: { Personal: buildShelf("Personal", { journals: ["other"] }) },
+        },
       });
-      journalsRepo.clone("daily", "daily copy");
-      expect(shelvesStorage.Personal?.journals).toEqual(["other"]);
+
+      harness.resolve(JournalsRepository).clone("daily", "daily copy");
+
+      expect(harness.settings.recordOf(shelvesCollection).Personal?.journals).toEqual(["other"]);
     });
   });
 
   describe("cascade on journal delete", () => {
-    it("removes the journal name from every shelf", () => {
-      const { journalsRepo, shelvesStorage } = setup({
-        journals: { daily: journalConfig("daily") },
-        shelves: { Personal: shelf("Personal", ["daily", "other"]) },
+    it("removes the journal name from every shelf", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: {
+          journals: { daily: fixedJournal("daily", { type: "day" }) },
+          shelves: { Personal: buildShelf("Personal", { journals: ["daily", "other"] }) },
+        },
       });
-      journalsRepo.delete("daily");
-      expect(shelvesStorage.Personal?.journals).toEqual(["other"]);
+
+      harness.resolve(JournalsRepository).delete("daily");
+
+      expect(harness.settings.recordOf(shelvesCollection).Personal?.journals).toEqual(["other"]);
     });
   });
 
   describe("hasShelves", () => {
-    it("returns false when no shelves exist", () => {
-      const { service } = setup({ shelves: {} });
-      expect(service.hasShelves()).toBe(false);
+    it("returns false when no shelves exist", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: { shelves: {} },
+      });
+
+      expect(harness.resolve(ShelvesService).hasShelves()).toBe(false);
     });
 
-    it("returns true when at least one shelf exists", () => {
-      const { service } = setup({ shelves: { Personal: shelf("Personal") } });
-      expect(service.hasShelves()).toBe(true);
+    it("returns true when at least one shelf exists", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: { shelves: { Personal: buildShelf("Personal") } },
+      });
+
+      expect(harness.resolve(ShelvesService).hasShelves()).toBe(true);
     });
   });
 });

--- a/src/shelves/testing.ts
+++ b/src/shelves/testing.ts
@@ -1,8 +1,13 @@
 import { createNanoEvents } from "nanoevents";
 
+import { shelvesCollection } from "./config";
 import { ShelvesRepository } from "./repository";
 
 import type { ShelfConfig } from "./config";
+
+export function buildShelf(name: string, overrides: Partial<ShelfConfig> = {}): ShelfConfig {
+  return { ...shelvesCollection.defaultItem(name), ...overrides };
+}
 
 export function fakeShelvesRepo(shelves: Record<string, ShelfConfig> = {}): ShelvesRepository {
   return ShelvesRepository.fromParts(shelves, createNanoEvents());

--- a/src/shelves/ui-module.ts
+++ b/src/shelves/ui-module.ts
@@ -1,0 +1,23 @@
+import type { Module } from "@/infrastructure/di";
+import { JournalEditSectionToken, defineJournalEditSection } from "@/journals";
+import { DashboardBlockToken, SubpageToken, defineDashboardBlock } from "@/settings";
+
+import JournalsDashboardBlock from "./ui/JournalsDashboardBlock.vue";
+import JournalShelfSection from "./ui/JournalShelfSection.vue";
+import { shelfEditSubpage } from "./ui/shelf-edit-subpage";
+import ShelvesDashboardBlock from "./ui/ShelvesDashboardBlock.vue";
+
+export const shelvesUiModule: Module = {
+  register(c) {
+    c.register(DashboardBlockToken).useValue(
+      defineDashboardBlock({ key: "shelves", component: ShelvesDashboardBlock, order: 4 }),
+    );
+    c.register(DashboardBlockToken).useValue(
+      defineDashboardBlock({ key: "journals", component: JournalsDashboardBlock, order: 5 }),
+    );
+    c.register(SubpageToken).useValue(shelfEditSubpage);
+    c.register(JournalEditSectionToken).useValue(
+      defineJournalEditSection({ key: "shelf", component: JournalShelfSection, order: 10 }),
+    );
+  },
+};

--- a/src/shelves/ui/DeleteShelfModal.test.ts
+++ b/src/shelves/ui/DeleteShelfModal.test.ts
@@ -1,31 +1,24 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/vue";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import { m } from "@/i18n";
-import type { ModalApi } from "@/infrastructure/host/modals";
-import { provideModalApiOnApp } from "@/infrastructure/host/modals/testing";
+import { journalsCoreModule } from "@/journals/module";
+import { testContainer, type TestHarness } from "@/testing";
+
+import { shelvesCoreModule } from "../module";
 
 import DeleteShelfModal from "./DeleteShelfModal.vue";
 
-afterEach(() => cleanup());
-
-function mountModal(props: { shelfName?: string; otherShelves?: string[] }) {
-  const submit = vi.fn();
-  const cancel = vi.fn();
-  const api: ModalApi<string> = { submit, cancel };
-  render(DeleteShelfModal, {
-    props: { shelfName: props.shelfName ?? "Work", otherShelves: props.otherShelves ?? [] },
-    global: {
-      plugins: [{ install: (app) => provideModalApiOnApp(app, api as ModalApi<unknown>) }],
-    },
-  });
-  return { submit, cancel };
-}
-
 describe("DeleteShelfModal", () => {
+  let harness: TestHarness;
+
+  beforeEach(async () => {
+    harness = await testContainer({ modules: [journalsCoreModule, shelvesCoreModule] });
+  });
+
   it("lists the other shelves as destinations", () => {
-    mountModal({ otherShelves: ["Personal", "Archive"] });
+    harness.renderModal(DeleteShelfModal, { props: { shelfName: "Work", otherShelves: ["Personal", "Archive"] } });
     const optionValues = [...screen.getByRole("combobox").querySelectorAll("option")].map((o) =>
       o.getAttribute("value"),
     );
@@ -33,26 +26,30 @@ describe("DeleteShelfModal", () => {
   });
 
   it("shows the moved-out message when no other shelves exist", () => {
-    mountModal({ otherShelves: [] });
+    harness.renderModal(DeleteShelfModal, { props: { shelfName: "Work", otherShelves: [] } });
     expect(screen.getByText(m.shelf_delete_modal_moved_out())).toBeTruthy();
     expect(screen.queryByRole("combobox")).toBeNull();
   });
 
   it("submits the empty destination when no destination is picked", async () => {
-    const { submit } = mountModal({ otherShelves: ["Personal"] });
+    const { submit } = harness.renderModal<typeof DeleteShelfModal, string>(DeleteShelfModal, {
+      props: { shelfName: "Work", otherShelves: ["Personal"] },
+    });
     await userEvent.click(screen.getByText(m.common_action_delete()));
     expect(submit).toHaveBeenCalledWith("");
   });
 
   it("submits the chosen destination", async () => {
-    const { submit } = mountModal({ otherShelves: ["Personal"] });
+    const { submit } = harness.renderModal<typeof DeleteShelfModal, string>(DeleteShelfModal, {
+      props: { shelfName: "Work", otherShelves: ["Personal"] },
+    });
     await userEvent.selectOptions(screen.getByRole("combobox"), "Personal");
     await userEvent.click(screen.getByText(m.common_action_delete()));
     expect(submit).toHaveBeenCalledWith("Personal");
   });
 
   it("cancels when the user clicks Cancel", async () => {
-    const { cancel } = mountModal({});
+    const { cancel } = harness.renderModal(DeleteShelfModal, { props: { shelfName: "Work", otherShelves: [] } });
     await userEvent.click(screen.getByText(m.common_action_cancel()));
     expect(cancel).toHaveBeenCalledTimes(1);
   });

--- a/src/shelves/ui/JournalList.test.ts
+++ b/src/shelves/ui/JournalList.test.ts
@@ -1,44 +1,11 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { afterEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
 
-import type { AnchorString } from "@/calendar";
 import { m } from "@/i18n";
-import type { JournalConfig } from "@/journals";
+import { fixedJournal } from "@/journals/testing";
 
 import JournalList from "./JournalList.vue";
-
-afterEach(() => cleanup());
-
-function makeJournal(name: string): JournalConfig {
-  return {
-    name,
-    write: { type: "day" },
-    timeline: { start: "2024-01-01" as AnchorString, end: { kind: "never" } },
-    dateFormat: "YYYY-MM-DD",
-    frontmatter: {
-      dateField: "journal-date",
-      startDateField: "journal-start-date",
-      endDateField: "journal-end-date",
-      addStartDate: false,
-      addEndDate: false,
-    },
-    numbering: {
-      enabled: false,
-      anchorDate: "2024-01-01" as AnchorString,
-      allowBefore: false,
-      sources: [],
-    },
-    nameTemplate: "{{date}}",
-    folder: "",
-    templates: [],
-    confirmCreation: false,
-    decorations: [],
-    autoCreate: false,
-    navBlock: { type: "create", lines: [], decorateWholeBlock: false },
-    intervalBlock: { type: "create", lines: [], decorateWholeBlock: false },
-  };
-}
 
 describe("JournalList", () => {
   it("shows the empty text when there are no entries", () => {
@@ -48,7 +15,7 @@ describe("JournalList", () => {
 
   it("renders a row per journal", () => {
     render(JournalList, {
-      props: { entries: [["Journal A", makeJournal("Journal A")]], emptyText: "Nothing here" },
+      props: { entries: [["Journal A", fixedJournal("Journal A", { type: "day" })]], emptyText: "Nothing here" },
     });
     expect(screen.getByText("Journal A")).toBeTruthy();
     expect(screen.queryByText("Nothing here")).toBeNull();
@@ -56,7 +23,7 @@ describe("JournalList", () => {
 
   it("emits bulk-add with the journal name", async () => {
     const { emitted } = render(JournalList, {
-      props: { entries: [["Journal A", makeJournal("Journal A")]], emptyText: "Nothing here" },
+      props: { entries: [["Journal A", fixedJournal("Journal A", { type: "day" })]], emptyText: "Nothing here" },
     });
     await userEvent.click(screen.getByLabelText(m.journal_dashboard_bulk_add({ name: "Journal A" })));
     expect(emitted()["bulk-add"]).toEqual([["Journal A"]]);
@@ -64,7 +31,7 @@ describe("JournalList", () => {
 
   it("emits edit with the journal name", async () => {
     const { emitted } = render(JournalList, {
-      props: { entries: [["Journal A", makeJournal("Journal A")]], emptyText: "Nothing here" },
+      props: { entries: [["Journal A", fixedJournal("Journal A", { type: "day" })]], emptyText: "Nothing here" },
     });
     await userEvent.click(screen.getByLabelText(m.journal_dashboard_edit({ name: "Journal A" })));
     expect(emitted().edit).toEqual([["Journal A"]]);
@@ -72,7 +39,7 @@ describe("JournalList", () => {
 
   it("emits clone with the journal name", async () => {
     const { emitted } = render(JournalList, {
-      props: { entries: [["Journal A", makeJournal("Journal A")]], emptyText: "Nothing here" },
+      props: { entries: [["Journal A", fixedJournal("Journal A", { type: "day" })]], emptyText: "Nothing here" },
     });
     await userEvent.click(screen.getByLabelText(m.journal_dashboard_clone({ name: "Journal A" })));
     expect(emitted().clone).toEqual([["Journal A"]]);
@@ -80,7 +47,7 @@ describe("JournalList", () => {
 
   it("emits delete with the journal name", async () => {
     const { emitted } = render(JournalList, {
-      props: { entries: [["Journal A", makeJournal("Journal A")]], emptyText: "Nothing here" },
+      props: { entries: [["Journal A", fixedJournal("Journal A", { type: "day" })]], emptyText: "Nothing here" },
     });
     await userEvent.click(screen.getByLabelText(m.common_delete_name({ name: "Journal A" })));
     expect(emitted().delete).toEqual([["Journal A"]]);

--- a/src/shelves/ui/JournalShelfSection.test.ts
+++ b/src/shelves/ui/JournalShelfSection.test.ts
@@ -1,80 +1,54 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { createNanoEvents } from "nanoevents";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/vue";
+import { describe, expect, it, vi } from "vitest";
 
 import { m } from "@/i18n";
-import { type Container, provideInjectorOnApp } from "@/infrastructure/di";
 import { Flows } from "@/infrastructure/flows";
-import { NoticeService } from "@/infrastructure/host";
-import { ModalService } from "@/infrastructure/host/modals";
-import { FakeModalService } from "@/infrastructure/host/modals/testing";
-import { FakeNoticeService } from "@/infrastructure/host/testing";
-import { journalConfigCollection } from "@/journals";
-import { JournalsRepository } from "@/journals/repository";
-import { JournalsEventsToken } from "@/journals/tokens";
-import { createSettingsService } from "@/settings/testing";
+import { journalsCoreModule } from "@/journals/module";
+import { testContainer } from "@/testing";
 
-import { shelvesCollection } from "../config";
 import { PlaceJournalFlow } from "../flows/place-journal.flow";
-import { ShelvesRepository } from "../repository";
-import { ShelvesService } from "../service";
-import { ShelvesEventsToken } from "../tokens";
+import { shelvesCoreModule } from "../module";
+import { buildShelf } from "../testing";
 
 import JournalShelfSection from "./JournalShelfSection.vue";
 
-afterEach(() => cleanup());
+import type { ShelfConfig } from "../config";
 
-async function setup(shelves: Record<string, { name: string; journals: string[] }> = {}) {
-  const { service: settings, container } = createSettingsService({
-    collections: [journalConfigCollection, shelvesCollection],
-    raw: { version: 5, shelves },
+async function setup(shelves: Record<string, ShelfConfig> = {}) {
+  const harness = await testContainer({
+    modules: [journalsCoreModule, shelvesCoreModule],
+    data: { shelves },
   });
-  await settings.initialize();
-  container.register(ModalService).useValue(new FakeModalService() as unknown as ModalService);
-  container.register(JournalsEventsToken).useFactory(() => createNanoEvents());
-  container.register(JournalsRepository).useClass(JournalsRepository);
-  container.register(ShelvesEventsToken).useFactory(() => createNanoEvents());
-  container.register(ShelvesRepository).useClass(ShelvesRepository);
-  container.register(ShelvesService).useClass(ShelvesService);
-  container.register(NoticeService).useValue(new FakeNoticeService());
-  container.register(Flows).useClass(Flows);
-  const flows = container.resolve(Flows);
+  const flows = harness.resolve(Flows);
   vi.spyOn(flows, "invoke").mockReturnValue({} as never);
-  return { container, flows };
-}
-
-function mount(container: Container, journalName: string) {
-  return render(JournalShelfSection, {
-    props: { journalName },
-    global: { plugins: [{ install: (app) => provideInjectorOnApp(app, container) }] },
-  });
+  return { harness, flows };
 }
 
 describe("JournalShelfSection", () => {
   it("renders nothing when no shelves exist", async () => {
-    const { container } = await setup({});
-    mount(container, "daily");
+    const { harness } = await setup({});
+    harness.render(JournalShelfSection, { props: { journalName: "daily" } });
     expect(screen.queryByText(m.common_label_shelf())).toBeNull();
   });
 
   it("shows the not-on-a-shelf message when the journal is unassigned", async () => {
-    const { container } = await setup({ Work: { name: "Work", journals: [] } });
-    mount(container, "daily");
+    const { harness } = await setup({ Work: buildShelf("Work") });
+    harness.render(JournalShelfSection, { props: { journalName: "daily" } });
     await userEvent.click(screen.getByText(m.common_label_shelf()));
     expect(screen.getByText(m.shelf_section_not_on_shelf())).toBeTruthy();
   });
 
   it("shows the current shelf when the journal is on one", async () => {
-    const { container } = await setup({ Work: { name: "Work", journals: ["daily"] } });
-    mount(container, "daily");
+    const { harness } = await setup({ Work: buildShelf("Work", { journals: ["daily"] }) });
+    harness.render(JournalShelfSection, { props: { journalName: "daily" } });
     await userEvent.click(screen.getByText(m.common_label_shelf()));
     expect(screen.getByText("Work")).toBeTruthy();
   });
 
   it("invokes PlaceJournalFlow when the place button is clicked", async () => {
-    const { container, flows } = await setup({ Work: { name: "Work", journals: [] } });
-    mount(container, "daily");
+    const { harness, flows } = await setup({ Work: buildShelf("Work") });
+    harness.render(JournalShelfSection, { props: { journalName: "daily" } });
     await userEvent.click(screen.getByText(m.common_label_shelf()));
     await userEvent.click(screen.getByLabelText(m.shelf_section_place_tooltip()));
     expect(flows.invoke).toHaveBeenCalledWith(PlaceJournalFlow, { journalName: "daily" });

--- a/src/shelves/ui/JournalsDashboardBlock.test.ts
+++ b/src/shelves/ui/JournalsDashboardBlock.test.ts
@@ -1,150 +1,95 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { createNanoEvents } from "nanoevents";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/vue";
+import { describe, expect, it, vi } from "vitest";
 
 import { m } from "@/i18n";
-import { type Container, provideInjectorOnApp } from "@/infrastructure/di";
 import { Flows } from "@/infrastructure/flows";
-import { NoticeService } from "@/infrastructure/host";
-import { ModalService } from "@/infrastructure/host/modals";
-import { FakeModalService } from "@/infrastructure/host/modals/testing";
-import { FakeNoticeService } from "@/infrastructure/host/testing";
-import {
-  AddJournalFlow,
-  DeleteJournalFlow,
-  CloneJournalFlow,
-  journalConfigCollection,
-  journalEditSubpage,
-} from "@/journals";
+import { AddJournalFlow, DeleteJournalFlow, CloneJournalFlow, type JournalConfig } from "@/journals";
+import { journalsCoreModule } from "@/journals/module";
 import { BulkAddFlow } from "@/journals/notes/bulk-add/flows/bulk-add.flow";
-import { JournalsRepository } from "@/journals/repository";
-import { JournalsEventsToken } from "@/journals/tokens";
-import { JournalsViewModel } from "@/journals/view-model";
-import { SettingsUiService, SubpageToken } from "@/settings";
-import { createSettingsService } from "@/settings/testing";
+import { journalsSettingsUiModule } from "@/journals/settings/ui-module";
+import { fixedJournal } from "@/journals/testing";
+import { SettingsUiService } from "@/settings";
+import { testContainer } from "@/testing";
 
-import { shelvesCollection } from "../config";
-import { ShelvesRepository } from "../repository";
-import { ShelvesEventsToken } from "../tokens";
-import { ShelvesViewModel } from "../view-model";
+import { shelvesCoreModule } from "../module";
+import { buildShelf } from "../testing";
 
 import JournalsDashboardBlock from "./JournalsDashboardBlock.vue";
 
-afterEach(() => cleanup());
+import type { ShelfConfig } from "../config";
 
-function makeJournal(name: string) {
-  return {
-    name,
-    write: { type: "day" as const },
-    timeline: { start: "2024-01-01", end: { kind: "never" as const } },
-    dateFormat: "YYYY-MM-DD",
-    frontmatter: {
-      dateField: "journal-date",
-      startDateField: "journal-start-date",
-      endDateField: "journal-end-date",
-      addStartDate: false,
-      addEndDate: false,
-    },
-    numbering: { enabled: false, anchorDate: "2024-01-01", allowBefore: false, sources: [] },
-    nameTemplate: "{{date}}",
-    folder: "",
-    templates: [],
-    confirmCreation: false,
-    autoCreate: false,
-  };
-}
-
-async function setup(options: { journals?: string[]; shelves?: Record<string, { name: string; journals: string[] }> }) {
-  const { service: settings, container } = createSettingsService({
-    collections: [journalConfigCollection, shelvesCollection],
-    raw: {
-      version: 5,
-      journals: Object.fromEntries((options.journals ?? []).map((n) => [n, makeJournal(n)])),
-      shelves: options.shelves ?? {},
-    },
+async function setup(options: { journals?: Record<string, JournalConfig>; shelves?: Record<string, ShelfConfig> }) {
+  const harness = await testContainer({
+    modules: [journalsCoreModule, journalsSettingsUiModule, shelvesCoreModule],
+    data: { journals: options.journals ?? {}, shelves: options.shelves ?? {} },
   });
-  await settings.initialize();
-  container.register(ModalService).useValue(new FakeModalService() as unknown as ModalService);
-  container.register(JournalsEventsToken).useFactory(() => createNanoEvents());
-  container.register(JournalsRepository).useClass(JournalsRepository);
-  container.register(JournalsViewModel).useClass(JournalsViewModel);
-  container.register(ShelvesEventsToken).useFactory(() => createNanoEvents());
-  container.register(ShelvesRepository).useClass(ShelvesRepository);
-  container.register(ShelvesViewModel).useClass(ShelvesViewModel);
-  container.register(SubpageToken).useValue(journalEditSubpage);
-  container.register(SettingsUiService).useClass(SettingsUiService);
-  container.register(NoticeService).useValue(new FakeNoticeService());
-  container.register(Flows).useClass(Flows);
-  const flows = container.resolve(Flows);
+  const flows = harness.resolve(Flows);
   vi.spyOn(flows, "invoke").mockReturnValue({} as never);
-  return { container, flows, ui: container.resolve(SettingsUiService) };
-}
-
-function mount(container: Container) {
-  return render(JournalsDashboardBlock, {
-    global: { plugins: [{ install: (app) => provideInjectorOnApp(app, container) }] },
-  });
+  return { harness, flows, ui: harness.resolve(SettingsUiService) };
 }
 
 describe("JournalsDashboardBlock", () => {
   it("lists only journals not on any shelf", async () => {
-    const { container } = await setup({
-      journals: ["daily", "weekly"],
-      shelves: { Work: { name: "Work", journals: ["weekly"] } },
+    const { harness } = await setup({
+      journals: {
+        daily: fixedJournal("daily", { type: "day" }),
+        weekly: fixedJournal("weekly", { type: "week" }),
+      },
+      shelves: { Work: buildShelf("Work", { journals: ["weekly"] }) },
     });
-    mount(container);
+    harness.render(JournalsDashboardBlock);
     expect(screen.getByLabelText(m.journal_dashboard_edit({ name: "daily" }))).toBeTruthy();
     expect(screen.queryByText("weekly")).toBeNull();
   });
 
   it("uses the plain title when no shelves exist", async () => {
-    const { container } = await setup({ journals: ["daily"] });
-    mount(container);
+    const { harness } = await setup({ journals: { daily: fixedJournal("daily", { type: "day" }) } });
+    harness.render(JournalsDashboardBlock);
     expect(screen.getByText(m.common_label_journals())).toBeTruthy();
   });
 
   it("uses the not-on-a-shelf title once a shelf exists", async () => {
-    const { container } = await setup({
-      journals: ["daily"],
-      shelves: { Work: { name: "Work", journals: [] } },
+    const { harness } = await setup({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      shelves: { Work: buildShelf("Work") },
     });
-    mount(container);
+    harness.render(JournalsDashboardBlock);
     expect(screen.getByText(m.shelf_journals_block_title_filtered())).toBeTruthy();
   });
 
   it("invokes AddJournalFlow when the add button is clicked", async () => {
-    const { container, flows } = await setup({});
-    mount(container);
+    const { harness, flows } = await setup({});
+    harness.render(JournalsDashboardBlock);
     await userEvent.click(screen.getByLabelText(m.journal_create()));
     expect(flows.invoke).toHaveBeenCalledWith(AddJournalFlow);
   });
 
   it("pushes the journal-edit subpage when Edit is clicked", async () => {
-    const { container, ui } = await setup({ journals: ["daily"] });
-    mount(container);
+    const { harness, ui } = await setup({ journals: { daily: fixedJournal("daily", { type: "day" }) } });
+    harness.render(JournalsDashboardBlock);
     await userEvent.click(screen.getByLabelText(m.journal_dashboard_edit({ name: "daily" })));
     expect(ui.current.value?.subpage.key).toBe("journal-edit");
     expect(ui.current.value?.props).toEqual({ journalName: "daily" });
   });
 
   it("invokes DeleteJournalFlow when Delete is clicked", async () => {
-    const { container, flows } = await setup({ journals: ["daily"] });
-    mount(container);
+    const { harness, flows } = await setup({ journals: { daily: fixedJournal("daily", { type: "day" }) } });
+    harness.render(JournalsDashboardBlock);
     await userEvent.click(screen.getByLabelText(m.common_delete_name({ name: "daily" })));
     expect(flows.invoke).toHaveBeenCalledWith(DeleteJournalFlow, { journalName: "daily" });
   });
 
   it("invokes BulkAddFlow when bulk-add is clicked", async () => {
-    const { container, flows } = await setup({ journals: ["daily"] });
-    mount(container);
+    const { harness, flows } = await setup({ journals: { daily: fixedJournal("daily", { type: "day" }) } });
+    harness.render(JournalsDashboardBlock);
     await userEvent.click(screen.getByLabelText(m.journal_dashboard_bulk_add({ name: "daily" })));
     expect(flows.invoke).toHaveBeenCalledWith(BulkAddFlow, { journalName: "daily" });
   });
 
   it("invokes CloneJournalFlow when clone is clicked", async () => {
-    const { container, flows } = await setup({ journals: ["daily"] });
-    mount(container);
+    const { harness, flows } = await setup({ journals: { daily: fixedJournal("daily", { type: "day" }) } });
+    harness.render(JournalsDashboardBlock);
     await userEvent.click(screen.getByLabelText(m.journal_dashboard_clone({ name: "daily" })));
     expect(flows.invoke).toHaveBeenCalledWith(CloneJournalFlow, { journalName: "daily" });
   });

--- a/src/shelves/ui/PlaceJournalModal.test.ts
+++ b/src/shelves/ui/PlaceJournalModal.test.ts
@@ -1,31 +1,24 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/vue";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import { m } from "@/i18n";
-import type { ModalApi } from "@/infrastructure/host/modals";
-import { provideModalApiOnApp } from "@/infrastructure/host/modals/testing";
+import { journalsCoreModule } from "@/journals/module";
+import { testContainer, type TestHarness } from "@/testing";
+
+import { shelvesCoreModule } from "../module";
 
 import PlaceJournalModal from "./PlaceJournalModal.vue";
 
-afterEach(() => cleanup());
-
-function mountModal(props: { currentShelf?: string; shelfNames?: string[] }) {
-  const submit = vi.fn();
-  const cancel = vi.fn();
-  const api: ModalApi<string> = { submit, cancel };
-  render(PlaceJournalModal, {
-    props: { currentShelf: props.currentShelf ?? "", shelfNames: props.shelfNames ?? [] },
-    global: {
-      plugins: [{ install: (app) => provideModalApiOnApp(app, api as ModalApi<unknown>) }],
-    },
-  });
-  return { submit, cancel };
-}
-
 describe("PlaceJournalModal", () => {
+  let harness: TestHarness;
+
+  beforeEach(async () => {
+    harness = await testContainer({ modules: [journalsCoreModule, shelvesCoreModule] });
+  });
+
   it("offers every shelf plus the not-on-a-shelf option", () => {
-    mountModal({ shelfNames: ["Work", "Personal"] });
+    harness.renderModal(PlaceJournalModal, { props: { currentShelf: "", shelfNames: ["Work", "Personal"] } });
     const optionValues = [...screen.getByRole("combobox").querySelectorAll("option")].map((o) =>
       o.getAttribute("value"),
     );
@@ -33,26 +26,30 @@ describe("PlaceJournalModal", () => {
   });
 
   it("starts with the journal's current shelf selected", () => {
-    mountModal({ currentShelf: "Personal", shelfNames: ["Work", "Personal"] });
+    harness.renderModal(PlaceJournalModal, { props: { currentShelf: "Personal", shelfNames: ["Work", "Personal"] } });
     expect(screen.getByRole<HTMLSelectElement>("combobox").value).toBe("Personal");
   });
 
   it("submits the chosen shelf", async () => {
-    const { submit } = mountModal({ shelfNames: ["Work"] });
+    const { submit } = harness.renderModal<typeof PlaceJournalModal, string>(PlaceJournalModal, {
+      props: { currentShelf: "", shelfNames: ["Work"] },
+    });
     await userEvent.selectOptions(screen.getByRole("combobox"), "Work");
     await userEvent.click(screen.getByText(m.common_action_submit()));
     expect(submit).toHaveBeenCalledWith("Work");
   });
 
   it("submits the empty shelf to unassign the journal", async () => {
-    const { submit } = mountModal({ currentShelf: "Work", shelfNames: ["Work"] });
+    const { submit } = harness.renderModal<typeof PlaceJournalModal, string>(PlaceJournalModal, {
+      props: { currentShelf: "Work", shelfNames: ["Work"] },
+    });
     await userEvent.selectOptions(screen.getByRole("combobox"), "");
     await userEvent.click(screen.getByText(m.common_action_submit()));
     expect(submit).toHaveBeenCalledWith("");
   });
 
   it("cancels when the user clicks Cancel", async () => {
-    const { cancel } = mountModal({});
+    const { cancel } = harness.renderModal(PlaceJournalModal, { props: { currentShelf: "", shelfNames: [] } });
     await userEvent.click(screen.getByText(m.common_action_cancel()));
     expect(cancel).toHaveBeenCalledTimes(1);
   });

--- a/src/shelves/ui/ShelfEditSubpage.test.ts
+++ b/src/shelves/ui/ShelfEditSubpage.test.ts
@@ -1,85 +1,33 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { createNanoEvents } from "nanoevents";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/vue";
+import { describe, expect, it, vi } from "vitest";
 import { nextTick } from "vue";
 
 import { m } from "@/i18n";
-import { type Container, provideInjectorOnApp } from "@/infrastructure/di";
 import { Flows } from "@/infrastructure/flows";
-import { NoticeService } from "@/infrastructure/host";
-import { ModalService } from "@/infrastructure/host/modals";
-import { FakeModalService } from "@/infrastructure/host/modals/testing";
-import { FakeNoticeService } from "@/infrastructure/host/testing";
 import { AsyncResult } from "@/infrastructure/result";
-import { AddJournalFlow, CloneJournalFlow, journalConfigCollection } from "@/journals";
+import { AddJournalFlow, CloneJournalFlow, type JournalConfig } from "@/journals";
+import { journalsCoreModule } from "@/journals/module";
 import { BulkAddFlow } from "@/journals/notes/bulk-add/flows/bulk-add.flow";
-import { JournalsRepository } from "@/journals/repository";
-import { JournalsEventsToken } from "@/journals/tokens";
-import { JournalsViewModel } from "@/journals/view-model";
-import { SettingsUiService, SubpageToken, type SubpageNav } from "@/settings";
-import { createSettingsService } from "@/settings/testing";
+import { fixedJournal } from "@/journals/testing";
+import type { SubpageNav } from "@/settings";
+import { testContainer, type TestHarness } from "@/testing";
 
-import { shelvesCollection } from "../config";
 import { EditShelfNameFlow } from "../flows/edit-shelf-name.flow";
+import { shelvesCoreModule } from "../module";
 import { ShelvesRepository } from "../repository";
-import { ShelvesService } from "../service";
-import { ShelvesEventsToken } from "../tokens";
-import { ShelvesViewModel } from "../view-model";
+import { buildShelf } from "../testing";
 
-import { shelfEditSubpage } from "./shelf-edit-subpage";
 import ShelfEditSubpage from "./ShelfEditSubpage.vue";
 
-afterEach(() => cleanup());
+import type { ShelfConfig } from "../config";
 
-function makeJournal(name: string) {
-  return {
-    name,
-    write: { type: "day" as const },
-    timeline: { start: "2024-01-01", end: { kind: "never" as const } },
-    dateFormat: "YYYY-MM-DD",
-    frontmatter: {
-      dateField: "journal-date",
-      startDateField: "journal-start-date",
-      endDateField: "journal-end-date",
-      addStartDate: false,
-      addEndDate: false,
-    },
-    numbering: { enabled: false, anchorDate: "2024-01-01", allowBefore: false, sources: [] },
-    nameTemplate: "{{date}}",
-    folder: "",
-    templates: [],
-    confirmCreation: false,
-    autoCreate: false,
-  };
-}
-
-async function setup(options: { journals?: string[]; shelves?: Record<string, { name: string; journals: string[] }> }) {
-  const raw = {
-    version: 5,
-    journals: Object.fromEntries((options.journals ?? []).map((n) => [n, makeJournal(n)])),
-    shelves: options.shelves ?? {},
-  };
-  const { service: settings, container } = createSettingsService({
-    collections: [journalConfigCollection, shelvesCollection],
-    raw,
+async function setup(options: { journals?: Record<string, JournalConfig>; shelves?: Record<string, ShelfConfig> }) {
+  const harness = await testContainer({
+    modules: [journalsCoreModule, shelvesCoreModule],
+    data: { journals: options.journals ?? {}, shelves: options.shelves ?? {} },
   });
-  await settings.initialize();
-  container.register(ModalService).useValue(new FakeModalService() as unknown as ModalService);
-  container.register(JournalsEventsToken).useFactory(() => createNanoEvents());
-  container.register(JournalsRepository).useClass(JournalsRepository);
-  container.register(JournalsViewModel).useClass(JournalsViewModel);
-  container.register(ShelvesEventsToken).useFactory(() => createNanoEvents());
-  container.register(ShelvesRepository).useClass(ShelvesRepository);
-  container.register(ShelvesService).useClass(ShelvesService);
-  container.register(ShelvesViewModel).useClass(ShelvesViewModel);
-  container.register(SubpageToken).useValue(shelfEditSubpage);
-  container.register(SettingsUiService).useClass(SettingsUiService);
-  container.register(NoticeService).useValue(new FakeNoticeService());
-  container.register(Flows).useClass(Flows);
-  const flows = container.resolve(Flows);
-  const shelvesRepo = container.resolve(ShelvesRepository);
-  return { container, shelvesRepo, flows };
+  return { harness, shelvesRepo: harness.resolve(ShelvesRepository), flows: harness.resolve(Flows) };
 }
 
 const noopNav: SubpageNav<{ shelfName: string }> = {
@@ -88,17 +36,14 @@ const noopNav: SubpageNav<{ shelfName: string }> = {
   replace: () => undefined,
 };
 
-function mount(container: Container, shelfName: string, nav: SubpageNav<{ shelfName: string }> = noopNav) {
-  return render(ShelfEditSubpage, {
-    props: { shelfName, nav },
-    global: { plugins: [{ install: (app) => provideInjectorOnApp(app, container) }] },
-  });
+function mount(harness: TestHarness, shelfName: string, nav: SubpageNav<{ shelfName: string }> = noopNav) {
+  return harness.render(ShelfEditSubpage, { props: { shelfName, nav } });
 }
 
 // The dashboard re-renders the subpage with the frame's replaced props; stand in for it.
-function mountFollowingFrame(container: Container, shelfName: string) {
+function mountFollowingFrame(harness: TestHarness, shelfName: string) {
   const back = vi.fn();
-  const utilities = mount(container, shelfName, {
+  const utilities = mount(harness, shelfName, {
     back,
     push: () => undefined,
     replace: (props) => void utilities.rerender(props),
@@ -108,63 +53,63 @@ function mountFollowingFrame(container: Container, shelfName: string) {
 
 describe("ShelfEditSubpage", () => {
   it("lists the shelf's member journals", async () => {
-    const { container } = await setup({
-      journals: ["daily"],
-      shelves: { Work: { name: "Work", journals: ["daily"] } },
+    const { harness } = await setup({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      shelves: { Work: buildShelf("Work", { journals: ["daily"] }) },
     });
-    mount(container, "Work");
+    mount(harness, "Work");
     expect(screen.getByLabelText(m.journal_dashboard_edit({ name: "daily" }))).toBeTruthy();
   });
 
   it("invokes BulkAddFlow when a member journal's bulk-add is clicked", async () => {
-    const { container, flows } = await setup({
-      journals: ["daily"],
-      shelves: { Work: { name: "Work", journals: ["daily"] } },
+    const { harness, flows } = await setup({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      shelves: { Work: buildShelf("Work", { journals: ["daily"] }) },
     });
     vi.spyOn(flows, "invoke").mockReturnValue(AsyncResult.ok(undefined));
-    mount(container, "Work");
+    mount(harness, "Work");
     await userEvent.click(screen.getByLabelText(m.journal_dashboard_bulk_add({ name: "daily" })));
     expect(flows.invoke).toHaveBeenCalledWith(BulkAddFlow, { journalName: "daily" });
   });
 
   it("invokes CloneJournalFlow when a member journal's clone is clicked", async () => {
-    const { container, flows } = await setup({
-      journals: ["daily"],
-      shelves: { Work: { name: "Work", journals: ["daily"] } },
+    const { harness, flows } = await setup({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      shelves: { Work: buildShelf("Work", { journals: ["daily"] }) },
     });
     vi.spyOn(flows, "invoke").mockReturnValue(AsyncResult.ok({ name: "daily copy" }));
-    mount(container, "Work");
+    mount(harness, "Work");
     await userEvent.click(screen.getByLabelText(m.journal_dashboard_clone({ name: "daily" })));
     expect(flows.invoke).toHaveBeenCalledWith(CloneJournalFlow, { journalName: "daily" });
   });
 
   it("invokes EditShelfNameFlow with the shelf name when rename is clicked", async () => {
-    const { container, flows } = await setup({ shelves: { Work: { name: "Work", journals: [] } } });
+    const { harness, flows } = await setup({ shelves: { Work: buildShelf("Work") } });
     vi.spyOn(flows, "invoke").mockReturnValue(AsyncResult.ok({ shelfName: "Work" }));
-    mount(container, "Work");
+    mount(harness, "Work");
     await userEvent.click(screen.getByLabelText(m.shelf_rename()));
     expect(flows.invoke).toHaveBeenCalledWith(EditShelfNameFlow, { shelfName: "Work" });
   });
 
   it("calls nav.back when the back breadcrumb is clicked", async () => {
-    const { container } = await setup({ shelves: { Work: { name: "Work", journals: [] } } });
+    const { harness } = await setup({ shelves: { Work: buildShelf("Work") } });
     const back = vi.fn();
-    mount(container, "Work", { back, push: () => undefined, replace: () => undefined });
+    mount(harness, "Work", { back, push: () => undefined, replace: () => undefined });
     await userEvent.click(screen.getByRole("button", { name: m.common_label_back() }));
     expect(back).toHaveBeenCalled();
   });
 
   it("calls nav.back when the shelf no longer exists", async () => {
-    const { container } = await setup({ shelves: {} });
+    const { harness } = await setup({ shelves: {} });
     const back = vi.fn();
-    mount(container, "Gone", { back, push: () => undefined, replace: () => undefined });
+    mount(harness, "Gone", { back, push: () => undefined, replace: () => undefined });
     expect(back).toHaveBeenCalled();
   });
 
   describe("when the shelf is renamed", () => {
     it("keeps the shelf's page open", async () => {
-      const { container, shelvesRepo } = await setup({ shelves: { Work: { name: "Work", journals: [] } } });
-      const { back } = mountFollowingFrame(container, "Work");
+      const { harness, shelvesRepo } = await setup({ shelves: { Work: buildShelf("Work") } });
+      const { back } = mountFollowingFrame(harness, "Work");
       shelvesRepo.rename("Work", "Office");
       await nextTick();
       await nextTick();
@@ -172,20 +117,20 @@ describe("ShelfEditSubpage", () => {
     });
 
     it("shows the shelf's new name", async () => {
-      const { container, shelvesRepo } = await setup({ shelves: { Work: { name: "Work", journals: [] } } });
-      mountFollowingFrame(container, "Work");
+      const { harness, shelvesRepo } = await setup({ shelves: { Work: buildShelf("Work") } });
+      mountFollowingFrame(harness, "Work");
       shelvesRepo.rename("Work", "Office");
       await vi.waitFor(() => expect(screen.getByText("Office")).toBeTruthy());
     });
   });
 
   it("assigns a newly created journal to the shelf", async () => {
-    const { container, flows, shelvesRepo } = await setup({
-      journals: ["daily"],
-      shelves: { Work: { name: "Work", journals: [] } },
+    const { harness, flows, shelvesRepo } = await setup({
+      journals: { daily: fixedJournal("daily", { type: "day" }) },
+      shelves: { Work: buildShelf("Work") },
     });
     vi.spyOn(flows, "invoke").mockReturnValue(AsyncResult.ok({ name: "daily" }));
-    mount(container, "Work");
+    mount(harness, "Work");
     await userEvent.click(screen.getByLabelText(m.journal_create()));
     await vi.waitFor(() => expect(shelvesRepo.get("Work").getOr(undefined as never)?.journals).toEqual(["daily"]));
     expect(flows.invoke).toHaveBeenCalledWith(AddJournalFlow);

--- a/src/shelves/ui/ShelfNameModal.test.ts
+++ b/src/shelves/ui/ShelfNameModal.test.ts
@@ -1,28 +1,15 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen, waitFor } from "@testing-library/vue";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/vue";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import { m } from "@/i18n";
-import type { ModalApi } from "@/infrastructure/host/modals";
-import { provideModalApiOnApp } from "@/infrastructure/host/modals/testing";
+import { journalsCoreModule } from "@/journals/module";
+import { testContainer, type TestHarness } from "@/testing";
+
+import { shelvesCoreModule } from "../module";
 
 import { shelfNameModal } from "./modals";
 import ShelfNameModal from "./ShelfNameModal.vue";
-
-afterEach(() => cleanup());
-
-function mountModal(props: { currentName?: string; takenNames?: string[] }) {
-  const submit = vi.fn();
-  const cancel = vi.fn();
-  const api: ModalApi<string> = { submit, cancel };
-  render(ShelfNameModal, {
-    props: { currentName: props.currentName, takenNames: props.takenNames ?? [] },
-    global: {
-      plugins: [{ install: (app) => provideModalApiOnApp(app, api as ModalApi<unknown>) }],
-    },
-  });
-  return { submit, cancel };
-}
 
 describe("shelfNameModal definition", () => {
   it("uses the add title when no current name is supplied", () => {
@@ -35,22 +22,30 @@ describe("shelfNameModal definition", () => {
 });
 
 describe("ShelfNameModal", () => {
+  let harness: TestHarness;
+
+  beforeEach(async () => {
+    harness = await testContainer({ modules: [journalsCoreModule, shelvesCoreModule] });
+  });
+
   it("submits the entered name", async () => {
-    const { submit } = mountModal({});
+    const { submit } = harness.renderModal<typeof ShelfNameModal, string>(ShelfNameModal, {
+      props: { takenNames: [] },
+    });
     await userEvent.type(screen.getByRole("textbox"), "Work");
     await userEvent.click(screen.getByText(m.common_action_create()));
     await waitFor(() => expect(submit).toHaveBeenCalledWith("Work"));
   });
 
   it("surfaces a required error when the name is empty", async () => {
-    const { submit } = mountModal({});
+    const { submit } = harness.renderModal(ShelfNameModal, { props: { takenNames: [] } });
     await userEvent.click(screen.getByText(m.common_action_create()));
     await waitFor(() => expect(screen.getByText(m.shelf_name_required_error())).toBeTruthy());
     expect(submit).not.toHaveBeenCalled();
   });
 
   it("surfaces a uniqueness error when the name is taken", async () => {
-    const { submit } = mountModal({ takenNames: ["Work"] });
+    const { submit } = harness.renderModal(ShelfNameModal, { props: { takenNames: ["Work"] } });
     await userEvent.type(screen.getByRole("textbox"), "Work");
     await userEvent.click(screen.getByText(m.common_action_create()));
     await waitFor(() => expect(screen.getByText(m.shelf_name_unique_error())).toBeTruthy());
@@ -58,14 +53,14 @@ describe("ShelfNameModal", () => {
   });
 
   it("rejects the unchanged name when renaming", async () => {
-    const { submit } = mountModal({ currentName: "Work" });
+    const { submit } = harness.renderModal(ShelfNameModal, { props: { currentName: "Work", takenNames: [] } });
     await userEvent.click(screen.getByText(m.common_action_submit()));
     await waitFor(() => expect(screen.getByText(m.shelf_name_unchanged_error())).toBeTruthy());
     expect(submit).not.toHaveBeenCalled();
   });
 
   it("cancels when the user clicks Cancel", async () => {
-    const { cancel } = mountModal({});
+    const { cancel } = harness.renderModal(ShelfNameModal, { props: { takenNames: [] } });
     await userEvent.click(screen.getByText(m.common_action_cancel()));
     expect(cancel).toHaveBeenCalledTimes(1);
   });

--- a/src/shelves/ui/ShelvesDashboardBlock.test.ts
+++ b/src/shelves/ui/ShelvesDashboardBlock.test.ts
@@ -1,53 +1,31 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { createNanoEvents } from "nanoevents";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/vue";
+import { describe, expect, it, vi } from "vitest";
 
 import { m } from "@/i18n";
-import { type Container, provideInjectorOnApp } from "@/infrastructure/di";
 import { Flows } from "@/infrastructure/flows";
-import { NoticeService } from "@/infrastructure/host";
-import { ModalService } from "@/infrastructure/host/modals";
-import { FakeModalService } from "@/infrastructure/host/modals/testing";
-import { FakeNoticeService } from "@/infrastructure/host/testing";
-import { SettingsUiService, SubpageToken } from "@/settings";
-import { createSettingsService } from "@/settings/testing";
+import { journalsCoreModule } from "@/journals/module";
+import { SettingsUiService } from "@/settings";
+import { testContainer } from "@/testing";
 
-import { shelvesCollection } from "../config";
 import { DeleteShelfFlow } from "../flows/delete-shelf.flow";
 import { EditShelfNameFlow } from "../flows/edit-shelf-name.flow";
-import { ShelvesRepository } from "../repository";
-import { ShelvesEventsToken } from "../tokens";
-import { ShelvesViewModel } from "../view-model";
+import { shelvesCoreModule } from "../module";
+import { buildShelf } from "../testing";
+import { shelvesUiModule } from "../ui-module";
 
-import { shelfEditSubpage } from "./shelf-edit-subpage";
 import ShelvesDashboardBlock from "./ShelvesDashboardBlock.vue";
 
-afterEach(() => cleanup());
+import type { ShelfConfig } from "../config";
 
-async function setup(shelves: Record<string, { name: string; journals: string[] }> = {}) {
-  const { service: settings, container } = createSettingsService({
-    collections: [shelvesCollection],
-    raw: { version: 5, shelves },
+async function setup(shelves: Record<string, ShelfConfig> = {}) {
+  const harness = await testContainer({
+    modules: [journalsCoreModule, shelvesCoreModule, shelvesUiModule],
+    data: { shelves },
   });
-  await settings.initialize();
-  container.register(ModalService).useValue(new FakeModalService() as unknown as ModalService);
-  container.register(ShelvesEventsToken).useFactory(() => createNanoEvents());
-  container.register(ShelvesRepository).useClass(ShelvesRepository);
-  container.register(ShelvesViewModel).useClass(ShelvesViewModel);
-  container.register(SubpageToken).useValue(shelfEditSubpage);
-  container.register(SettingsUiService).useClass(SettingsUiService);
-  container.register(NoticeService).useValue(new FakeNoticeService());
-  container.register(Flows).useClass(Flows);
-  const flows = container.resolve(Flows);
+  const flows = harness.resolve(Flows);
   vi.spyOn(flows, "invoke").mockReturnValue({ tap: () => undefined } as never);
-  return { container, flows, ui: container.resolve(SettingsUiService) };
-}
-
-function mount(container: Container) {
-  return render(ShelvesDashboardBlock, {
-    global: { plugins: [{ install: (app) => provideInjectorOnApp(app, container) }] },
-  });
+  return { harness, flows, ui: harness.resolve(SettingsUiService) };
 }
 
 async function expand(): Promise<void> {
@@ -56,49 +34,49 @@ async function expand(): Promise<void> {
 
 describe("ShelvesDashboardBlock", () => {
   it("explains what a shelf is even once shelves exist", async () => {
-    const { container } = await setup({ Work: { name: "Work", journals: ["daily"] } });
-    mount(container);
+    const { harness } = await setup({ Work: buildShelf("Work", { journals: ["daily"] }) });
+    harness.render(ShelvesDashboardBlock);
     expect(screen.getByText(m.shelf_dashboard_description())).toBeTruthy();
   });
 
   it("starts collapsed when no shelves exist", async () => {
-    const { container } = await setup();
-    mount(container);
+    const { harness } = await setup();
+    harness.render(ShelvesDashboardBlock);
     expect(screen.queryByText(m.shelf_dashboard_description())).toBeNull();
   });
 
   it("shows the empty state when no shelves exist", async () => {
-    const { container } = await setup();
-    mount(container);
+    const { harness } = await setup();
+    harness.render(ShelvesDashboardBlock);
     await expand();
     expect(screen.getByText(m.shelf_dashboard_empty())).toBeTruthy();
   });
 
   it("lists each shelf with its member count", async () => {
-    const { container } = await setup({ Work: { name: "Work", journals: ["daily", "weekly"] } });
-    mount(container);
+    const { harness } = await setup({ Work: buildShelf("Work", { journals: ["daily", "weekly"] }) });
+    harness.render(ShelvesDashboardBlock);
     expect(screen.getByText("Work")).toBeTruthy();
     expect(screen.getByText(m.shelf_member_count({ count: 2 }))).toBeTruthy();
   });
 
   it("invokes EditShelfNameFlow when the add button is clicked", async () => {
-    const { container, flows } = await setup();
-    mount(container);
+    const { harness, flows } = await setup();
+    harness.render(ShelvesDashboardBlock);
     await userEvent.click(screen.getByLabelText(m.shelf_add()));
     expect(flows.invoke).toHaveBeenCalledWith(EditShelfNameFlow, {});
   });
 
   it("opens the shelf-detail subpage when the organize button is clicked", async () => {
-    const { container, ui } = await setup({ Work: { name: "Work", journals: [] } });
-    mount(container);
+    const { harness, ui } = await setup({ Work: buildShelf("Work") });
+    harness.render(ShelvesDashboardBlock);
     await userEvent.click(screen.getByLabelText(m.shelf_dashboard_open({ name: "Work" })));
     expect(ui.current.value?.subpage.key).toBe("shelf-edit");
     expect(ui.current.value?.props).toEqual({ shelfName: "Work" });
   });
 
   it("invokes DeleteShelfFlow when the delete button is clicked", async () => {
-    const { container, flows } = await setup({ Work: { name: "Work", journals: [] } });
-    mount(container);
+    const { harness, flows } = await setup({ Work: buildShelf("Work") });
+    harness.render(ShelvesDashboardBlock);
     await userEvent.click(screen.getByLabelText(m.common_delete_name({ name: "Work" })));
     expect(flows.invoke).toHaveBeenCalledWith(DeleteShelfFlow, { shelfName: "Work" });
   });

--- a/src/shelves/view-model.test.ts
+++ b/src/shelves/view-model.test.ts
@@ -1,43 +1,45 @@
-import { createNanoEvents } from "nanoevents";
-import { describe, expect, it } from "vitest";
-import { reactive } from "vue";
+import { beforeEach, describe, expect, it } from "vitest";
 
-import { ShelvesRepository, type ShelvesEvents } from "./repository";
+import { journalsCoreModule } from "@/journals/module";
+import { testContainer, type TestHarness } from "@/testing";
+
+import { shelvesCoreModule } from "./module";
+import { ShelvesRepository } from "./repository";
+import { buildShelf } from "./testing";
 import { ShelvesViewModel } from "./view-model";
-
-import type { ShelfConfig } from "./config";
-
-function buildVM(initial: Record<string, ShelfConfig> = {}) {
-  const storage = reactive<Record<string, ShelfConfig>>({ ...initial });
-  const events = createNanoEvents<ShelvesEvents>();
-  const repo = ShelvesRepository.fromParts(storage, events);
-  const vm = ShelvesViewModel.fromRepository(repo);
-  return { vm, repo };
-}
-
-const shelf = (name: string, journals: string[] = []): ShelfConfig => ({ name, journals, decorations: [] });
 
 describe("ShelvesViewModel", () => {
   describe("shelves", () => {
-    it("yields the current shelves", () => {
-      const { vm } = buildVM({ Personal: shelf("Personal") });
-      expect(vm.shelves.value.map((s) => s.name)).toEqual(["Personal"]);
+    it("yields the current shelves", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: { shelves: { Personal: buildShelf("Personal") } },
+      });
+
+      expect(harness.resolve(ShelvesViewModel).shelves.value.map((s) => s.name)).toEqual(["Personal"]);
     });
 
-    it("reflects mutations after create", () => {
-      const { vm, repo } = buildVM();
-      repo.create("Personal");
+    it("reflects mutations after create", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: { shelves: {} },
+      });
+      const vm = harness.resolve(ShelvesViewModel);
+
+      harness.resolve(ShelvesRepository).create("Personal");
+
       expect(vm.shelves.value.map((s) => s.name)).toEqual(["Personal"]);
     });
   });
 
   describe("shelfOptions", () => {
-    it("labels options by the shelf name", () => {
-      const { vm } = buildVM({
-        Personal: shelf("Personal"),
-        Home: shelf("Home"),
+    it("labels options by the shelf name", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: { shelves: { Personal: buildShelf("Personal"), Home: buildShelf("Home") } },
       });
-      expect(vm.shelfOptions.value).toEqual([
+
+      expect(harness.resolve(ShelvesViewModel).shelfOptions.value).toEqual([
         { value: "Personal", label: "Personal" },
         { value: "Home", label: "Home" },
       ]);
@@ -45,38 +47,55 @@ describe("ShelvesViewModel", () => {
   });
 
   describe("shelfCount", () => {
-    it("returns the count", () => {
-      const { vm } = buildVM({ Personal: shelf("Personal") });
-      expect(vm.shelfCount.value).toBe(1);
+    it("returns the count", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: { shelves: { Personal: buildShelf("Personal") } },
+      });
+
+      expect(harness.resolve(ShelvesViewModel).shelfCount.value).toBe(1);
     });
   });
 
   describe("getShelf", () => {
+    let harness: TestHarness;
+
+    beforeEach(async () => {
+      harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: { shelves: { Personal: buildShelf("Personal") } },
+      });
+    });
+
     it("returns Some for a known name", () => {
-      const { vm } = buildVM({ Personal: shelf("Personal") });
-      expect(vm.getShelf("Personal").isSome()).toBe(true);
+      expect(harness.resolve(ShelvesViewModel).getShelf("Personal").isSome()).toBe(true);
     });
 
     it("returns None for an unknown name", () => {
-      const { vm } = buildVM();
-      expect(vm.getShelf("nope").isNone()).toBe(true);
+      expect(harness.resolve(ShelvesViewModel).getShelf("nope").isNone()).toBe(true);
     });
   });
 
   describe("isShelfNameAvailable", () => {
+    let harness: TestHarness;
+
+    beforeEach(async () => {
+      harness = await testContainer({
+        modules: [journalsCoreModule, shelvesCoreModule],
+        data: { shelves: { Personal: buildShelf("Personal") } },
+      });
+    });
+
     it("is false when the name is in use", () => {
-      const { vm } = buildVM({ Personal: shelf("Personal") });
-      expect(vm.isShelfNameAvailable("Personal")).toBe(false);
+      expect(harness.resolve(ShelvesViewModel).isShelfNameAvailable("Personal")).toBe(false);
     });
 
     it("is true when the name is free", () => {
-      const { vm } = buildVM({ Personal: shelf("Personal") });
-      expect(vm.isShelfNameAvailable("Other")).toBe(true);
+      expect(harness.resolve(ShelvesViewModel).isShelfNameAvailable("Other")).toBe(true);
     });
 
     it("treats excludeCurrent as available", () => {
-      const { vm } = buildVM({ Personal: shelf("Personal") });
-      expect(vm.isShelfNameAvailable("Personal", "Personal")).toBe(true);
+      expect(harness.resolve(ShelvesViewModel).isShelfNameAvailable("Personal", "Personal")).toBe(true);
     });
   });
 });

--- a/src/shelves/view-model.test.ts
+++ b/src/shelves/view-model.test.ts
@@ -1,32 +1,35 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { journalsCoreModule } from "@/journals/module";
-import { testContainer, type TestHarness } from "@/testing";
+import { testContainer } from "@/testing";
 
 import { shelvesCoreModule } from "./module";
 import { ShelvesRepository } from "./repository";
 import { buildShelf } from "./testing";
 import { ShelvesViewModel } from "./view-model";
 
+import type { ShelfConfig } from "./config";
+
+async function buildVM(initial: Record<string, ShelfConfig> = {}) {
+  const harness = await testContainer({
+    modules: [journalsCoreModule, shelvesCoreModule],
+    data: { shelves: initial },
+  });
+  return { vm: harness.resolve(ShelvesViewModel), repo: harness.resolve(ShelvesRepository) };
+}
+
 describe("ShelvesViewModel", () => {
   describe("shelves", () => {
     it("yields the current shelves", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: { shelves: { Personal: buildShelf("Personal") } },
-      });
+      const { vm } = await buildVM({ Personal: buildShelf("Personal") });
 
-      expect(harness.resolve(ShelvesViewModel).shelves.value.map((s) => s.name)).toEqual(["Personal"]);
+      expect(vm.shelves.value.map((s) => s.name)).toEqual(["Personal"]);
     });
 
     it("reflects mutations after create", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: { shelves: {} },
-      });
-      const vm = harness.resolve(ShelvesViewModel);
+      const { vm, repo } = await buildVM();
 
-      harness.resolve(ShelvesRepository).create("Personal");
+      repo.create("Personal");
 
       expect(vm.shelves.value.map((s) => s.name)).toEqual(["Personal"]);
     });
@@ -34,12 +37,9 @@ describe("ShelvesViewModel", () => {
 
   describe("shelfOptions", () => {
     it("labels options by the shelf name", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: { shelves: { Personal: buildShelf("Personal"), Home: buildShelf("Home") } },
-      });
+      const { vm } = await buildVM({ Personal: buildShelf("Personal"), Home: buildShelf("Home") });
 
-      expect(harness.resolve(ShelvesViewModel).shelfOptions.value).toEqual([
+      expect(vm.shelfOptions.value).toEqual([
         { value: "Personal", label: "Personal" },
         { value: "Home", label: "Home" },
       ]);
@@ -48,54 +48,43 @@ describe("ShelvesViewModel", () => {
 
   describe("shelfCount", () => {
     it("returns the count", async () => {
-      const harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: { shelves: { Personal: buildShelf("Personal") } },
-      });
+      const { vm } = await buildVM({ Personal: buildShelf("Personal") });
 
-      expect(harness.resolve(ShelvesViewModel).shelfCount.value).toBe(1);
+      expect(vm.shelfCount.value).toBe(1);
     });
   });
 
   describe("getShelf", () => {
-    let harness: TestHarness;
+    it("returns Some for a known name", async () => {
+      const { vm } = await buildVM({ Personal: buildShelf("Personal") });
 
-    beforeEach(async () => {
-      harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: { shelves: { Personal: buildShelf("Personal") } },
-      });
+      expect(vm.getShelf("Personal").isSome()).toBe(true);
     });
 
-    it("returns Some for a known name", () => {
-      expect(harness.resolve(ShelvesViewModel).getShelf("Personal").isSome()).toBe(true);
-    });
+    it("returns None for an unknown name", async () => {
+      const { vm } = await buildVM();
 
-    it("returns None for an unknown name", () => {
-      expect(harness.resolve(ShelvesViewModel).getShelf("nope").isNone()).toBe(true);
+      expect(vm.getShelf("nope").isNone()).toBe(true);
     });
   });
 
   describe("isShelfNameAvailable", () => {
-    let harness: TestHarness;
+    it("is false when the name is in use", async () => {
+      const { vm } = await buildVM({ Personal: buildShelf("Personal") });
 
-    beforeEach(async () => {
-      harness = await testContainer({
-        modules: [journalsCoreModule, shelvesCoreModule],
-        data: { shelves: { Personal: buildShelf("Personal") } },
-      });
+      expect(vm.isShelfNameAvailable("Personal")).toBe(false);
     });
 
-    it("is false when the name is in use", () => {
-      expect(harness.resolve(ShelvesViewModel).isShelfNameAvailable("Personal")).toBe(false);
+    it("is true when the name is free", async () => {
+      const { vm } = await buildVM({ Personal: buildShelf("Personal") });
+
+      expect(vm.isShelfNameAvailable("Other")).toBe(true);
     });
 
-    it("is true when the name is free", () => {
-      expect(harness.resolve(ShelvesViewModel).isShelfNameAvailable("Other")).toBe(true);
-    });
+    it("treats excludeCurrent as available", async () => {
+      const { vm } = await buildVM({ Personal: buildShelf("Personal") });
 
-    it("treats excludeCurrent as available", () => {
-      expect(harness.resolve(ShelvesViewModel).isShelfNameAvailable("Personal", "Personal")).toBe(true);
+      expect(vm.isShelfNameAvailable("Personal", "Personal")).toBe(true);
     });
   });
 });

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -48,12 +48,18 @@ export default defineConfig({
         // test-only seeding hatches on this campaign's deletion list, so the drop records them
         // getting closer to deletion rather than a test getting weaker. Same shape as the journals
         // move that took functions from 89.1 to 89.08 one sweep earlier.
-        statements: 92.18,
+        // Back up past that 89.08: repository.test.ts's two unknown-id tests now run against the
+        // DI-constructed repository instead of a `fromParts` clone, which reaches the previously
+        // uncovered `unknownEntityError` factory at repository.ts:49 (`invalidUpdateError` at :50
+        // stays uncovered, which is why this is +1 function, not +2).
+        // 92.18 -> 92.19, 94.3 -> 94.31: converting `MaintenanceSubpage.test.ts` onto testContainer
+        // (booting `maintenanceUiModule` instead of hand-registered stubs) now executes
+        // `maintenance-subpage.ts:5`'s `defineSubpage(...)` call, which no test reached before —
+        // one statement/line, no branches or functions in it.
+        statements: 92.19,
         branches: 87.82,
-        // Back up past that 89.08: booting DynamicCommandRegistry through its real module wiring
-        // reaches the repository's own error factories, which the hand-built container did not.
         functions: 89.12,
-        lines: 94.3,
+        lines: 94.31,
       },
     },
     projects: [

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -71,8 +71,15 @@ export default defineConfig({
         //
         // The commands component step (d8d38490), both module splits and the api step (ed62898c)
         // moved no number.
+        //
+        // Shelf cascade re-seed -> 92.19 / 87.86 / 89.12 / 94.31. The Commands step above lost two
+        // branches because its converted shelf-rename and shelf-delete tests seeded only a command
+        // matching the shelf being renamed or deleted, so the skip arm of the loop in
+        // `#onShelfRenamed` (:265) and `#onShelfDeleted` (:273) was never taken. Both tests now also
+        // seed a non-matching command (a different shelf, and a non-shelf target) and assert it is
+        // left alone, exercising that arm again and restoring the two branches.
         statements: 92.19,
-        branches: 87.82,
+        branches: 87.86,
         functions: 89.12,
         lines: 94.31,
       },

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -42,15 +42,18 @@ export default defineConfig({
       // earlier gate in this campaign was deleted because the cheapest route past a failure was
       // regenerating its baseline, which trains reviewers to dismiss it.
       thresholds: {
-        statements: 92.25,
-        branches: 87.86,
-        // 89.1 -> 89.08: converting the journals repository tests onto testContainer left the two
-        // error-factory arrows that `JournalsRepository.fromParts` hand-assigns (repository.ts:50-51)
-        // with no caller. They are duplicates of the class's own fields, reachable only through the
-        // seeding path this campaign is retiring, so the drop records `fromParts` getting closer to
-        // deletion rather than a test getting weaker.
-        functions: 89.08,
-        lines: 94.39,
+        // 92.25 -> 92.18, 87.86 -> 87.82, 94.39 -> 94.3: converting the commands service tests
+        // onto testContainer left `CommandsRepository.fromParts` (repository.ts:22-42) and
+        // `CommandsViewModel.fromRepository` (view-model.ts:11-13) with no caller at all. Both are
+        // test-only seeding hatches on this campaign's deletion list, so the drop records them
+        // getting closer to deletion rather than a test getting weaker. Same shape as the journals
+        // move that took functions from 89.1 to 89.08 one sweep earlier.
+        statements: 92.18,
+        branches: 87.82,
+        // Back up past that 89.08: booting DynamicCommandRegistry through its real module wiring
+        // reaches the repository's own error factories, which the hand-built container did not.
+        functions: 89.12,
+        lines: 94.3,
       },
     },
     projects: [

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -42,20 +42,35 @@ export default defineConfig({
       // earlier gate in this campaign was deleted because the cheapest route past a failure was
       // regenerating its baseline, which trains reviewers to dismiss it.
       thresholds: {
-        // 92.25 -> 92.18, 87.86 -> 87.82, 94.39 -> 94.3: converting the commands service tests
-        // onto testContainer left `CommandsRepository.fromParts` (repository.ts:22-42) and
-        // `CommandsViewModel.fromRepository` (view-model.ts:11-13) with no caller at all. Both are
-        // test-only seeding hatches on this campaign's deletion list, so the drop records them
-        // getting closer to deletion rather than a test getting weaker. Same shape as the journals
-        // move that took functions from 89.1 to 89.08 one sweep earlier.
-        // Back up past that 89.08: repository.test.ts's two unknown-id tests now run against the
-        // DI-constructed repository instead of a `fromParts` clone, which reaches the previously
-        // uncovered `unknownEntityError` factory at repository.ts:49 (`invalidUpdateError` at :50
-        // stays uncovered, which is why this is +1 function, not +2).
-        // 92.18 -> 92.19, 94.3 -> 94.31: converting `MaintenanceSubpage.test.ts` onto testContainer
-        // (booting `maintenanceUiModule` instead of hand-registered stubs) now executes
-        // `maintenance-subpage.ts:5`'s `defineSubpage(...)` call, which no test reached before —
-        // one statement/line, no branches or functions in it.
+        // Measured at each step of this sweep rather than reasoned about — two earlier versions of
+        // this comment narrated the wrong cause. Merge base (fa6aeacf): 92.25 / 87.86 / 89.08 / 94.39.
+        //
+        // Shelves (400479de) -> 92.26 / 87.86 / 89.10 / 94.39. `buildShelf` had no callers at all
+        // before this sweep and is now the shelf fixture everywhere, so `shelvesCollection`'s
+        // defaultItem factory (shelves/config.ts:19) runs for the first time: +1 function, +1
+        // statement. Nothing attributed this step before, which is how the statements clause used
+        // to read 92.25 -> 92.18 straight past a measured 92.26.
+        //
+        // Commands (b374d993) -> 92.18 / 87.82 / 89.12 / 94.30. Down: `CommandsRepository.fromParts`
+        // (repository.ts:22-42) and `CommandsViewModel.fromRepository` (view-model.ts:11-13) lost
+        // their last call sites, so their bodies stop executing (-10 statements, -10 lines between
+        // them). Both are test-only seeding hatches on this campaign's deletion list, so that part
+        // records them getting closer to deletion rather than a test getting weaker. The two
+        // branches are not that: the converted shelf-rename and shelf-delete tests seed only
+        // commands that match, so the skip arm of the loop in `#onShelfRenamed` (:265) and
+        // `#onShelfDeleted` (:273) is never taken. Up: command-registry.test.ts boots the whole
+        // `commandsModule`, whose UI half calls `defineShelfEditSection`
+        // (shelves/ui/shelf-edit-section.ts:11) — that, not anything under src/commands, is the +1
+        // function. Functions inside commands/repository.ts net zero across this step: the
+        // `fromParts` clone's `unknownEntityError` arrow (:39) goes cold exactly as the real class
+        // field (:49) comes alive.
+        //
+        // Maintenance (b01967b1) -> 92.19 / 87.82 / 89.12 / 94.31. `MaintenanceSubpage.test.ts`
+        // boots `maintenanceUiModule` instead of hand-registered stubs, so `maintenance-subpage.ts:5`'s
+        // `defineSubpage(...)` call executes — one statement and line, no branches or functions in it.
+        //
+        // The commands component step (d8d38490), both module splits and the api step (ed62898c)
+        // moved no number.
         statements: 92.19,
         branches: 87.82,
         functions: 89.12,


### PR DESCRIPTION
## What and why

Sweep 1 of the Phase 3 test-conversion campaign (see
`.superpowers/plans/2026-08-24-testing-strategy-phase-3-charter.md`, not
committed — it's the working charter for the six-sweep campaign). Converts
`src/shelves`, `src/commands`, `src/maintenance` and `src/api` off the old
hand-built `Container()` / `fakeRepo` / `provideInjectorOnApp` harness onto
`testContainer`, the same harness the journals sweep (#274) landed.

37 test files converted, three module splits, one lint hoist, four glob
enablements. No test added, deleted, renamed or merged — this is a wiring
conversion, not a coverage change, except where noted below.

### Module splits (one commit each, e2e bisects by commit)

- **shelves** (`d54c128d`) — `shelvesCoreModule` / `shelvesUiModule`.
  `ShelvesService` stays in **core**, not startup, even though it injects
  `JournalsRepository` and `JournalsEventsToken` (eager, subscribes to
  journal `renamed`/`deleted`/`cloned` from boot). Moving it to a startup
  module would name a domain service after a lifecycle it lacks; dropping
  `.eager()` would be a production regression. Consequence: shelves core is
  **not independently bootable** — every consumer passes
  `[journalsCoreModule, shelvesCoreModule]`, in this PR and in the sweeps
  still to come that touch shelves (views, decorations, code-blocks).
- **commands** (`bf46b20a`) — `commandsCoreModule` / `commandsUiModule` /
  `commandsStartupModule`. `DynamicCommandRegistry`'s `#reconcile()` calls
  `CommandService.register`/`unregister` — a genuine host effect — which is
  what puts it in startup rather than core, unlike `ShelvesService` above.
- **maintenance** (`6375ab1c`) — `maintenanceCoreModule` / `maintenanceUiModule`.
  `legacyMigrationsModule` plus an explicit `pendingNoteMigration: []` seed
  are both load-bearing: `ScanService` reads that slice in a field
  initializer and throws at construction without it.

New fixtures: `buildShelf`, `buildCommand` (both delegate to the collection's
`defaultItem`, matching `fixedJournal` → `journalDefaultsFor`). Maintenance
and api needed none.

### Lint

`8a3faf70` hoists the five campaign test selectors (`vi.mock` plus four
fixture/DI-shape rules) onto a shared `campaignTestSelectors` array and a
`convertedTestGlobs` file list in `eslint.config.mjs`. Each converted
directory appends one glob; `shelves`, `commands` and `maintenance`/`api`
are enabled here (journals was already enabled). `src/infrastructure/**`
stays permanently excluded — it's what `testContainer` is built from, and
linting it against its own campaign rules would be circular.

## Measured, before/after

**Test count — unchanged, and why that matters:** `npm test` gives
**395 test files / 4196 tests** both before (`fa6aeacf`) and at this PR's head.
Zero tests added, deleted, renamed, or merged
across 37 converted files — the conversion is wiring-only, which is the gate
this campaign runs on rather than a mutation-testing gate (that's Phase 5).

**Coverage — the floor moves at three of the sweep's steps.** Every step was
re-measured in a scratch worktree for the final review round, because two
earlier versions of the `vitest.config.mts` comment narrated the wrong cause.
The floor values did not change; the attribution did.

| | statements | branches | functions | lines |
| --- | --- | --- | --- | --- |
| baseline (`fa6aeacf`) | 92.25 | 87.86 | 89.08 | 94.39 |
| after shelves (`400479de`) | 92.26 | 87.86 | 89.10 | 94.39 |
| after commands (`b374d993`) | 92.18 | 87.82 | 89.12 | 94.30 |
| after maintenance + api (`ce71664d`) | 92.19 | 87.82 | 89.12 | 94.31 |
| **this PR's head** (`1a987a8b`) | **92.19** | **87.86** | **89.12** | **94.31** |

- **Shelves (+1 statement, +1 function).** `buildShelf` (`shelves/testing.ts`)
  had zero callers before this sweep and is now the shelf fixture everywhere,
  so `shelvesCollection`'s `defaultItem` factory (`shelves/config.ts:19`) runs
  for the first time. Nothing attributed this step in the earlier write-ups,
  which is how the statements clause used to read 92.25→92.18 straight past a
  measured 92.26 — and how the functions rise read as one +2 step instead of
  two +1 steps.
- **Commands (−9 statements, −9 lines, −2 branches, +1 function).**
  `CommandsRepository.fromParts` (`repository.ts:22-42`) and
  `CommandsViewModel.fromRepository` (`view-model.ts:11-13`) lost their last
  call sites, so their bodies stop executing (−10 statements and −10 lines
  between them); both are test-only seeding hatches on the closing PR's
  deletion list. The +1 function is **not** in `src/commands`:
  `command-registry.test.ts` boots the whole `commandsModule`, whose UI half
  calls `defineShelfEditSection` (`shelves/ui/shelf-edit-section.ts:11`).
  Functions inside `commands/repository.ts` net zero — the `fromParts` clone's
  `unknownEntityError` arrow (`:39`) goes cold exactly as the real class field
  (`:49`) comes alive, which is what the earlier comment saw and mistook for
  the whole rise.
- **The −2 branches were a genuine loss of test strength, and are fixed in
  `1a987a8b`.** The converted shelf-rename and shelf-delete tests seeded only
  commands that matched the target, so the skip arm of the loop in
  `DynamicCommandRegistry`'s `#onShelfRenamed` (`:265`) and `#onShelfDeleted`
  (`:273`) was never taken — **deleting the guard entirely left every one of
  those tests green.** Unlike the statement/line drop this was not a retired
  hatch. Both tests now also seed a command targeting a *different* shelf and
  one targeting a journal, covering both ways the guard can be false, and
  assert those are untouched. Proven by deleting each handler's condition and
  confirming the matching test goes red. Branch coverage is back to the
  baseline 87.86.

  Worth noting how it was found: it survived the implementer, the task review
  and the whole-branch review, and surfaced only because branch coverage moved
  by 0.04. It is exactly the failure mode this campaign exists to prevent — a
  conversion that stays green while destroying what it caught.
- **Maintenance (+1 statement, +1 line).** `MaintenanceSubpage.test.ts` boots
  `maintenanceUiModule` instead of hand-registering stubs, which executes
  `src/maintenance/ui/maintenance-subpage.ts:5` (`defineSubpage(...)`) for the
  first time — no branches or functions in it.
- The commands **component** step (`d8d38490`), both module splits and the api
  step (`ed62898c`) moved no number at all.

**Per-directory test LOC** (`find src/<dir> -name '*.test.ts' | xargs cat | wc -l`):

| dir | files | LOC before | LOC after | delta |
| --- | --- | --- | --- | --- |
| `shelves` | 15 | 1,463 | 1,275 | −188 |
| `commands` | 14 | 1,839 | 1,624 | −215 |
| `maintenance` | 6 | 1,496 | 1,379 | −117 |
| `api` | 2 | 590 | 499 | −91 |
| **total** | **37** | **5,388** | **4,777** | **−611 (−11%)** |

Most converted files got shorter, but not all: of the 32 files this sweep actually
edited, 26 shrank, one is unchanged, and five grew —
`shelves/repository.test.ts` 145→187, `shelves/service.test.ts` 186→200,
`shelves/view-model.test.ts` 82→90, `commands/command-registry.test.ts` 662→677 and
`commands/repository.test.ts` 94→98. Across those 32 files the net is 5,043→4,444
lines (−599). The two largest of those five are the seed-per-test files discussed under
the arrange-helper ruling below.

## Rulings that changed the work

Full detail in the (git-ignored) sweep-1 ledger; the ones that changed
behavior or reviewer expectations:

- **`ShelvesService` stays in core; shelves core is not independently
  bootable.** See the module-split section above. `shelvesCoreModule` alone
  throws `TokenNotRegisteredError` naming its own cause — every consumer
  passes both core modules together.
- **The arrange-helper rule was corrected mid-sweep.** The original charter
  recipe said "no per-file arrange helpers." That was wrong and contradicted
  `1086d78f` on `main`, which restored `journals/repository.test.ts`'s local
  `buildRepo` over inlined `testContainer` calls after the inlined version
  grew the file and made 6 of 9 call sites byte-identical boilerplate. The
  ban targets helpers that **reconstruct wiring** (hand-built `Container`,
  `fromParts`, duplicated fixtures) — not thin wrappers over `testContainer`.
  `shelves/repository.test.ts` and `service.test.ts` grew (145→187 and
  186→200 lines at this head) by design: seeds genuinely differ per test, so a
  `beforeEach` hoist doesn't apply. They peaked higher — 226 and 228 at
  `610bda59` — and the review round in `d4960953` thinned them back to the
  numbers above.
- **The coverage floor moves in either direction, attributed by
  measurement.** See the coverage table above. Three of the four movements
  are wiring reaching code a hand-built container never did, or retired
  seeding hatches going cold; the fourth — the −2 branches — was a real loss
  of coverage in the converted shelf-cascade tests, called out as such rather
  than filed under the hatches, and then fixed in `1a987a8b`.
- **The split cap is risk-based, not a count.** Sweep 1 carried three splits
  against a charter cap of two, which exposed the cap as badly worded: it now
  counts splits that **move an eager service**. Shelves and commands each
  relocated an eager registration and carry real boot-order risk; maintenance
  has no eager service at all, so its UI-only split cannot change construction
  order. Sweep 1 carried two risk-bearing splits and one inert one. Each is
  still its own commit and e2e still bisects by commit.

## The limits of what was verified

This section is not soft-pedaled on purpose.

- **The shelves schema-repair path is unproven.** `config.test.ts`'s guard
  that a bad decoration must not wipe a shelf's `journals` membership on
  load was re-proven with a break/confirm-red/restore probe, but the probe
  is weaker than it looks: removing `v.fallback` makes `testContainer()`
  itself throw `TestContainerInvalidSeedError` before any `expect` runs,
  because the seed guard rejects **any** repair-warning log unconditionally.
  A `repairCollectionEntry` bug that wiped `journals` would throw the
  identical error in the identical place — the red proves "the schema
  change is detectable," not "journals survive repair." What the test does
  assert for real, on the green path, is that `v.fallback` absorbs a bad
  decoration **without** triggering repair at all. The repair path itself
  is unreached by any seed that doesn't trip the guard — a Phase 4.5
  coverage gap, not a defect in this PR. The compensating control is the
  settings-service suite.
- **`DynamicCommandRegistry`'s break-probe (task 6, probe 1) proves less
  than it appears to.** Deleting `#reconcile` from `initialize` produced 22
  reds, which shows the boot trigger is load-bearing — not that any specific
  assertion bites, and it cannot go red at all for a test whose expectation
  is negative (`toBeUndefined()`/`isNone()`). Probe 2 (deleting the dead-end
  notice, 4 reds) is exact. Left unproven by either probe: anchor
  resolution, timeline filtering, palette-name prefixes, the unregister
  branch, ribbon dedup, the reloaded handler, every cascade/clone outcome —
  roughly 30 of the 44 tests in that file. Their assurance is that every
  assertion's matcher and expected value survived the diff byte-identical
  (independently re-verified by the task reviewer, not just claimed).
- **One of six named API error codes was probed.** `journals-api.test.ts`
  asserts six distinct error codes; only one was verified with an actual
  break/confirm-red probe. The other five are unprobed — recorded here
  rather than filled, per the campaign's "record gaps for Phase 4.5, don't
  fill them mid-sweep" rule.
- **`ShelfEditSubpage.test.ts` behaves as predicted, not as hoped.** The
  conversion was expected to surface a pre-existing gap and it did; treated
  as information, not churn, and left as-is.
- **`journals-api.test.ts`'s un-ready-index cases kept a local builder**
  rather than converting fully — flagged as possibly unconvertible going
  in; the local builder stays until a later sweep revisits it.

## Fixed after the first review round

- `journals-api.test.ts:207-210` — a comment claimed the result "must come
  from the write, not a lookup" above an assertion that no longer
  discriminated. The obvious remedy (give the journal a `folder` so the paths
  diverge) turns out **not to work**: `#pathOf` → `#renderedPath` → `pathFor`
  operates on the metadata, not on the existing path, so a folder is honoured
  on both branches. Only the `file` assertion diverges, so the comment moved
  onto it.
- `scanned-note.test.ts:43` — a blanket `getFileCache.mockReturnValue(null)`
  made the `putFile` on `:40` decorative, so the test could not distinguish
  "file absent" from "file present but unparsed." Now scoped by path via the
  `leaveUnparsed` helper the sibling `scan-service.test.ts` already had, with
  an added assertion that the cache was actually consulted.

## Deferred minors (for the reviewer to triage)

- `journals-api.test.ts:290-293,309-312` — four consecutive
  `await Promise.resolve()` where the suite idiom elsewhere is two, or a
  named `flush()`.
- `scan-service.test.ts:287` — discards `repository.update`'s `Result`;
  `expectOk` costs nothing to add.
- `DeleteCommandModal`'s test wires `[commandsCoreModule]` though the
  component only injects `useModal()` — harmless, matches the
  `DeleteShelfModal` sibling, but inconsistent with the narrowing rationale
  used for the other two command modals in the same file set.
- `buildApi` installs the `Flows.invoke` spy for all 31 `api` tests
  including the 20 that never read it — harmless call-through, not fixed.
- Several `toEqual(buildShelf(...))`-shaped self-referential assertions in
  the shelves suite (matches the journals precedent; a campaign-wide
  trade-off, not new here).
- Report-transcription nits with no code impact (two selector error
  messages transcribed without trailing periods in an earlier task report;
  a view-model test file's line count was off by one in another).

## Gates run for this PR

- `npm test` — **395 test files / 4196 tests**, exact match to the pre-sweep
  baseline.
- `npm run coverage` — passes at the newly-set floor (92.19/87.86/89.12/94.31);
  see the table above for full attribution.
- `npm run check:types`, `npm run check:lint`, `npm run check:i18n` — clean
  (lint: 0 errors, 11 pre-existing warnings elsewhere in the repo, none
  attributable to this PR, none in the four converted directories).
- Conversion greps (`new Container()`, `fakeRepo`/`fakeShelvesRepo`/
  `createSettingsService`, `provideInjectorOnApp`) — **zero matches** across
  `src/shelves`, `src/commands`, `src/maintenance`, `src/api`.
- Deletion targets confirmed still present (this PR does not remove them —
  that's the closing PR, sweep 7): `fakeRepo` (`journals/testing.ts:16`),
  `fakeShelvesRepo` (`shelves/testing.ts:12`), `createSettingsService`
  (`settings/testing.ts:35`), `CommandsRepository.fromParts`
  (`commands/repository.ts:22`), `CommandsViewModel.fromRepository`
  (`commands/view-model.ts:11`).
- **e2e — targeted, not full-suite.** A known local-environment issue wedges
  headed full-suite e2e runs in ways CI does not reproduce (recorded in
  project memory from an earlier sweep), so a local full-suite run is not
  treated as evidence either way. Ran the suites most likely to catch a
  module-split regression instead, after confirming no `npm run dev`
  watcher was live:
  - `e2e/smoke/plugin-activates.e2e.ts` — 2/2 passing.
  - `e2e/journeys/commands.e2e.ts`, `available-command.e2e.ts`,
    `default-commands.e2e.ts`, `dynamic-commands.e2e.ts` — 15/15 passing.
    These exercise `DynamicCommandRegistry` directly, which moved from
    first to last registration in the split.
  - `e2e/migration/vault-check.e2e.ts` — 1/1 passing (maintenance).
  - `e2e/journeys/settings.e2e.ts` — 29/33 passing. The shelves and
    commands sub-suites inside this file (rename/delete/move a shelf,
    place a journal on a shelf, edit/delete a command) all passed. Four
    unrelated tests failed: three "view editor drag reorder" specs
    (SortableJS drag) hit `chromedriver` renderer timeouts
    ("Timed out receiving message from renderer", `querySelector` on
    `undefined`) and one decorations spec ("the 'rating' property was
    never suggested") — none of these touch shelves, commands, or
    maintenance code, and the failure shape (timeouts, stale-element
    errors, a `querySelector` crash) matches the known local headed-runner
    wedge, not a module-split regression. **Treated as unverified locally,
    not as a passing or failing verdict** — CI is the authoritative e2e
    gate for this PR.

## Known follow-ups for the campaign (recorded in the charter)

- The seed guard (`TestContainerInvalidSeedError`) rejects any
  repair-warning log unconditionally, which caps what a break-probe can
  prove for any repair-path test across every remaining sweep — not unique
  to shelves.
- The fixture-factory lint selector matches `build`+`View`, so a legitimate
  `buildViewModel` helper trips it; the views sweep will hit this directly
  (`resolveViewModel` is the workaround used in this PR's `view-model.test.ts`).
- `JournalsDashboardBlock`-shaped components need a third module
  (`journalsSettingsUiModule`) because `journalEditSubpage` registers
  there; the views and decorations sweeps will hit the same shape.
- Six maintenance harness findings (fake-timer interaction, the
  `resetInverters`/inverter-cache/concurrent-metadata-wait/`clearMutator`
  probes, positional-intent pairing, duplicate group keys) are written into
  the charter for sweeps 2-6 to reuse rather than rediscover.
- Sweep 1 carried three module splits in one PR against the charter's
  planned cap of two (see "Rulings that changed the work" above); the
  charter's cap is corrected in the same edit as this PR's coverage-floor
  fix.

## Checklist

- [x] `npm run check:types` passes
- [x] `npm test` passes (395/4196, exact)
- [x] `npm run check:lint` passes (0 errors; 11 pre-existing warnings, none from this PR)
- [x] `npm run check:i18n` passes (11 locales, no violations)
- [ ] the e2e per-suite scripts pass — targeted suites run locally and pass except four
      unrelated failures attributed to a known local renderer wedge (see above); CI is
      the authoritative verdict
- [x] User-facing copy is in `messages/en.json` only (no user-facing copy changed)
- [x] `CHANGELOG.md` — no entry: this PR changes only test wiring and internal module
      boundaries, nothing user-visible
