### PR TITLE
test(calendar): sweep 2 — move src/calendar onto testContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 
 - Journals created in the same session no longer share one navigation block, interval block, and set of decorations. Editing the navigation block of one daily journal used to change every daily journal created alongside it in that session, and a journal created after such an edit was born carrying it; restarting Obsidian separated them again, so journals created in different sessions were never affected. A journal already changed this way keeps the settings it ended up with — check the navigation blocks and decorations of journals you created together, and set them back by hand where they are wrong.
+- A fresh install no longer logs a repair warning at startup for settings it has never saved. Having no stored value yet was being treated the same as a corrupted one, so a brand-new install's log read as if its settings were already damaged.
 
 ## [3.2.0] - 2026-08-23
 

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -46,6 +46,7 @@ words:
   - vueuse
   - wdio
   - wikilinks
+  - worktree
 ignorePaths:
   - node_modules
   - build

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,6 +33,7 @@ const convertedTestGlobs = [
   "src/commands/**/*.test.ts",
   "src/maintenance/**/*.test.ts",
   "src/api/**/*.test.ts",
+  "src/calendar/**/*.test.ts",
 ];
 
 // `no-restricted-syntax` options replace rather than merge, so this array must carry

--- a/src/calendar/calendar-date.test.ts
+++ b/src/calendar/calendar-date.test.ts
@@ -1,23 +1,13 @@
-import { afterEach, beforeEach, describe, expect, expectTypeOf, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 
 import { expectErr, expectOk } from "@/infrastructure/result/testing";
 
 import { CalendarDate } from "./calendar-date";
-import { anchor, installTestCalendar } from "./testing";
+import { anchor } from "./testing";
 
 import type { AnchorString } from "./types";
 
 describe("CalendarDate", () => {
-  let teardown: () => void;
-
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-
-  afterEach(() => {
-    teardown();
-  });
-
   describe("today", () => {
     it("returns a CalendarDate whose anchor matches the current local date", () => {
       const today = CalendarDate.today();

--- a/src/calendar/clock.test.ts
+++ b/src/calendar/clock.test.ts
@@ -1,16 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Clock } from "./clock";
-import { installTestCalendar } from "./testing";
 
 describe("Clock", () => {
-  let teardown: () => void;
-
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
   afterEach(() => {
-    teardown();
     vi.useRealTimers();
   });
 

--- a/src/calendar/date-input.test.ts
+++ b/src/calendar/date-input.test.ts
@@ -1,7 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { parseDateExpression } from "./date-input";
-import { installTestCalendar } from "./testing";
 
 function parsed(input: string): string | null {
   const result = parseDateExpression(input);
@@ -9,16 +8,6 @@ function parsed(input: string): string | null {
 }
 
 describe("parseDateExpression", () => {
-  let teardown: () => void;
-
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-
-  afterEach(() => {
-    teardown();
-  });
-
   it("parses an absolute anchor", () => {
     expect(parsed("2026-08-18")).toBe("2026-08-18");
   });

--- a/src/calendar/errors.test.ts
+++ b/src/calendar/errors.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { DateTimeError, IntervalError, ParseError } from "./errors";
-import { date, installTestCalendar } from "./testing";
+import { date } from "./testing";
 
 describe("ParseError", () => {
   it("formats the message without a format hint when none is given", () => {
@@ -33,14 +33,6 @@ describe("DateTimeError", () => {
 });
 
 describe("IntervalError", () => {
-  let teardown: () => void;
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-  });
-
   it("formats the message with both anchor strings", () => {
     const error = new IntervalError(date("2025-03-15"), date("2025-03-14"));
 

--- a/src/calendar/interval.test.ts
+++ b/src/calendar/interval.test.ts
@@ -1,19 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { expectErr, expectOk } from "@/infrastructure/result/testing";
 
 import { Interval } from "./interval";
-import { date, installTestCalendar } from "./testing";
+import { date } from "./testing";
 
 describe("Interval", () => {
-  let teardown: () => void;
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-  });
-
   describe("between", () => {
     it("returns Ok with start preserved when start <= end", () => {
       const result = Interval.between(date("2025-03-10"), date("2025-03-15"));

--- a/src/calendar/open-interval.test.ts
+++ b/src/calendar/open-interval.test.ts
@@ -1,20 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { expectErr, expectOk } from "@/infrastructure/result/testing";
 
 import { OpenInterval } from "./open-interval";
 import { MonthPeriod } from "./period-month";
-import { date, installTestCalendar } from "./testing";
+import { date } from "./testing";
 
 describe("OpenInterval", () => {
-  let teardown: () => void;
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-  });
-
   describe("from", () => {
     it("creates an interval with Some start", () => {
       expect(OpenInterval.from(date("2025-03-10")).start.isSome()).toBe(true);

--- a/src/calendar/period-day.test.ts
+++ b/src/calendar/period-day.test.ts
@@ -1,18 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { DayPeriod } from "./period-day";
-import { date, installTestCalendar } from "./testing";
+import { date } from "./testing";
 
 describe("DayPeriod", () => {
-  let teardown: () => void;
-
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-  });
-
   describe("containing", () => {
     it("uses the given date as start", () => {
       expect(DayPeriod.containing(date("2025-03-14")).start.toAnchor()).toBe("2025-03-14");

--- a/src/calendar/period-decade.test.ts
+++ b/src/calendar/period-decade.test.ts
@@ -1,18 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { DecadePeriod } from "./period-decade";
-import { date, installTestCalendar } from "./testing";
+import { date } from "./testing";
 
 describe("DecadePeriod", () => {
-  let teardown: () => void;
-
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-  });
-
   describe("containing", () => {
     it("starts on January 1 of the floor-of-10 year", () => {
       expect(DecadePeriod.containing(date("2025-05-15")).start.toAnchor()).toBe("2020-01-01");

--- a/src/calendar/period-month.test.ts
+++ b/src/calendar/period-month.test.ts
@@ -1,18 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { MonthPeriod } from "./period-month";
-import { date, installTestCalendar } from "./testing";
+import { date } from "./testing";
 
 describe("MonthPeriod", () => {
-  let teardown: () => void;
-
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-  });
-
   describe("containing", () => {
     it("starts on the first of the month", () => {
       expect(MonthPeriod.containing(date("2025-03-14")).start.toAnchor()).toBe("2025-03-01");

--- a/src/calendar/period-quarter.test.ts
+++ b/src/calendar/period-quarter.test.ts
@@ -1,18 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { QuarterPeriod } from "./period-quarter";
-import { date, installTestCalendar } from "./testing";
+import { date } from "./testing";
 
 describe("QuarterPeriod", () => {
-  let teardown: () => void;
-
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-  });
-
   describe("containing", () => {
     it("starts on the first day of the first month of the quarter", () => {
       expect(QuarterPeriod.containing(date("2025-05-15")).start.toAnchor()).toBe("2025-04-01");

--- a/src/calendar/period-week.test.ts
+++ b/src/calendar/period-week.test.ts
@@ -1,18 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { WeekPeriod } from "./period-week";
 import { date, installTestCalendar } from "./testing";
 
 describe("WeekPeriod", () => {
-  let teardown: () => void;
-
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-  });
-
   describe("containing", () => {
     it("spans Monday to start", () => {
       expect(WeekPeriod.containing(date("2025-03-14")).start.toAnchor()).toBe("2025-03-10");
@@ -46,8 +37,7 @@ describe("WeekPeriod", () => {
     // so only the day six into the week is still inside January 1-7 of the week-year no matter
     // which weekday January 1 lands on.
     it("is the Saturday inside a Sunday-start week under dow=0, doy=6", () => {
-      teardown();
-      ({ teardown } = installTestCalendar({ dow: 0, doy: 6 }));
+      installTestCalendar({ dow: 0, doy: 6 });
 
       expect(WeekPeriod.containing(date("2025-03-14")).representative.toAnchor()).toBe("2025-03-15");
     });
@@ -157,8 +147,7 @@ describe("WeekPeriod", () => {
     });
 
     it("resolves the same week to its Sunday under a Sunday-start grid", () => {
-      teardown();
-      ({ teardown } = installTestCalendar({ dow: 0, doy: 6 }));
+      installTestCalendar({ dow: 0, doy: 6 });
       expect(WeekPeriod.ofWeek(2026, 23).anchor.toAnchor()).toBe("2026-05-31");
     });
 
@@ -170,29 +159,25 @@ describe("WeekPeriod", () => {
 
   describe("non-ISO locale", () => {
     it("uses Sunday-start week when configured with dow=0", () => {
-      teardown();
-      ({ teardown } = installTestCalendar({ dow: 0, doy: 6 }));
+      installTestCalendar({ dow: 0, doy: 6 });
 
       expect(WeekPeriod.containing(date("2025-03-14")).start.toAnchor()).toBe("2025-03-09");
     });
 
     it("ends Saturday when Sunday-start", () => {
-      teardown();
-      ({ teardown } = installTestCalendar({ dow: 0, doy: 6 }));
+      installTestCalendar({ dow: 0, doy: 6 });
 
       expect(WeekPeriod.containing(date("2025-03-14")).end.toAnchor()).toBe("2025-03-15");
     });
 
     it("anchor is the Sunday for a Sun-start week under dow=0, doy=6", () => {
-      teardown();
-      ({ teardown } = installTestCalendar({ dow: 0, doy: 6 }));
+      installTestCalendar({ dow: 0, doy: 6 });
 
       expect(WeekPeriod.containing(date("2025-03-14")).anchor.toAnchor()).toBe("2025-03-09");
     });
 
     it("year returns owning year for a cross-year week under dow=0, doy=6", () => {
-      teardown();
-      ({ teardown } = installTestCalendar({ dow: 0, doy: 6 }));
+      installTestCalendar({ dow: 0, doy: 6 });
 
       // Week containing 2025-12-31: starts Sun 2025-12-28, ends Sat 2026-01-03,
       // owning day (Friday) is 2026-01-02 → owning year is 2026.
@@ -200,8 +185,7 @@ describe("WeekPeriod", () => {
     });
 
     it("representative.year matches year for the cross-year week under dow=0, doy=6", () => {
-      teardown();
-      ({ teardown } = installTestCalendar({ dow: 0, doy: 6 }));
+      installTestCalendar({ dow: 0, doy: 6 });
 
       const week = WeekPeriod.containing(date("2025-12-31"));
 
@@ -212,8 +196,7 @@ describe("WeekPeriod", () => {
     // furthest to reach. The 2025-12-31 week above puts it mid-week, so it passes under
     // any offset from 4 through 6 and cannot distinguish a wrong one.
     it("representative.year matches year when January 1 falls on the week's last day", () => {
-      teardown();
-      ({ teardown } = installTestCalendar({ dow: 0, doy: 6 }));
+      installTestCalendar({ dow: 0, doy: 6 });
 
       const week = WeekPeriod.containing(date("2021-12-28"));
 
@@ -221,8 +204,7 @@ describe("WeekPeriod", () => {
     });
 
     it("representative falls inside the week under dow=6, doy=12", () => {
-      teardown();
-      ({ teardown } = installTestCalendar({ dow: 6, doy: 12 }));
+      installTestCalendar({ dow: 6, doy: 12 });
 
       const week = WeekPeriod.containing(date("2025-03-10"));
 
@@ -231,8 +213,7 @@ describe("WeekPeriod", () => {
     });
 
     it("representative.year matches year for a cross-year week under dow=6, doy=12", () => {
-      teardown();
-      ({ teardown } = installTestCalendar({ dow: 6, doy: 12 }));
+      installTestCalendar({ dow: 6, doy: 12 });
 
       const week = WeekPeriod.containing(date("2021-12-28"));
 

--- a/src/calendar/period-year.test.ts
+++ b/src/calendar/period-year.test.ts
@@ -1,18 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { YearPeriod } from "./period-year";
-import { date, installTestCalendar } from "./testing";
+import { date } from "./testing";
 
 describe("YearPeriod", () => {
-  let teardown: () => void;
-
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-  });
-
   describe("containing", () => {
     it("starts on January 1", () => {
       expect(YearPeriod.containing(date("2025-05-15")).start.toAnchor()).toBe("2025-01-01");

--- a/src/calendar/period.test.ts
+++ b/src/calendar/period.test.ts
@@ -1,8 +1,8 @@
 import { match } from "ts-pattern";
-import { afterEach, beforeEach, describe, expect, expectTypeOf, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 
 import { advance, periodKinds, periodOfKind, window } from "./period";
-import { date, installTestCalendar } from "./testing";
+import { date } from "./testing";
 
 import type { Period, PeriodKind } from "./period";
 import type { DayPeriod } from "./period-day";
@@ -51,15 +51,6 @@ describe("Period union", () => {
 });
 
 describe("periodOfKind", () => {
-  let teardown: () => void;
-
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-  });
-
   it("returns a period tagged with the requested kind", () => {
     for (const kind of periodKinds) {
       expect(periodOfKind(kind, date("2025-03-14")).kind).toBe(kind);
@@ -72,14 +63,6 @@ describe("periodOfKind", () => {
 });
 
 describe("advance", () => {
-  let teardown: () => void;
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-  });
-
   it("returns the same period for zero steps", () => {
     const start = periodOfKind("month", date("2025-03-14"));
     expect(advance(start, 0).start.toAnchor()).toBe("2025-03-01");
@@ -97,14 +80,6 @@ describe("advance", () => {
 });
 
 describe("window", () => {
-  let teardown: () => void;
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-  });
-
   it("returns before + after + 1 periods", () => {
     const focus = periodOfKind("month", date("2025-03-14"));
     expect(window(focus, 2, 1)).toHaveLength(4);

--- a/src/calendar/settings/bridge.test.ts
+++ b/src/calendar/settings/bridge.test.ts
@@ -1,84 +1,76 @@
-import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
+import { beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
+import { nextTick } from "vue";
 
-import type { Container } from "@/infrastructure/di";
-import { createSettingsService } from "@/settings/testing";
-
-import { Calendar } from "../calendar";
+import type { Calendar } from "@/calendar";
+import { testCalendar } from "@/calendar/testing";
+import { testContainer } from "@/testing";
 
 import { CalendarSettingsBridge } from "./bridge";
+import { calendarSettingsCoreModule } from "./module";
 import { calendarSlice } from "./slice";
 
-import type { CalendarSliceState } from "./slice";
-
 describe("CalendarSettingsBridge", () => {
-  let container: Container;
-  let calendar: Calendar;
   let applySpy: MockInstance<Calendar["applyWeekConfig"]>;
 
-  function build(raw?: { calendar?: CalendarSliceState }) {
-    const settings = createSettingsService({
-      slices: [calendarSlice],
-      raw: raw === undefined ? undefined : { version: 3, ...raw },
-    });
-    container = settings.container;
-    calendar = new Calendar();
-    container.register(Calendar).useValue(calendar);
-    applySpy = vi.spyOn(calendar, "applyWeekConfig");
-    container.register(CalendarSettingsBridge).useClass(CalendarSettingsBridge);
-    return { settings: settings.service };
-  }
-
   beforeEach(() => {
-    applySpy?.mockReset();
-  });
-
-  afterEach(() => {
-    void container?.dispose().catch(() => null);
+    applySpy = vi.spyOn(testCalendar(), "applyWeekConfig");
+    applySpy.mockClear();
   });
 
   it('pushes "locale" on first construction when slice defaults to locale', async () => {
-    const { settings } = build();
-    await settings.initialize();
-    container.resolve(CalendarSettingsBridge);
+    await testContainer({
+      modules: [calendarSettingsCoreModule],
+      data: { calendar: { mode: "locale" }, calendarDisplay: {} },
+    });
     expect(applySpy).toHaveBeenCalledWith("locale", { propagateToGlobal: false });
   });
 
   it("pushes the custom week when the slice changes to custom", async () => {
-    const { settings } = build();
-    await settings.initialize();
-    container.resolve(CalendarSettingsBridge);
+    const harness = await testContainer({
+      modules: [calendarSettingsCoreModule],
+      data: { calendar: { mode: "locale" }, calendarDisplay: {} },
+    });
     applySpy.mockClear();
-    settings.getSlice(calendarSlice).state = { mode: "custom", dow: 0, doy: 6, global: false };
-    await Promise.resolve();
+    harness.settings.getSlice(calendarSlice).state = { mode: "custom", dow: 0, doy: 6, global: false };
+    await nextTick();
     expect(applySpy).toHaveBeenCalledWith({ dow: 0, doy: 6 }, { propagateToGlobal: false });
   });
 
   it("propagates the global flag when slice global is true", async () => {
-    const { settings } = build();
-    await settings.initialize();
-    container.resolve(CalendarSettingsBridge);
+    const harness = await testContainer({
+      modules: [calendarSettingsCoreModule],
+      data: { calendar: { mode: "locale" }, calendarDisplay: {} },
+    });
     applySpy.mockClear();
-    settings.getSlice(calendarSlice).state = { mode: "custom", dow: 1, doy: 4, global: true };
-    await Promise.resolve();
+    harness.settings.getSlice(calendarSlice).state = { mode: "custom", dow: 1, doy: 4, global: true };
+    await nextTick();
     expect(applySpy).toHaveBeenCalledWith({ dow: 1, doy: 4 }, { propagateToGlobal: true });
   });
 
   it('pushes "locale" again when slice reverts to locale', async () => {
-    const { settings } = build({ calendar: { mode: "custom", dow: 1, doy: 4, global: false } });
-    await settings.initialize();
-    container.resolve(CalendarSettingsBridge);
+    const harness = await testContainer({
+      modules: [calendarSettingsCoreModule],
+      data: { calendar: { mode: "custom", dow: 1, doy: 4, global: false }, calendarDisplay: {} },
+    });
     applySpy.mockClear();
-    settings.getSlice(calendarSlice).state = { mode: "locale" };
-    await Promise.resolve();
+    harness.settings.getSlice(calendarSlice).state = { mode: "locale" };
+    await nextTick();
     expect(applySpy).toHaveBeenCalledWith("locale", { propagateToGlobal: false });
   });
 
   it("does not crash when constructed before SettingsService.initialize", async () => {
-    const { settings } = build();
-    container.resolve(CalendarSettingsBridge);
-    expect(applySpy).not.toHaveBeenCalled();
-    await settings.initialize();
-    await Promise.resolve();
+    let callsAtConstruction = -1;
+    await testContainer({
+      modules: [calendarSettingsCoreModule],
+      data: { calendar: { mode: "locale" }, calendarDisplay: {} },
+      overrides: [
+        (container) => {
+          container.resolve(CalendarSettingsBridge);
+          callsAtConstruction = applySpy.mock.calls.length;
+        },
+      ],
+    });
+    expect(callsAtConstruction).toBe(0);
     expect(applySpy).toHaveBeenCalledWith("locale", { propagateToGlobal: false });
   });
 });

--- a/src/calendar/settings/bridge.test.ts
+++ b/src/calendar/settings/bridge.test.ts
@@ -57,6 +57,8 @@ describe("CalendarSettingsBridge", () => {
     let callsAtConstruction = -1;
     await testContainer({
       modules: [calendarSettingsCoreModule],
+      // `overrides` runs before `settings.initialize()`, not just before `autoLoad` — that's
+      // the window this test needs to force construction ahead of initialize.
       overrides: [
         (container) => {
           container.resolve(CalendarSettingsBridge);

--- a/src/calendar/settings/bridge.test.ts
+++ b/src/calendar/settings/bridge.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
 import { nextTick } from "vue";
 
 import type { Calendar } from "@/calendar";
@@ -17,19 +17,17 @@ describe("CalendarSettingsBridge", () => {
     applySpy.mockClear();
   });
 
+  afterEach(() => {
+    applySpy.mockRestore();
+  });
+
   it('pushes "locale" on first construction when slice defaults to locale', async () => {
-    await testContainer({
-      modules: [calendarSettingsCoreModule],
-      data: { calendar: { mode: "locale" }, calendarDisplay: {} },
-    });
+    await testContainer({ modules: [calendarSettingsCoreModule] });
     expect(applySpy).toHaveBeenCalledWith("locale", { propagateToGlobal: false });
   });
 
   it("pushes the custom week when the slice changes to custom", async () => {
-    const harness = await testContainer({
-      modules: [calendarSettingsCoreModule],
-      data: { calendar: { mode: "locale" }, calendarDisplay: {} },
-    });
+    const harness = await testContainer({ modules: [calendarSettingsCoreModule] });
     applySpy.mockClear();
     harness.settings.getSlice(calendarSlice).state = { mode: "custom", dow: 0, doy: 6, global: false };
     await nextTick();
@@ -37,10 +35,7 @@ describe("CalendarSettingsBridge", () => {
   });
 
   it("propagates the global flag when slice global is true", async () => {
-    const harness = await testContainer({
-      modules: [calendarSettingsCoreModule],
-      data: { calendar: { mode: "locale" }, calendarDisplay: {} },
-    });
+    const harness = await testContainer({ modules: [calendarSettingsCoreModule] });
     applySpy.mockClear();
     harness.settings.getSlice(calendarSlice).state = { mode: "custom", dow: 1, doy: 4, global: true };
     await nextTick();
@@ -50,7 +45,7 @@ describe("CalendarSettingsBridge", () => {
   it('pushes "locale" again when slice reverts to locale', async () => {
     const harness = await testContainer({
       modules: [calendarSettingsCoreModule],
-      data: { calendar: { mode: "custom", dow: 1, doy: 4, global: false }, calendarDisplay: {} },
+      data: { calendar: { mode: "custom", dow: 1, doy: 4, global: false } },
     });
     applySpy.mockClear();
     harness.settings.getSlice(calendarSlice).state = { mode: "locale" };
@@ -62,7 +57,6 @@ describe("CalendarSettingsBridge", () => {
     let callsAtConstruction = -1;
     await testContainer({
       modules: [calendarSettingsCoreModule],
-      data: { calendar: { mode: "locale" }, calendarDisplay: {} },
       overrides: [
         (container) => {
           container.resolve(CalendarSettingsBridge);

--- a/src/calendar/settings/module.ts
+++ b/src/calendar/settings/module.ts
@@ -1,22 +1,22 @@
 import type { Module } from "@/infrastructure/di";
-import { DashboardBlockToken, SliceDefinitionToken, defineDashboardBlock } from "@/settings";
+import { SliceDefinitionToken } from "@/settings";
 
 import { CalendarSettingsBridge } from "./bridge";
 import { calendarDisplaySlice } from "./display-slice";
 import { calendarSlice } from "./slice";
-import CalendarWeekBlock from "./ui/CalendarWeekBlock.vue";
+import { calendarSettingsUiModule } from "./ui-module";
 
-export const calendarSettingsModule: Module = {
+export const calendarSettingsCoreModule: Module = {
   register(c) {
     c.register(SliceDefinitionToken).useValue(calendarSlice);
     c.register(SliceDefinitionToken).useValue(calendarDisplaySlice);
-    c.register(DashboardBlockToken).useValue(
-      defineDashboardBlock({
-        key: "calendar-week",
-        component: CalendarWeekBlock,
-        order: 10,
-      }),
-    );
     c.register(CalendarSettingsBridge).useClass(CalendarSettingsBridge).eager();
+  },
+};
+
+export const calendarSettingsModule: Module = {
+  register(c) {
+    calendarSettingsCoreModule.register(c);
+    calendarSettingsUiModule.register(c);
   },
 };

--- a/src/calendar/settings/ui-module.ts
+++ b/src/calendar/settings/ui-module.ts
@@ -1,0 +1,16 @@
+import type { Module } from "@/infrastructure/di";
+import { DashboardBlockToken, defineDashboardBlock } from "@/settings";
+
+import CalendarWeekBlock from "./ui/CalendarWeekBlock.vue";
+
+export const calendarSettingsUiModule: Module = {
+  register(c) {
+    c.register(DashboardBlockToken).useValue(
+      defineDashboardBlock({
+        key: "calendar-week",
+        component: CalendarWeekBlock,
+        order: 10,
+      }),
+    );
+  },
+};

--- a/src/calendar/settings/ui/CalendarWeekBlock.test.ts
+++ b/src/calendar/settings/ui/CalendarWeekBlock.test.ts
@@ -1,14 +1,15 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen, within } from "@testing-library/vue";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { screen, within } from "@testing-library/vue";
+import { describe, expect, it, vi } from "vitest";
 
-import { Calendar, WeekPresetApplierToken } from "@/calendar";
+import { WeekPresetApplierToken } from "@/calendar";
+import { calendarSettingsCoreModule } from "@/calendar/settings/module";
 import { m } from "@/i18n";
-import { provideInjectorOnApp, type Container } from "@/infrastructure/di";
-import { ModalService } from "@/infrastructure/host/modals";
 import { AsyncResult } from "@/infrastructure/result";
-import { ReloadHintService } from "@/settings";
-import { createSettingsService } from "@/settings/testing";
+import { journalsCoreModule } from "@/journals/module";
+import { journalsSettingsCoreModule } from "@/journals/settings/module";
+import { ReloadHintService, type SettingsService } from "@/settings";
+import { overrideWith, testContainer, type TestHarness } from "@/testing";
 
 import { calendarDisplaySlice } from "../display-slice";
 import { calendarSlice } from "../slice";
@@ -18,49 +19,27 @@ import { weekPresetPickerModal } from "./modals";
 
 import type { CalendarSliceState } from "../slice";
 
-function setupContainer(initial?: CalendarSliceState) {
-  const raw = initial ? { version: 5, calendar: initial } : undefined;
-  const settings = createSettingsService({ slices: [calendarSlice, calendarDisplaySlice], raw });
-  const container = settings.container;
-
-  const modalService = {
-    open: vi.fn(),
-  } as unknown as ModalService;
-  container.register(ModalService).useValue(modalService);
-  container.register(Calendar).useValue(new Calendar());
-  container.register(ReloadHintService).useClass(ReloadHintService);
+async function setupContainer(initial?: CalendarSliceState): Promise<{
+  harness: TestHarness;
+  applier: { apply: ReturnType<typeof vi.fn> };
+}> {
+  let settings!: SettingsService;
   // Mirrors WeekPresetService.apply: the real applier writes the slice synchronously before
   // it awaits the re-anchor, so reload-hint tests stay sensitive to call order against a
   // stub that does the same.
   const applier = {
     apply: vi.fn((next: CalendarSliceState) => {
-      settings.service.getSlice(calendarSlice).state = next;
+      settings.getSlice(calendarSlice).state = next;
       return AsyncResult.ok();
     }),
   };
-  container.register(WeekPresetApplierToken).useValue(applier);
-
-  return {
-    container,
-    settings: settings.service,
-    modalService,
-    reloadHint: container.resolve(ReloadHintService),
-    applier,
-  };
-}
-
-function mount(container: Container) {
-  return render(CalendarWeekBlock, {
-    global: {
-      plugins: [
-        {
-          install(app) {
-            provideInjectorOnApp(app, container);
-          },
-        },
-      ],
-    },
+  const harness = await testContainer({
+    modules: [journalsCoreModule, journalsSettingsCoreModule, calendarSettingsCoreModule],
+    data: { calendar: initial ?? { mode: "locale" }, calendarDisplay: {} },
+    overrides: [overrideWith(WeekPresetApplierToken, applier)],
   });
+  settings = harness.settings;
+  return { harness, applier };
 }
 
 async function openSection(): Promise<void> {
@@ -74,65 +53,54 @@ function toggleInRow(name: string): HTMLElement {
   return within(row as HTMLElement).getByRole("checkbox");
 }
 
-afterEach(() => cleanup());
-
 describe("CalendarWeekBlock", () => {
   it("starts collapsed and hides the inner settings", async () => {
-    const { container, settings } = setupContainer();
-    await settings.initialize();
-    mount(container);
+    const { harness } = await setupContainer();
+    harness.render(CalendarWeekBlock);
     expect(screen.queryByText(m.calendar_week_config_change())).toBeNull();
   });
 
   it("renders the Change button once expanded", async () => {
-    const { container, settings } = setupContainer();
-    await settings.initialize();
-    mount(container);
+    const { harness } = await setupContainer();
+    harness.render(CalendarWeekBlock);
     await openSection();
     expect(screen.getByText(m.calendar_week_config_change())).toBeTruthy();
   });
 
   it("hides the global toggle when mode is locale", async () => {
-    const { container, settings } = setupContainer({ mode: "locale" });
-    await settings.initialize();
-    mount(container);
+    const { harness } = await setupContainer({ mode: "locale" });
+    harness.render(CalendarWeekBlock);
     await openSection();
     expect(screen.queryByText(m.calendar_apply_globally_title())).toBeNull();
   });
 
   it("shows the global toggle when mode is custom", async () => {
-    const { container, settings } = setupContainer({ mode: "custom", dow: 1, doy: 4, global: false });
-    await settings.initialize();
-    mount(container);
+    const { harness } = await setupContainer({ mode: "custom", dow: 1, doy: 4, global: false });
+    harness.render(CalendarWeekBlock);
     await openSection();
     expect(screen.getByText(m.calendar_apply_globally_title())).toBeTruthy();
   });
 
   it("opens the modal when Change is clicked", async () => {
-    const { container, settings, modalService } = setupContainer();
-    await settings.initialize();
-    const pending = new Promise<CalendarSliceState>(() => undefined);
-    (modalService.open as ReturnType<typeof vi.fn>).mockReturnValue(
-      AsyncResult.fromPromise(pending, () => new Error("never")),
-    );
-    mount(container);
+    const { harness } = await setupContainer();
+    harness.render(CalendarWeekBlock);
     await openSection();
     await userEvent.click(screen.getByText(m.calendar_week_config_change()));
-    expect(modalService.open).toHaveBeenCalledWith(weekPresetPickerModal, { current: { mode: "locale" } });
+    const opened = harness.modals.lastOpen<{ current: CalendarSliceState }, CalendarSliceState>();
+    expect(opened.definition).toBe(weekPresetPickerModal);
+    expect(opened.props).toEqual({ current: { mode: "locale" } });
   });
 
   it("shows the active preset name in the description", async () => {
-    const { container, settings } = setupContainer({ mode: "custom", dow: 1, doy: 4, global: false });
-    await settings.initialize();
-    mount(container);
+    const { harness } = await setupContainer({ mode: "custom", dow: 1, doy: 4, global: false });
+    harness.render(CalendarWeekBlock);
     await openSection();
     expect(screen.getByText(m.calendar_preset_name({ preset: "iso-8601" }))).toBeTruthy();
   });
 
   it("shows a dynamic summary when the current week settings do not match a named preset", async () => {
-    const { container, settings } = setupContainer({ mode: "custom", dow: 3, doy: 7, global: false });
-    await settings.initialize();
-    mount(container);
+    const { harness } = await setupContainer({ mode: "custom", dow: 3, doy: 7, global: false });
+    harness.render(CalendarWeekBlock);
     await openSection();
     expect(screen.getByText(m.calendar_preset_name({ preset: "custom" }))).toBeTruthy();
     expect(screen.getByText(/Wednesday/)).toBeTruthy();
@@ -140,70 +108,71 @@ describe("CalendarWeekBlock", () => {
   });
 
   it("flips slice.state.global when the apply-globally toggle is clicked", async () => {
-    const { container, settings } = setupContainer({ mode: "custom", dow: 1, doy: 4, global: false });
-    await settings.initialize();
-    mount(container);
+    const { harness } = await setupContainer({ mode: "custom", dow: 1, doy: 4, global: false });
+    harness.render(CalendarWeekBlock);
     await openSection();
     await userEvent.click(toggleInRow(m.calendar_apply_globally_title()));
-    const state = settings.getSlice(calendarSlice).state;
+    const state = harness.settings.getSlice(calendarSlice).state;
     expect(state).toEqual({ mode: "custom", dow: 1, doy: 4, global: true });
   });
 
   it("writes timelineNavigation to the display slice when its toggle is flipped", async () => {
-    const { container, settings } = setupContainer({ mode: "custom", dow: 1, doy: 4, global: false });
-    await settings.initialize();
-    mount(container);
+    const { harness } = await setupContainer({ mode: "custom", dow: 1, doy: 4, global: false });
+    harness.render(CalendarWeekBlock);
     await openSection();
 
     await userEvent.click(toggleInRow(m.calendar_timeline_navigation_label()));
 
-    expect(settings.getSlice(calendarDisplaySlice).state.timelineNavigation).toBe(true);
+    expect(harness.settings.getSlice(calendarDisplaySlice).state.timelineNavigation).toBe(true);
   });
 
   it("requests a reload when the apply-globally toggle is flipped", async () => {
-    const { container, settings, reloadHint } = setupContainer({ mode: "custom", dow: 1, doy: 4, global: false });
-    await settings.initialize();
-    mount(container);
+    const { harness } = await setupContainer({ mode: "custom", dow: 1, doy: 4, global: false });
+    harness.render(CalendarWeekBlock);
     await openSection();
     await userEvent.click(toggleInRow(m.calendar_apply_globally_title()));
-    expect(reloadHint.pending.value).toBe(true);
+    expect(harness.resolve(ReloadHintService).pending.value).toBe(true);
   });
 
   it("does not request a reload for a preset change that never touches the global patch", async () => {
-    const { container, settings, modalService, reloadHint } = setupContainer();
-    await settings.initialize();
-    (modalService.open as ReturnType<typeof vi.fn>).mockReturnValue(
-      AsyncResult.ok<CalendarSliceState>({ mode: "custom", dow: 0, doy: 6, global: false }),
-    );
-    mount(container);
+    const { harness, applier } = await setupContainer();
+    harness.render(CalendarWeekBlock);
     await openSection();
     await userEvent.click(screen.getByText(m.calendar_week_config_change()));
-    await Promise.resolve();
-    expect(reloadHint.pending.value).toBe(false);
+    harness.modals
+      .lastOpen<{ current: CalendarSliceState }, CalendarSliceState>()
+      .submit({ mode: "custom", dow: 0, doy: 6, global: false });
+    // The tap callback that requests the reload hint and hands off to the applier settles
+    // asynchronously across several promise hops; wait for the applier call as the signal
+    // that it has run before reading the (otherwise-default) reload-hint flag.
+    await vi.waitFor(() => expect(applier.apply).toHaveBeenCalled());
+    expect(harness.resolve(ReloadHintService).pending.value).toBe(false);
   });
 
   it("requests a reload when the picked preset turns the global patch on", async () => {
-    const { container, settings, modalService, reloadHint } = setupContainer();
-    await settings.initialize();
-    (modalService.open as ReturnType<typeof vi.fn>).mockReturnValue(
-      AsyncResult.ok<CalendarSliceState>({ mode: "custom", dow: 0, doy: 6, global: true }),
-    );
-    mount(container);
+    const { harness, applier } = await setupContainer();
+    harness.render(CalendarWeekBlock);
     await openSection();
     await userEvent.click(screen.getByText(m.calendar_week_config_change()));
-    await Promise.resolve();
-    expect(reloadHint.pending.value).toBe(true);
+    harness.modals
+      .lastOpen<{ current: CalendarSliceState }, CalendarSliceState>()
+      .submit({ mode: "custom", dow: 0, doy: 6, global: true });
+    await vi.waitFor(() => expect(applier.apply).toHaveBeenCalled());
+    expect(harness.resolve(ReloadHintService).pending.value).toBe(true);
   });
 
   it("hands the picked preset to the applier", async () => {
-    const { container, settings, modalService, applier } = setupContainer();
-    await settings.initialize();
-    vi.mocked(modalService.open).mockReturnValue(AsyncResult.ok({ mode: "custom", dow: 0, doy: 6, global: false }));
-    mount(container);
+    const { harness, applier } = await setupContainer();
+    harness.render(CalendarWeekBlock);
     await openSection();
 
     await userEvent.click(screen.getByText(m.calendar_week_config_change()));
+    harness.modals
+      .lastOpen<{ current: CalendarSliceState }, CalendarSliceState>()
+      .submit({ mode: "custom", dow: 0, doy: 6, global: false });
 
-    expect(applier.apply).toHaveBeenCalledWith({ mode: "custom", dow: 0, doy: 6, global: false });
+    await vi.waitFor(() =>
+      expect(applier.apply).toHaveBeenCalledWith({ mode: "custom", dow: 0, doy: 6, global: false }),
+    );
   });
 });

--- a/src/calendar/settings/ui/WeekPresetPickerModal.test.ts
+++ b/src/calendar/settings/ui/WeekPresetPickerModal.test.ts
@@ -1,39 +1,20 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/vue";
+import { describe, expect, it, vi } from "vitest";
 
 import { Calendar } from "@/calendar";
 import { m } from "@/i18n";
-import { Container, provideInjectorOnApp } from "@/infrastructure/di";
-import type { ModalApi } from "@/infrastructure/host/modals";
-import { provideModalApiOnApp } from "@/infrastructure/host/modals/testing";
+import { testContainer } from "@/testing";
 
 import WeekPresetPickerModal from "./WeekPresetPickerModal.vue";
 
 import type { CalendarSliceState } from "../slice";
 
-function mountModal(
-  current: CalendarSliceState,
-  api: ModalApi<CalendarSliceState>,
-  localeWeek?: { dow: number; doy: number },
-) {
-  const container = new Container();
-  const calendar = new Calendar();
-  vi.spyOn(calendar, "localeWeek").mockReturnValue(localeWeek ?? { dow: 1, doy: 4 });
-  container.register(Calendar).useValue(calendar);
-
-  return render(WeekPresetPickerModal, {
+async function resolveModal(current: CalendarSliceState, localeWeek?: { dow: number; doy: number }) {
+  const harness = await testContainer();
+  vi.spyOn(harness.resolve(Calendar), "localeWeek").mockReturnValue(localeWeek ?? { dow: 1, doy: 4 });
+  return harness.renderModal<typeof WeekPresetPickerModal, CalendarSliceState>(WeekPresetPickerModal, {
     props: { current },
-    global: {
-      plugins: [
-        {
-          install(app) {
-            provideInjectorOnApp(app, container);
-            provideModalApiOnApp(app, api as ModalApi<unknown>);
-          },
-        },
-      ],
-    },
   });
 }
 
@@ -44,34 +25,29 @@ function rowFor(name: string): HTMLElement {
   return row as HTMLElement;
 }
 
-afterEach(() => cleanup());
-
 describe("WeekPresetPickerModal", () => {
   it("submits the ISO 8601 preset when its Use button is clicked then Update is pressed", async () => {
-    const api: ModalApi<CalendarSliceState> = { submit: vi.fn(), cancel: vi.fn() };
-    mountModal({ mode: "locale" }, api);
+    const { submit } = await resolveModal({ mode: "locale" });
 
     const useButton = rowFor(m.calendar_preset_name({ preset: "iso-8601" })).querySelector("button");
     await userEvent.click(useButton!);
     await userEvent.click(screen.getByText(m.calendar_picker_update_action()));
 
-    expect(api.submit).toHaveBeenCalledWith({ mode: "custom", dow: 1, doy: 4, global: false });
+    expect(submit).toHaveBeenCalledWith({ mode: "custom", dow: 1, doy: 4, global: false });
   });
 
   it('submits { mode: "locale" } when the locale row\'s Use button + Update are clicked', async () => {
-    const api: ModalApi<CalendarSliceState> = { submit: vi.fn(), cancel: vi.fn() };
-    mountModal({ mode: "custom", dow: 1, doy: 4, global: false }, api);
+    const { submit } = await resolveModal({ mode: "custom", dow: 1, doy: 4, global: false });
 
     const useButton = rowFor(m.calendar_preset_name({ preset: "locale" })).querySelector("button");
     await userEvent.click(useButton!);
     await userEvent.click(screen.getByText(m.calendar_picker_update_action()));
 
-    expect(api.submit).toHaveBeenCalledWith({ mode: "locale" });
+    expect(submit).toHaveBeenCalledWith({ mode: "locale" });
   });
 
   it("switches into custom mode when the Custom row's Use button is clicked, even from a preset", async () => {
-    const api: ModalApi<CalendarSliceState> = { submit: vi.fn(), cancel: vi.fn() };
-    mountModal({ mode: "custom", dow: 1, doy: 4, global: false }, api);
+    await resolveModal({ mode: "custom", dow: 1, doy: 4, global: false });
 
     const useButton = rowFor(m.calendar_preset_name({ preset: "custom" })).querySelector("button");
     await userEvent.click(useButton!);
@@ -81,18 +57,16 @@ describe("WeekPresetPickerModal", () => {
   });
 
   it("prefills the custom fields from the locale week when Custom is opened from locale mode", async () => {
-    const api: ModalApi<CalendarSliceState> = { submit: vi.fn(), cancel: vi.fn() };
-    mountModal({ mode: "locale" }, api, { dow: 0, doy: 6 });
+    const { submit } = await resolveModal({ mode: "locale" }, { dow: 0, doy: 6 });
 
     await userEvent.click(rowFor(m.calendar_preset_name({ preset: "custom" })).querySelector("button")!);
     await userEvent.click(screen.getByText(m.calendar_picker_update_action()));
 
-    expect(api.submit).toHaveBeenCalledWith({ mode: "custom", dow: 0, doy: 6, global: false });
+    expect(submit).toHaveBeenCalledWith({ mode: "custom", dow: 0, doy: 6, global: false });
   });
 
   it("submits the custom dow/doy when in custom mode with edited values", async () => {
-    const api: ModalApi<CalendarSliceState> = { submit: vi.fn(), cancel: vi.fn() };
-    mountModal({ mode: "custom", dow: 1, doy: 4, global: false }, api);
+    const { submit } = await resolveModal({ mode: "custom", dow: 1, doy: 4, global: false });
     await userEvent.click(rowFor(m.calendar_preset_name({ preset: "custom" })).querySelector("button")!);
 
     const dropdown = rowFor(m.calendar_picker_start_week_on()).querySelector("select");
@@ -103,12 +77,11 @@ describe("WeekPresetPickerModal", () => {
     await userEvent.type(numberInput!, "2");
 
     await userEvent.click(screen.getByText(m.calendar_picker_update_action()));
-    expect(api.submit).toHaveBeenCalledWith({ mode: "custom", dow: 3, doy: 8, global: false });
+    expect(submit).toHaveBeenCalledWith({ mode: "custom", dow: 3, doy: 8, global: false });
   });
 
   it("shows the Currently used marker on the saved row, not the staged row", async () => {
-    const api: ModalApi<CalendarSliceState> = { submit: vi.fn(), cancel: vi.fn() };
-    mountModal({ mode: "custom", dow: 1, doy: 4, global: false }, api);
+    await resolveModal({ mode: "custom", dow: 1, doy: 4, global: false });
 
     const isoRow = rowFor(m.calendar_preset_name({ preset: "iso-8601" }));
     expect(isoRow.textContent).toContain(m.calendar_picker_in_use_marker());
@@ -124,10 +97,9 @@ describe("WeekPresetPickerModal", () => {
   });
 
   it("cancels via the api when the Cancel button is clicked", async () => {
-    const api: ModalApi<CalendarSliceState> = { submit: vi.fn(), cancel: vi.fn() };
-    mountModal({ mode: "locale" }, api);
+    const { cancel } = await resolveModal({ mode: "locale" });
 
     await userEvent.click(screen.getByText(m.common_action_cancel()));
-    expect(api.cancel).toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalled();
   });
 });

--- a/src/calendar/settings/ui/WeekPresetPickerModal.test.ts
+++ b/src/calendar/settings/ui/WeekPresetPickerModal.test.ts
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import { screen } from "@testing-library/vue";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi, type MockInstance } from "vitest";
 
 import { Calendar } from "@/calendar";
 import { m } from "@/i18n";
@@ -10,9 +10,11 @@ import WeekPresetPickerModal from "./WeekPresetPickerModal.vue";
 
 import type { CalendarSliceState } from "../slice";
 
+let localeWeekSpy: MockInstance<Calendar["localeWeek"]> | undefined;
+
 async function resolveModal(current: CalendarSliceState, localeWeek?: { dow: number; doy: number }) {
   const harness = await testContainer();
-  vi.spyOn(harness.resolve(Calendar), "localeWeek").mockReturnValue(localeWeek ?? { dow: 1, doy: 4 });
+  localeWeekSpy = vi.spyOn(harness.resolve(Calendar), "localeWeek").mockReturnValue(localeWeek ?? { dow: 1, doy: 4 });
   return harness.renderModal<typeof WeekPresetPickerModal, CalendarSliceState>(WeekPresetPickerModal, {
     props: { current },
   });
@@ -26,6 +28,10 @@ function rowFor(name: string): HTMLElement {
 }
 
 describe("WeekPresetPickerModal", () => {
+  afterEach(() => {
+    localeWeekSpy?.mockRestore();
+  });
+
   it("submits the ISO 8601 preset when its Use button is clicked then Update is pressed", async () => {
     const { submit } = await resolveModal({ mode: "locale" });
 

--- a/src/calendar/ui/CalendarDecadeView.test.ts
+++ b/src/calendar/ui/CalendarDecadeView.test.ts
@@ -1,42 +1,18 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
 
-import { Calendar, DecadePeriod, OpenInterval, YearPeriod } from "@/calendar";
+import { DecadePeriod, OpenInterval, YearPeriod } from "@/calendar";
 import type { Period } from "@/calendar";
-import { date, installTestCalendar, testCalendar } from "@/calendar/testing";
-import { Container, provideInjectorOnApp } from "@/infrastructure/di";
+import { date } from "@/calendar/testing";
 
 import CalendarDecadeView from "./CalendarDecadeView.vue";
 
 function mount(props: { outerPeriod: DecadePeriod; selected: Period | null; bounds?: OpenInterval }) {
-  const container = new Container();
-  container.register(Calendar).useValue(testCalendar());
-
-  return render(CalendarDecadeView, {
-    props,
-    global: {
-      plugins: [
-        {
-          install(app) {
-            provideInjectorOnApp(app, container);
-          },
-        },
-      ],
-    },
-  });
+  return render(CalendarDecadeView, { props });
 }
 
 describe("CalendarDecadeView", () => {
-  let teardown: () => void;
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-    cleanup();
-  });
-
   describe("year cells", () => {
     it("renders exactly ten year cells", () => {
       const outerPeriod = DecadePeriod.containing(date("2025-01-01"));

--- a/src/calendar/ui/CalendarMonthView.test.ts
+++ b/src/calendar/ui/CalendarMonthView.test.ts
@@ -1,11 +1,11 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
 import { nextTick } from "vue";
 
 import { DayPeriod, MonthPeriod, OpenInterval } from "@/calendar";
 import type { Period } from "@/calendar";
-import { date, installTestCalendar, testCalendar } from "@/calendar/testing";
+import { date, testCalendar } from "@/calendar/testing";
 
 import CalendarMonthView from "./CalendarMonthView.vue";
 
@@ -18,15 +18,6 @@ function setWeek(dow: number, doy: number): void {
 }
 
 describe("CalendarMonthView", () => {
-  let teardown: () => void;
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-    cleanup();
-  });
-
   describe("day cells", () => {
     it("renders cells for every day in every week overlapping the month", () => {
       const outerPeriod = MonthPeriod.containing(date("2024-05-15"));

--- a/src/calendar/ui/CalendarQuarterView.test.ts
+++ b/src/calendar/ui/CalendarQuarterView.test.ts
@@ -1,42 +1,18 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
 
-import { Calendar, OpenInterval, QuarterPeriod, YearPeriod } from "@/calendar";
+import { OpenInterval, QuarterPeriod, YearPeriod } from "@/calendar";
 import type { Period } from "@/calendar";
-import { date, installTestCalendar, testCalendar } from "@/calendar/testing";
-import { Container, provideInjectorOnApp } from "@/infrastructure/di";
+import { date } from "@/calendar/testing";
 
 import CalendarQuarterView from "./CalendarQuarterView.vue";
 
 function mount(props: { outerPeriod: YearPeriod; selected: Period | null; bounds?: OpenInterval }) {
-  const container = new Container();
-  container.register(Calendar).useValue(testCalendar());
-
-  return render(CalendarQuarterView, {
-    props,
-    global: {
-      plugins: [
-        {
-          install(app) {
-            provideInjectorOnApp(app, container);
-          },
-        },
-      ],
-    },
-  });
+  return render(CalendarQuarterView, { props });
 }
 
 describe("CalendarQuarterView", () => {
-  let teardown: () => void;
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-    cleanup();
-  });
-
   describe("quarter cells", () => {
     it("renders exactly four quarter cells", () => {
       const outerPeriod = YearPeriod.containing(date("2025-01-01"));

--- a/src/calendar/ui/CalendarWeekView.test.ts
+++ b/src/calendar/ui/CalendarWeekView.test.ts
@@ -1,45 +1,18 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
 
-import { Calendar, MonthPeriod, OpenInterval, WeekPeriod } from "@/calendar";
+import { MonthPeriod, OpenInterval, WeekPeriod } from "@/calendar";
 import type { Period } from "@/calendar";
-import { date, installTestCalendar, testCalendar } from "@/calendar/testing";
-import { Container, provideInjectorOnApp } from "@/infrastructure/di";
+import { date } from "@/calendar/testing";
 
 import CalendarWeekView from "./CalendarWeekView.vue";
 
-function mount(
-  props: { outerPeriod: MonthPeriod; selected: Period | null; bounds?: OpenInterval },
-  calendar?: Calendar,
-) {
-  const container = new Container();
-  container.register(Calendar).useValue(calendar ?? testCalendar());
-
-  return render(CalendarWeekView, {
-    props,
-    global: {
-      plugins: [
-        {
-          install(app) {
-            provideInjectorOnApp(app, container);
-          },
-        },
-      ],
-    },
-  });
+function mount(props: { outerPeriod: MonthPeriod; selected: Period | null; bounds?: OpenInterval }) {
+  return render(CalendarWeekView, { props });
 }
 
 describe("CalendarWeekView", () => {
-  let teardown: () => void;
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-    cleanup();
-  });
-
   describe("week cells", () => {
     it("renders one cell per week overlapping the month", () => {
       const outerPeriod = MonthPeriod.containing(date("2025-03-15"));

--- a/src/calendar/ui/CalendarYearView.test.ts
+++ b/src/calendar/ui/CalendarYearView.test.ts
@@ -1,42 +1,18 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
 
-import { Calendar, MonthPeriod, OpenInterval, YearPeriod } from "@/calendar";
+import { MonthPeriod, OpenInterval, YearPeriod } from "@/calendar";
 import type { Period } from "@/calendar";
-import { date, installTestCalendar, testCalendar } from "@/calendar/testing";
-import { Container, provideInjectorOnApp } from "@/infrastructure/di";
+import { date } from "@/calendar/testing";
 
 import CalendarYearView from "./CalendarYearView.vue";
 
 function mount(props: { outerPeriod: YearPeriod; selected: Period | null; bounds?: OpenInterval }) {
-  const container = new Container();
-  container.register(Calendar).useValue(testCalendar());
-
-  return render(CalendarYearView, {
-    props,
-    global: {
-      plugins: [
-        {
-          install(app) {
-            provideInjectorOnApp(app, container);
-          },
-        },
-      ],
-    },
-  });
+  return render(CalendarYearView, { props });
 }
 
 describe("CalendarYearView", () => {
-  let teardown: () => void;
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-    cleanup();
-  });
-
   describe("month cells", () => {
     it("renders exactly twelve month cells", () => {
       const outerPeriod = YearPeriod.containing(date("2025-01-01"));

--- a/src/calendar/ui/DatePicker.test.ts
+++ b/src/calendar/ui/DatePicker.test.ts
@@ -1,13 +1,11 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/vue";
+import { describe, expect, it, vi } from "vitest";
 
-import { Calendar, DayPeriod, type OpenInterval, type Period } from "@/calendar";
-import { date, installTestCalendar, testCalendar } from "@/calendar/testing";
+import { DayPeriod, type OpenInterval, type Period } from "@/calendar";
+import { date } from "@/calendar/testing";
 import { m } from "@/i18n";
-import { Container, provideInjectorOnApp } from "@/infrastructure/di";
-import { ModalService } from "@/infrastructure/host/modals";
-import { FakeModalService } from "@/infrastructure/host/modals/testing";
+import { testContainer } from "@/testing";
 
 import DatePicker from "./DatePicker.vue";
 
@@ -22,81 +20,55 @@ interface MountProps {
   modelValue?: Period | null;
 }
 
-function mount(props: MountProps) {
-  const container = new Container();
-  const fakeService = new FakeModalService();
-  container.register(Calendar).useValue(testCalendar());
-  container.register(ModalService).useValue(fakeService as unknown as ModalService);
-  return {
-    fakeService,
-    ...render(DatePicker, {
-      props,
-      global: {
-        plugins: [
-          {
-            install(app) {
-              provideInjectorOnApp(app, container);
-            },
-          },
-        ],
-      },
-    }),
-  };
+async function mount(props: MountProps) {
+  const harness = await testContainer();
+  return { harness, ...harness.render(DatePicker, { props }) };
 }
 
 describe("DatePicker", () => {
-  let teardown: () => void;
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-    cleanup();
-  });
-
   describe("label", () => {
-    it("shows the placeholder when modelValue is null and no placeholder is provided", () => {
-      mount({ picking: "day", modelValue: null });
+    it("shows the placeholder when modelValue is null and no placeholder is provided", async () => {
+      await mount({ picking: "day", modelValue: null });
       expect(screen.getByRole("button").textContent?.trim()).toBe(m.common_pick_a_date());
     });
 
-    it("shows the explicit placeholder when modelValue is null and a placeholder is provided", () => {
-      mount({ picking: "day", modelValue: null, placeholder: "Choose a day" });
+    it("shows the explicit placeholder when modelValue is null and a placeholder is provided", async () => {
+      await mount({ picking: "day", modelValue: null, placeholder: "Choose a day" });
       expect(screen.getByRole("button").textContent?.trim()).toBe("Choose a day");
     });
 
-    it("shows the formatted period label when modelValue is a DayPeriod", () => {
-      mount({ picking: "day", modelValue: DayPeriod.containing(date("2025-03-15")) });
+    it("shows the formatted period label when modelValue is a DayPeriod", async () => {
+      await mount({ picking: "day", modelValue: DayPeriod.containing(date("2025-03-15")) });
       expect(screen.getByRole("button").textContent?.trim()).toBe("2025-03-15");
     });
   });
 
   describe("modal opening", () => {
     it("opens the modal when the button is clicked", async () => {
-      const { fakeService } = mount({ picking: "day", modelValue: null });
+      const { harness } = await mount({ picking: "day", modelValue: null });
       await userEvent.click(screen.getByRole("button"));
-      expect(fakeService.opens.length).toBe(1);
+      expect(harness.modals.opens.length).toBe(1);
     });
 
     it("passes picking to the modal props", async () => {
-      const { fakeService } = mount({ picking: "day", modelValue: null });
+      const { harness } = await mount({ picking: "day", modelValue: null });
       await userEvent.click(screen.getByRole("button"));
-      expect(fakeService.lastOpen<DatePickerModalProps, Period>().props.picking).toBe("day");
+      expect(harness.modals.lastOpen<DatePickerModalProps, Period>().props.picking).toBe("day");
     });
 
     it("does not open the modal when disabled", async () => {
-      const { fakeService } = mount({ picking: "day", modelValue: null, disabled: true });
+      const { harness } = await mount({ picking: "day", modelValue: null, disabled: true });
       await userEvent.click(screen.getByRole("button"));
-      expect(fakeService.opens.length).toBe(0);
+      expect(harness.modals.opens.length).toBe(0);
     });
   });
 
   describe("modelValue updates", () => {
     it("emits update:modelValue with the submitted period when the modal resolves", async () => {
-      const { fakeService, emitted } = mount({ picking: "day", modelValue: null });
+      const { harness, emitted } = await mount({ picking: "day", modelValue: null });
       await userEvent.click(screen.getByRole("button"));
       const period = DayPeriod.containing(date("2025-03-15"));
-      fakeService.lastOpen<unknown, typeof period>().submit(period);
+      harness.modals.lastOpen<unknown, typeof period>().submit(period);
       await vi.waitFor(() => {
         expect(emitted("update:modelValue")).toBeDefined();
       });
@@ -105,9 +77,9 @@ describe("DatePicker", () => {
     });
 
     it("does not emit update:modelValue when the modal is cancelled", async () => {
-      const { fakeService, emitted } = mount({ picking: "day", modelValue: null });
+      const { harness, emitted } = await mount({ picking: "day", modelValue: null });
       await userEvent.click(screen.getByRole("button"));
-      fakeService.lastOpen().cancel();
+      harness.modals.lastOpen().cancel();
       await Promise.resolve();
       await Promise.resolve();
       expect(emitted("update:modelValue")).toBeUndefined();

--- a/src/calendar/ui/DatePickerModal.test.ts
+++ b/src/calendar/ui/DatePickerModal.test.ts
@@ -1,9 +1,8 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
 
 import {
-  Calendar,
   CalendarDate,
   DayPeriod,
   MonthPeriod,
@@ -13,100 +12,71 @@ import {
   WeekPeriod,
   YearPeriod,
 } from "@/calendar";
-import { date, installTestCalendar, testCalendar } from "@/calendar/testing";
-import { Container, provideInjectorOnApp } from "@/infrastructure/di";
-import { provideModalApiOnApp } from "@/infrastructure/host/modals/testing";
+import { date } from "@/calendar/testing";
+import { testContainer } from "@/testing";
 
 import DatePickerModal from "./DatePickerModal.vue";
 
-function renderModal(options: {
+async function renderModal(options: {
   picking: "day" | "week" | "month" | "quarter" | "year";
   selected?: Period | null;
   bounds?: OpenInterval;
-  submit?: (v: unknown) => void;
-  cancel?: () => void;
 }) {
-  const container = new Container();
-  container.register(Calendar).useValue(testCalendar());
-  const submit = options.submit ?? vi.fn();
-  const cancel = options.cancel ?? vi.fn();
-  return {
-    submit,
-    cancel,
-    ...render(DatePickerModal, {
-      props: { picking: options.picking, selected: options.selected, bounds: options.bounds },
-      global: {
-        plugins: [
-          {
-            install(app) {
-              provideInjectorOnApp(app, container);
-              provideModalApiOnApp(app, { submit, cancel });
-            },
-          },
-        ],
-      },
-    }),
-  };
+  const harness = await testContainer();
+  return harness.renderModal<typeof DatePickerModal, Period>(DatePickerModal, {
+    props: { picking: options.picking, selected: options.selected, bounds: options.bounds },
+  });
 }
 
 describe("DatePickerModal", () => {
-  let teardown: () => void;
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-    cleanup();
-  });
-
   describe("initial view", () => {
-    it("opens at the month view when picking is day", () => {
+    it("opens at the month view when picking is day", async () => {
       const selected = DayPeriod.containing(date("2025-03-15"));
-      renderModal({ picking: "day", selected });
+      await renderModal({ picking: "day", selected });
 
       expect(screen.queryAllByTestId("month-cell").length).toBeGreaterThan(0);
     });
 
-    it("opens at the week view when picking is week", () => {
+    it("opens at the week view when picking is week", async () => {
       const selected = WeekPeriod.containing(date("2025-03-15"));
-      renderModal({ picking: "week", selected });
+      await renderModal({ picking: "week", selected });
 
       expect(screen.queryAllByTestId("week-cell").length).toBeGreaterThan(0);
     });
 
-    it("opens at the year view when picking is month", () => {
+    it("opens at the year view when picking is month", async () => {
       const selected = MonthPeriod.containing(date("2025-03-15"));
-      renderModal({ picking: "month", selected });
+      await renderModal({ picking: "month", selected });
 
       expect(screen.queryAllByTestId("year-cell").length).toBeGreaterThan(0);
     });
 
-    it("opens at the quarter view when picking is quarter", () => {
+    it("opens at the quarter view when picking is quarter", async () => {
       const selected = QuarterPeriod.containing(date("2025-03-15"));
-      renderModal({ picking: "quarter", selected });
+      await renderModal({ picking: "quarter", selected });
 
       expect(screen.queryAllByTestId("quarter-cell").length).toBeGreaterThan(0);
     });
 
-    it("opens at the decade view when picking is year", () => {
+    it("opens at the decade view when picking is year", async () => {
       const selected = YearPeriod.containing(date("2025-03-15"));
-      renderModal({ picking: "year", selected });
+      await renderModal({ picking: "year", selected });
 
       expect(screen.queryAllByTestId("decade-cell").length).toBeGreaterThan(0);
     });
 
-    it("opens on the bounded period when there is no selection and bounds lie entirely in the past", () => {
+    it("opens on the bounded period when there is no selection and bounds lie entirely in the past", async () => {
       const end = CalendarDate.today().shift(-2, "y");
       const bounds = OpenInterval.until(end);
-      renderModal({ picking: "day", selected: null, bounds });
+      await renderModal({ picking: "day", selected: null, bounds });
 
       expect(screen.getByTestId("modal-title-label").textContent).toBe(end.format("MMMM YYYY"));
     });
 
-    it("opens on the bounded period when there is no selection and bounds lie entirely in the future", () => {
+    it("opens on the bounded period when there is no selection and bounds lie entirely in the future", async () => {
       const start = CalendarDate.today().shift(2, "y");
       const bounds = OpenInterval.from(start);
-      renderModal({ picking: "day", selected: null, bounds });
+      await renderModal({ picking: "day", selected: null, bounds });
 
       expect(screen.getByTestId("modal-title-label").textContent).toBe(start.format("MMMM YYYY"));
     });
@@ -114,9 +84,8 @@ describe("DatePickerModal", () => {
 
   describe("target click", () => {
     it("submits the clicked period when in target view", async () => {
-      const submit = vi.fn();
       const selected = DayPeriod.containing(date("2025-03-15"));
-      renderModal({ picking: "day", selected, submit });
+      const { submit } = await renderModal({ picking: "day", selected });
 
       const cells = screen.getAllByTestId("month-cell");
       const march15 = cells.find((c) => c.dataset.anchor === "2025-03-15")!;
@@ -132,7 +101,7 @@ describe("DatePickerModal", () => {
   describe("descent", () => {
     it("descends from decade to year view for picking=day after a year click", async () => {
       const selected = DayPeriod.containing(date("2025-03-15"));
-      renderModal({ picking: "day", selected });
+      await renderModal({ picking: "day", selected });
 
       // Ascend month → year
       await userEvent.click(screen.getByTestId("modal-title-button"));
@@ -149,7 +118,7 @@ describe("DatePickerModal", () => {
 
     it("descends from year to month view for picking=day after a month click", async () => {
       const selected = DayPeriod.containing(date("2025-03-15"));
-      renderModal({ picking: "day", selected });
+      await renderModal({ picking: "day", selected });
 
       // Ascend month → year
       await userEvent.click(screen.getByTestId("modal-title-button"));
@@ -166,7 +135,7 @@ describe("DatePickerModal", () => {
   describe("drill up", () => {
     it("ascends from month to year on title click", async () => {
       const selected = DayPeriod.containing(date("2025-03-15"));
-      renderModal({ picking: "day", selected });
+      await renderModal({ picking: "day", selected });
 
       await userEvent.click(screen.getByTestId("modal-title-button"));
 
@@ -177,7 +146,7 @@ describe("DatePickerModal", () => {
   describe("navigation", () => {
     it("moves to the previous outer period when prev is clicked", async () => {
       const selected = DayPeriod.containing(date("2025-03-15"));
-      renderModal({ picking: "day", selected });
+      await renderModal({ picking: "day", selected });
 
       const titleBefore = screen.getByTestId("modal-title-label").textContent;
       await userEvent.click(screen.getByTestId("modal-prev"));
@@ -186,11 +155,11 @@ describe("DatePickerModal", () => {
       expect(titleAfter).not.toBe(titleBefore);
     });
 
-    it("hides prev when the previous outer period does not overlap bounds", () => {
+    it("hides prev when the previous outer period does not overlap bounds", async () => {
       // Bounds start from 2025-03-01, so previous month (Feb 2025) is entirely before bounds
       const selected = DayPeriod.containing(date("2025-03-15"));
       const bounds = OpenInterval.from(date("2025-03-01"));
-      renderModal({ picking: "day", selected, bounds });
+      await renderModal({ picking: "day", selected, bounds });
 
       expect(screen.queryByTestId("modal-prev")).toBeNull();
     });

--- a/src/calendar/ui/DatePickerModal.test.ts
+++ b/src/calendar/ui/DatePickerModal.test.ts
@@ -17,7 +17,7 @@ import { testContainer } from "@/testing";
 
 import DatePickerModal from "./DatePickerModal.vue";
 
-async function renderModal(options: {
+async function resolveModal(options: {
   picking: "day" | "week" | "month" | "quarter" | "year";
   selected?: Period | null;
   bounds?: OpenInterval;
@@ -32,35 +32,35 @@ describe("DatePickerModal", () => {
   describe("initial view", () => {
     it("opens at the month view when picking is day", async () => {
       const selected = DayPeriod.containing(date("2025-03-15"));
-      await renderModal({ picking: "day", selected });
+      await resolveModal({ picking: "day", selected });
 
       expect(screen.queryAllByTestId("month-cell").length).toBeGreaterThan(0);
     });
 
     it("opens at the week view when picking is week", async () => {
       const selected = WeekPeriod.containing(date("2025-03-15"));
-      await renderModal({ picking: "week", selected });
+      await resolveModal({ picking: "week", selected });
 
       expect(screen.queryAllByTestId("week-cell").length).toBeGreaterThan(0);
     });
 
     it("opens at the year view when picking is month", async () => {
       const selected = MonthPeriod.containing(date("2025-03-15"));
-      await renderModal({ picking: "month", selected });
+      await resolveModal({ picking: "month", selected });
 
       expect(screen.queryAllByTestId("year-cell").length).toBeGreaterThan(0);
     });
 
     it("opens at the quarter view when picking is quarter", async () => {
       const selected = QuarterPeriod.containing(date("2025-03-15"));
-      await renderModal({ picking: "quarter", selected });
+      await resolveModal({ picking: "quarter", selected });
 
       expect(screen.queryAllByTestId("quarter-cell").length).toBeGreaterThan(0);
     });
 
     it("opens at the decade view when picking is year", async () => {
       const selected = YearPeriod.containing(date("2025-03-15"));
-      await renderModal({ picking: "year", selected });
+      await resolveModal({ picking: "year", selected });
 
       expect(screen.queryAllByTestId("decade-cell").length).toBeGreaterThan(0);
     });
@@ -68,7 +68,7 @@ describe("DatePickerModal", () => {
     it("opens on the bounded period when there is no selection and bounds lie entirely in the past", async () => {
       const end = CalendarDate.today().shift(-2, "y");
       const bounds = OpenInterval.until(end);
-      await renderModal({ picking: "day", selected: null, bounds });
+      await resolveModal({ picking: "day", selected: null, bounds });
 
       expect(screen.getByTestId("modal-title-label").textContent).toBe(end.format("MMMM YYYY"));
     });
@@ -76,7 +76,7 @@ describe("DatePickerModal", () => {
     it("opens on the bounded period when there is no selection and bounds lie entirely in the future", async () => {
       const start = CalendarDate.today().shift(2, "y");
       const bounds = OpenInterval.from(start);
-      await renderModal({ picking: "day", selected: null, bounds });
+      await resolveModal({ picking: "day", selected: null, bounds });
 
       expect(screen.getByTestId("modal-title-label").textContent).toBe(start.format("MMMM YYYY"));
     });
@@ -85,7 +85,7 @@ describe("DatePickerModal", () => {
   describe("target click", () => {
     it("submits the clicked period when in target view", async () => {
       const selected = DayPeriod.containing(date("2025-03-15"));
-      const { submit } = await renderModal({ picking: "day", selected });
+      const { submit } = await resolveModal({ picking: "day", selected });
 
       const cells = screen.getAllByTestId("month-cell");
       const march15 = cells.find((c) => c.dataset.anchor === "2025-03-15")!;
@@ -101,7 +101,7 @@ describe("DatePickerModal", () => {
   describe("descent", () => {
     it("descends from decade to year view for picking=day after a year click", async () => {
       const selected = DayPeriod.containing(date("2025-03-15"));
-      await renderModal({ picking: "day", selected });
+      await resolveModal({ picking: "day", selected });
 
       // Ascend month → year
       await userEvent.click(screen.getByTestId("modal-title-button"));
@@ -118,7 +118,7 @@ describe("DatePickerModal", () => {
 
     it("descends from year to month view for picking=day after a month click", async () => {
       const selected = DayPeriod.containing(date("2025-03-15"));
-      await renderModal({ picking: "day", selected });
+      await resolveModal({ picking: "day", selected });
 
       // Ascend month → year
       await userEvent.click(screen.getByTestId("modal-title-button"));
@@ -135,7 +135,7 @@ describe("DatePickerModal", () => {
   describe("drill up", () => {
     it("ascends from month to year on title click", async () => {
       const selected = DayPeriod.containing(date("2025-03-15"));
-      await renderModal({ picking: "day", selected });
+      await resolveModal({ picking: "day", selected });
 
       await userEvent.click(screen.getByTestId("modal-title-button"));
 
@@ -146,7 +146,7 @@ describe("DatePickerModal", () => {
   describe("navigation", () => {
     it("moves to the previous outer period when prev is clicked", async () => {
       const selected = DayPeriod.containing(date("2025-03-15"));
-      await renderModal({ picking: "day", selected });
+      await resolveModal({ picking: "day", selected });
 
       const titleBefore = screen.getByTestId("modal-title-label").textContent;
       await userEvent.click(screen.getByTestId("modal-prev"));
@@ -159,7 +159,7 @@ describe("DatePickerModal", () => {
       // Bounds start from 2025-03-01, so previous month (Feb 2025) is entirely before bounds
       const selected = DayPeriod.containing(date("2025-03-15"));
       const bounds = OpenInterval.from(date("2025-03-01"));
-      await renderModal({ picking: "day", selected, bounds });
+      await resolveModal({ picking: "day", selected, bounds });
 
       expect(screen.queryByTestId("modal-prev")).toBeNull();
     });

--- a/src/calendar/ui/descend.test.ts
+++ b/src/calendar/ui/descend.test.ts
@@ -1,20 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { YearPeriod } from "@/calendar";
-import { date, installTestCalendar } from "@/calendar/testing";
+import { date } from "@/calendar/testing";
 
 import { descend } from "./descend";
 import { DatePickerInvariantError } from "./errors";
 
 describe("descend", () => {
-  let teardown: () => void;
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-  });
-
   it("throws DatePickerInvariantError on an impossible (view, picking, cellKind) combination", () => {
     // picking=quarter never lands on year view in the modal's flow
     const cell = YearPeriod.containing(date("2025-05-15"));

--- a/src/calendar/ui/use-anchor-field.test.ts
+++ b/src/calendar/ui/use-anchor-field.test.ts
@@ -1,20 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { ref } from "vue";
 
 import { DayPeriod, WeekPeriod, type AnchorString } from "@/calendar";
-import { date, installTestCalendar } from "@/calendar/testing";
+import { date } from "@/calendar/testing";
 
 import { useAnchorField } from "./use-anchor-field";
 
 describe("useAnchorField", () => {
-  let teardown: () => void;
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-  });
-
   describe("getter", () => {
     it("maps an empty anchor to null", () => {
       const anchor = ref<AnchorString>("" as AnchorString);

--- a/src/calendar/ui/use-calendar-grid.test.ts
+++ b/src/calendar/ui/use-calendar-grid.test.ts
@@ -1,8 +1,8 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { ref } from "vue";
 
 import { type CalendarDate, DayPeriod, MonthPeriod, OpenInterval, YearPeriod } from "@/calendar";
-import { date, installTestCalendar } from "@/calendar/testing";
+import { date } from "@/calendar/testing";
 
 import { useCalendarGrid } from "./use-calendar-grid";
 
@@ -16,14 +16,6 @@ function monthCells(refDate: CalendarDate): readonly DayPeriod[] {
 }
 
 describe("useCalendarGrid", () => {
-  let teardown: () => void;
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-  });
-
   describe("isSelected", () => {
     it("marks the cell whose period matches the selection of the same kind", () => {
       const cells = useCalendarGrid({

--- a/src/calendar/ui/use-period-window.test.ts
+++ b/src/calendar/ui/use-period-window.test.ts
@@ -1,20 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { ref } from "vue";
 
 import type { AnchorString } from "@/calendar";
-import { installTestCalendar } from "@/calendar/testing";
 
 import { usePeriodWindow } from "./use-period-window";
 
 describe("usePeriodWindow", () => {
-  let teardown: () => void;
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-  });
-
   it("returns the window of months around the focus month", () => {
     const months = usePeriodWindow("month", "2026-03-15" as AnchorString, 1, 1);
     expect(months.value.map((m) => m.start.toAnchor())).toEqual(["2026-02-01", "2026-03-01", "2026-04-01"]);

--- a/src/calendar/ui/use-today.test.ts
+++ b/src/calendar/ui/use-today.test.ts
@@ -2,16 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { effectScope, type EffectScope, type ShallowRef } from "vue";
 
 import type { CalendarDate } from "@/calendar";
-import { installTestCalendar } from "@/calendar/testing";
 
 import { useToday } from "./use-today";
 
 describe("useToday", () => {
-  let teardown: () => void;
   let scope: EffectScope;
 
   beforeEach(() => {
-    ({ teardown } = installTestCalendar());
     vi.useFakeTimers();
     vi.setSystemTime(new Date(2026, 4, 25, 23, 30, 0));
     scope = effectScope();
@@ -19,7 +16,6 @@ describe("useToday", () => {
   afterEach(() => {
     scope.stop();
     vi.useRealTimers();
-    teardown();
   });
 
   const today = (): Readonly<ShallowRef<CalendarDate>> => scope.run(() => useToday())!;

--- a/src/calendar/week-of-month.test.ts
+++ b/src/calendar/week-of-month.test.ts
@@ -1,18 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { date, installTestCalendar } from "./testing";
 import { weekOfMonth } from "./week-of-month";
 
 describe("weekOfMonth", () => {
-  let teardown: () => void;
-
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-  });
-
   it("counts the week holding the first of the month as week 1", () => {
     expect(weekOfMonth(date("2026-06-01"))).toBe(1);
   });
@@ -34,8 +25,7 @@ describe("weekOfMonth", () => {
   });
 
   it("follows the configured week start", () => {
-    teardown();
-    ({ teardown } = installTestCalendar({ dow: 0, doy: 6 }));
+    installTestCalendar({ dow: 0, doy: 6 });
 
     expect(weekOfMonth(date("2026-08-30"))).toBe(6);
   });
@@ -43,15 +33,13 @@ describe("weekOfMonth", () => {
   // The week-owned reading a template writes as {{week_of_month<endOf=week>}}: reading the
   // number off the week's last day moves the whole straddling week into the month it ends in.
   it("reads as week 1 of the next month when taken from the end of a straddling week", () => {
-    teardown();
-    ({ teardown } = installTestCalendar({ dow: 0, doy: 6 }));
+    installTestCalendar({ dow: 0, doy: 6 });
 
     expect(weekOfMonth(date("2026-08-30").endOf("week"))).toBe(1);
   });
 
   it("agrees across every day of a straddling week read from the week's end", () => {
-    teardown();
-    ({ teardown } = installTestCalendar({ dow: 0, doy: 6 }));
+    installTestCalendar({ dow: 0, doy: 6 });
     const week = ["2026-08-30", "2026-08-31", "2026-09-01", "2026-09-02", "2026-09-03", "2026-09-04", "2026-09-05"];
 
     const numbers = week.map((day) => weekOfMonth(date(day).endOf("week")));

--- a/src/journals/settings/week-preset-service.test.ts
+++ b/src/journals/settings/week-preset-service.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { WeekPeriod, calendarSettingsModule, calendarSlice, type AnchorString } from "@/calendar";
+import { WeekPeriod, calendarSlice, type AnchorString } from "@/calendar";
+import { calendarSettingsCoreModule } from "@/calendar/settings/module";
 import { date } from "@/calendar/testing";
 import { NotesService } from "@/infrastructure/host";
 import type { VaultPath } from "@/infrastructure/host";
@@ -19,7 +20,7 @@ import type { JournalConfig } from "../config";
 const ISO = { mode: "custom", dow: 1, doy: 4, global: false } as const;
 const WESTERN = { mode: "custom", dow: 0, doy: 6, global: false } as const;
 
-const MODULES = [journalsCoreModule, journalsSettingsCoreModule, calendarSettingsModule];
+const MODULES = [journalsCoreModule, journalsSettingsCoreModule, calendarSettingsCoreModule];
 
 function weekly(patch: { addStartDate?: boolean; addEndDate?: boolean } = {}): Record<string, JournalConfig> {
   const config = fixedJournal("weekly", { type: "week" });

--- a/src/settings/settings-service.ts
+++ b/src/settings/settings-service.ts
@@ -362,6 +362,9 @@ function parseSliceValue<TSchema extends AnySchema>(
   raw: unknown,
   logger: Logger,
 ): InferOutput<TSchema> {
+  // Absence is the fresh-install case and must stay silent, mirroring parseCollectionValue's
+  // carve-out above; a stored value of the wrong shape still falls through to the warning below.
+  if (raw === undefined) return structuredClone(definition.defaults);
   const parsed = v.safeParse(definition.schema, raw);
   if (parsed.success) return parsed.output;
   logger.warn("slice reset to defaults", {

--- a/src/testing.test.ts
+++ b/src/testing.test.ts
@@ -4,8 +4,9 @@ import { moment } from "obsidian";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { defineComponent, h } from "vue";
 
-import { Calendar, calendarSettingsModule } from "@/calendar";
+import { Calendar } from "@/calendar";
 import { CUSTOM_LOCALE } from "@/calendar/calendar";
+import { calendarSettingsCoreModule } from "@/calendar/settings/module";
 import { anchor, installTestCalendar, testCalendar } from "@/calendar/testing";
 import type { CannotOverrideError } from "@/infrastructure/di";
 import { ContainerDisposedError, useService } from "@/infrastructure/di";
@@ -234,7 +235,7 @@ describe("seed guard", () => {
   it("rejects a fixture whose slice the settings parse reset to defaults", async () => {
     await expect(
       testContainer({
-        modules: [calendarSettingsModule],
+        modules: [calendarSettingsCoreModule],
         data: { calendar: { mode: "custom", dow: 9, doy: 4, global: false } },
       }),
     ).rejects.toThrow(TestContainerInvalidSeedError);

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -78,10 +78,34 @@ export default defineConfig({
         // `#onShelfRenamed` (:265) and `#onShelfDeleted` (:273) was never taken. Both tests now also
         // seed a non-matching command (a different shelf, and a non-shelf target) and assert it is
         // left alone, exercising that arm again and restoring the two branches.
-        statements: 92.19,
+        //
+        // Sweep 2 (calendar) measured each of its nine commits in a scratch worktree rather than
+        // reasoning about the total. Base (db945149): 92.19 / 87.86 / 89.12 / 94.31, matching the
+        // numbers above exactly. The module split (42d61ff8), both `installTestCalendar`-triple
+        // cleanups (a6a95c4b, 5bd27bee), the dead-container deletion (d8bfc762) and the DatePicker
+        // staging (8d134fbb) moved nothing.
+        //
+        // Bridge and CalendarWeekBlock staging (6a94e0d6) -> 92.20 / 87.86 / 89.15 / 94.32. Up:
+        // `CalendarWeekBlock.test.ts` swapped its hand-built `ModalService` stub for
+        // `harness.modals`, the real fake — which actually invokes a modal descriptor's `title`
+        // resolver instead of short-circuiting past it. `weekPresetPickerModal`'s `title` arrow
+        // (calendar/settings/ui/modals.ts:10) goes from 0% to 100% function coverage: +1 function,
+        // +1 statement, +1 line. No branches in it, so branches held.
+        //
+        // Fresh-install carve-out (d3f7f65a) -> 92.20 / 87.86 / 89.15 / 94.32, numerators and
+        // denominators both up: 11062/11997 -> 11064/11999 statements, 4771/5430 -> 4773/5432
+        // branches, 9674/10256 -> 9675/10257 lines. `parseSliceValue`'s new
+        // `if (raw === undefined) return ...` (settings-service.ts:365) adds one statement for the
+        // guard and one for the return, and one branch point with both arms exercised elsewhere in
+        // the suite (the fresh-install arm was already covered before the calendar suite touched
+        // it) — a rise, not the branch-drop pattern to watch for. Percentages hold because the new
+        // code is fully covered. `184da953` (dropping the now-unneeded guard-dodge seeds) and
+        // `8915a293` (lint-selector arming) moved nothing further; the branch was already covered
+        // without them.
+        statements: 92.2,
         branches: 87.86,
-        functions: 89.12,
-        lines: 94.31,
+        functions: 89.15,
+        lines: 94.32,
       },
     },
     projects: [


### PR DESCRIPTION
Sweep 2 of the Phase 3 test-conversion campaign: all **36 test files under `src/calendar`** move onto the `testContainer` harness. Follows [#293](https://github.com/srg-kostyrko/obsidian-journal/pull/293) (shelves/commands/maintenance/api).

Deliberately the cheap sweep — it proves the grouped-sweep shape before `decorations` (48 files) and `views` (64). Net **-374 lines** across 38 files.

## What changed

| Commit | What |
| --- | --- |
| `42d61ff8` | Split `calendar/settings` into core + UI halves |
| `a6a95c4b` | Drop the redundant `installTestCalendar` triple — 14 root pure tests |
| `5bd27bee` | Same, 6 `ui/` pure tests |
| `d8bfc762` | Delete the **dead** DI container from 4 grid-view component tests |
| `8d134fbb` | `DatePicker`, `DatePickerModal`, `WeekPresetPickerModal` onto the harness |
| `6a94e0d6` | `bridge` and `CalendarWeekBlock` onto the harness |
| `d3f7f65a` | **fix(settings)**: silence the fresh-install repair warning for a slice |
| `184da953` | Drop guard-dodge seeds now that fresh install is silent |
| `8915a293` | Arm the campaign lint selectors for `src/calendar` |
| `2c093ad3` | Raise the coverage floor, attributed per commit |
| `facbd286` | Whole-branch review's Minor findings |

After this: `src/calendar` has **zero** `new Container()`, `provideInjectorOnApp`, `createSettingsService`, or `afterEach(cleanup)`. The 18 surviving `installTestCalendar` calls are all the legitimate inline non-default-grid form.

## The one production change — please read this part

`d3f7f65a` gives `parseSliceValue` the same `raw === undefined` fresh-install carve-out `parseCollectionValue` already had. **On a fresh v3 install, every registered slice was logging `slice reset to defaults` at boot** — console noise that reads as data corruption.

It was found the long way round: a converted test named *"pushes locale on first construction when slice **defaults** to locale"* had been made to seed `{ mode: "locale" }` explicitly. Every assertion identical, suite green, `it(` count unchanged — but the name claimed a defaulting behaviour that had dropped out of the causal chain. The available shortcuts (`allow: { dataRepair: true }`, or shrugging at the name) were both declined; the root cause was the parser.

**Why it is safe, verified rather than assumed:** all seven `defineSlice` call sites use a root-level object, variant, or array schema — none is a root-level `v.optional`. So `safeParse(schema, undefined)` already failed for every one, and the old code already returned `structuredClone(defaults)` on that path. **The only observable difference is the removed log line.** The corrupt-value path is untouched: `null`, wrong-typed values and out-of-range fields still log and reset, which `src/testing.test.ts`'s `dow: 9` fixture proves.

It has no direct test, and could not get one here — gate 1 forbids adding tests. Its incidental guard is `bridge.test.ts`, which now boots with no `data` and would go red if the warning returned.

## Gates

| Gate | Result |
| --- | --- |
| 1 — test count exact | **395 files / 4196 tests**, unchanged from `main` |
| 2 — coverage floor | **92.2 / 87.86 / 89.15 / 94.32**, raised, attributed per commit, **no branch drop** |
| 3 — e2e | this PR's CI |
| 4 — regression guards | all four probes re-run by the whole-branch reviewer |

Coverage was measured per commit in scratch worktrees, not reasoned about. The rise is two commits: `6a94e0d6` (+1 statement/function/line — `weekPresetPickerModal`'s `title` resolver goes 0%→100%, because the converted test routes through `harness.modals` and the old hand-built `{ open: vi.fn() }` stub never constructed a `FakeModalHandle`) and `d3f7f65a` (+2 statements/+2 branches/+1 line, both arms exercised). The other seven commits moved nothing.

Gate 4's four probes, each red on exactly its predicted tests:

| Broken line | Result |
| --- | --- |
| `bridge.ts:24` `if (state === undefined) return;` | 1 failed / 4 passed |
| `CalendarWeekBlock.vue:83` reload requested unconditionally | 1 failed / 12 passed |
| `use-today.ts` `focus` + `visibilitychange` listeners dropped | 2 failed / 3 passed |
| `use-today.ts` midnight timeout emptied | 2 failed / 3 passed |

## Notes for review

- **The module split is UI-only.** `CalendarSettingsBridge` fails both clauses of the mechanical rule — no host side effect, and it injects only `Calendar` (same feature) and `SettingsService` (harness-supplied) — so it stays in core and only the `DashboardBlockToken` moves. Per ruling 15 this sweep carries **zero** risk-bearing splits. Nothing forced it: the `hostState` guard does not measure dashboard blocks. It is convention-driven.
- **Four component tests carried a container nothing read.** `CalendarYearView` and its three siblings contain no `useService`/`inject` — their only composable is `useToday()`, which takes no DI. Verified against all five `.vue` files before deleting. They became pure raw-`render` tests, matching `CalendarMonthView.test.ts`, which already had that shape.
- **`bridge.test.ts`'s pre-`initialize` test was preserved, not weakened.** The harness always calls `settings.initialize()` before `autoLoad()`, so it cannot be staged head-on; it now resolves the bridge from inside the `overrides` array, which runs in exactly that window. A `-1` sentinel closes the "override never ran" loophole.

## Limits of what was verified

- **e2e ran only here.** Local headed runs on this machine wedge specs CI never fails, so gate 3 is this PR's CI alone.
- **`d3f7f65a` has no direct test** (see above), only an incidental one.
- **The break-probes cover one file each** where a task had several: task 4 probed `CalendarYearView` and applied the identical mechanical transformation to its three siblings; task 5 probed `DatePicker` of three files.
- **📐 The carve-out costs a diagnostic.** A `data` seed with a mis-keyed slice — `calender` for `calendar` — now silently asserts against defaults where it used to raise `TestContainerInvalidSeedError`. The identical hole has existed for **collections** since `parseCollectionValue`'s own carve-out, so this generalized a pre-existing shape rather than creating one. The fix belongs in `testContainer` (reject any `data` key that is neither `version` nor a registered slice/collection key) and needs its own PR, because the test it requires cannot land inside a sweep. **It should land before sweep 3**, which is the first sweep to write `data` seeds under the new behaviour.
- **Deferred, none blocking:** `let settings!` assigned after `await testContainer(...)` in `CalendarWeekBlock.test.ts`; `mount`/`setupContainer` helper names not following the `resolve<Thing>` convention; four repeated `testContainer` blocks in `bridge.test.ts` that a helper would trade for indirection; now-inert `calendarDisplay: {}` and `pendingNoteMigration: []` seeds elsewhere in the suite.
