### PR TITLE
test(harness): close two testContainer guard holes before sweep 3

### DIFF
--- a/docs/unit-testing-strategy.md
+++ b/docs/unit-testing-strategy.md
@@ -143,7 +143,11 @@ subject **is** a host registration passes a full module, with
 `testContainer` throws rather than letting a misconfigured boot pass quietly.
 
 `TestContainerLeakedHostStateError` fires when a boot left commands, setting
-tabs, or ribbon icons behind — which a core module never produces. The usual
+tabs, ribbon icons, or markdown code-block processors behind — which a core
+module never produces. Code-block processors are on that list because
+`CodeBlockService` is eager and lives in the host module the harness always
+adds, so a full feature module's `CodeBlockDefinitionToken` values reach the
+host during `autoLoad` without touching a command or a tab. The usual
 cause is a full `<feature>Module` in `modules`. **The type system does not catch
 this**: the tokens a full module adds beyond core are all multi-tokens, whose
 bindings are additive, so registering one a second time succeeds silently.

--- a/docs/unit-testing-strategy.md
+++ b/docs/unit-testing-strategy.md
@@ -138,7 +138,7 @@ Service tests take core. Component tests take core plus ui. Only a test whose
 subject **is** a host registration passes a full module, with
 `allow: { hostState: true }`.
 
-### The two guards
+### The three guards
 
 `testContainer` throws rather than letting a misconfigured boot pass quietly.
 
@@ -158,6 +158,16 @@ a test asserts against a journal it did not ask for and fails somewhere far away
 **If it fires, your fixture is incomplete; fix the fixture.**
 `allow: { dataRepair: true }` is only for a test whose subject _is_ the repair
 path.
+
+`TestContainerUnknownSeedKeyError` fires when `data` carries a key that no
+loaded module registers. An absent slice or collection key is silent by design —
+a fresh install has none, and the parse answers with the defaults — which leaves
+a **mis-keyed** seed silent too: `calender` for `calendar` would let the test
+assert against the slice's defaults and pass with the seed ignored. The other
+cause is a correctly spelled key whose module was left out of `modules`, which
+is the same "your seed is not reaching the parse" mistake wearing a different
+hat. There is no `allow` for it: a key nothing registers is never what the test
+meant. `version` is always accepted — it is honored by the harness itself.
 
 ## Mounting
 

--- a/src/journals/notes/journal-link-handler.test.ts
+++ b/src/journals/notes/journal-link-handler.test.ts
@@ -217,7 +217,10 @@ describe("JournalLinkHandler", () => {
     it("leaves the token unresolved when no handler is registered under the token", async () => {
       // Guards the assertions above: without the FunctionHandlerToken binding the engine
       // cannot dispatch, so a passing render proves the wiring, not the grammar alone.
-      const bare = await testContainer({ data: { journals: ALL_JOURNALS } });
+      // No modules, and so no `journals` seed either: journalsCoreModule registers the
+      // collection and the handler together, so "collection without handler" is not a
+      // reachable wiring and a seed here would only have been ignored.
+      const bare = await testContainer();
 
       const rendered = bare.resolve(TemplateEngine).renderString("{{journal_link(yearly)}}", crossYearWeek());
 

--- a/src/testing.test.ts
+++ b/src/testing.test.ts
@@ -9,6 +9,7 @@ import { CUSTOM_LOCALE } from "@/calendar/calendar";
 import { calendarSettingsCoreModule } from "@/calendar/settings/module";
 import { calendarSlice } from "@/calendar/settings/slice";
 import { anchor, installTestCalendar, testCalendar } from "@/calendar/testing";
+import { codeBlocksModule } from "@/code-blocks";
 import type { CannotOverrideError } from "@/infrastructure/di";
 import { ContainerDisposedError, useService } from "@/infrastructure/di";
 import { NoticeService } from "@/infrastructure/host";
@@ -160,6 +161,16 @@ describe("testContainer", () => {
 
   it("throws a named error when a full module leaks host state", async () => {
     await expect(testContainer({ modules: [journalsModule] })).rejects.toThrow(TestContainerLeakedHostStateError);
+  });
+
+  it("counts a registered code-block processor as leaked host state", async () => {
+    // CodeBlockService is eager and always present, so a full module's code-block
+    // definitions reach the host during autoLoad without touching commands or tabs.
+    // The regex, not the error class: codeBlocksModule registers no command or tab, so a
+    // class-only assertion would still pass if this leak were the one the guard cannot see.
+    await expect(testContainer({ modules: [journalsCoreModule, codeBlocksModule] })).rejects.toThrow(
+      /codeBlockProcessors/,
+    );
   });
 });
 

--- a/src/testing.test.ts
+++ b/src/testing.test.ts
@@ -7,6 +7,7 @@ import { defineComponent, h } from "vue";
 import { Calendar } from "@/calendar";
 import { CUSTOM_LOCALE } from "@/calendar/calendar";
 import { calendarSettingsCoreModule } from "@/calendar/settings/module";
+import { calendarSlice } from "@/calendar/settings/slice";
 import { anchor, installTestCalendar, testCalendar } from "@/calendar/testing";
 import type { CannotOverrideError } from "@/infrastructure/di";
 import { ContainerDisposedError, useService } from "@/infrastructure/di";
@@ -28,6 +29,7 @@ import { SettingsService } from "@/settings";
 import {
   TestContainerInvalidSeedError,
   TestContainerLeakedHostStateError,
+  TestContainerUnknownSeedKeyError,
   overrideWith,
   overrideWithClass,
   testContainer,
@@ -248,6 +250,37 @@ describe("seed guard", () => {
         data: { journals: "nonsense" },
       }),
     ).rejects.toThrow(TestContainerInvalidSeedError);
+  });
+
+  it("rejects a seed key that no loaded module registers", async () => {
+    await expect(
+      testContainer({
+        modules: [calendarSettingsCoreModule],
+        data: { calender: { mode: "custom", dow: 1, doy: 4, global: false } },
+      }),
+    ).rejects.toThrow(TestContainerUnknownSeedKeyError);
+  });
+
+  it("names the unknown key in the error", async () => {
+    await expect(
+      testContainer({
+        modules: [calendarSettingsCoreModule],
+        data: { calender: { mode: "custom", dow: 1, doy: 4, global: false } },
+      }),
+    ).rejects.toThrow(
+      expect.objectContaining({
+        keys: ["calender"],
+      } satisfies Partial<TestContainerUnknownSeedKeyError>),
+    );
+  });
+
+  it("accepts a seed key registered by a module the test opted into", async () => {
+    const harness = await testContainer({
+      modules: [calendarSettingsCoreModule],
+      data: { calendar: { mode: "custom", dow: 1, doy: 4, global: false } },
+    });
+
+    expect(harness.settings.getSlice(calendarSlice).state).toEqual({ mode: "custom", dow: 1, doy: 4, global: false });
   });
 
   it("accepts a deliberately broken fixture when the test opts in", async () => {

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -28,7 +28,13 @@ import { FakeModalService, provideModalApiOnApp } from "@/infrastructure/host/mo
 import { FakeSuggestService } from "@/infrastructure/host/suggests/testing";
 import { FakeNoticeService, FakePluginData, FakeTemplaterService } from "@/infrastructure/host/testing";
 import { createLoggerTestingModule, type MemorySink } from "@/infrastructure/logger/testing";
-import { CURRENT_VERSION, SettingsService, settingsCoreModule } from "@/settings";
+import {
+  CURRENT_VERSION,
+  CollectionDefinitionToken,
+  SettingsService,
+  SliceDefinitionToken,
+  settingsCoreModule,
+} from "@/settings";
 import { templatesModule } from "@/templates";
 
 import type { App } from "vue";
@@ -77,6 +83,26 @@ export class TestContainerInvalidSeedError extends Error {
   }
 }
 
+/**
+ * Thrown when `data` carries a key that no loaded module registers. An absent slice or collection
+ * key is silent by design — a fresh install has none — which leaves a *mis-keyed* seed silent too:
+ * `calender` for `calendar` would otherwise let the test assert against the slice's defaults and
+ * pass with the seed ignored. The other cause is a correctly spelled key whose module was left out
+ * of `modules`.
+ */
+export class TestContainerUnknownSeedKeyError extends Error {
+  readonly keys: readonly string[];
+  constructor(keys: readonly string[], registered: readonly string[]) {
+    super(
+      `testContainer seed has key(s) no loaded module registers: ${keys.join(", ")}. ` +
+        `Registered: ${registered.join(", ")}. Either the key is misspelled, or the module that ` +
+        "registers it is missing from `modules`.",
+    );
+    this.name = "TestContainerUnknownSeedKeyError";
+    this.keys = keys;
+  }
+}
+
 export type TestOverride = (container: Container) => void;
 
 export function overrideWith<T>(token: TokenLike<T>, value: T): TestOverride {
@@ -118,7 +144,8 @@ export interface TestContainerOptions {
    * Seeded settings data, keyed by collection or slice key. Parsed by the real schema. `version`
    * is an honored key too — it defaults to `CURRENT_VERSION` but can be overridden to exercise
    * migrations. Omit `data` entirely (rather than passing `{}`) to simulate a fresh install with
-   * no stored data at all.
+   * no stored data at all. Any other key throws `TestContainerUnknownSeedKeyError`: the parse
+   * treats an absent key as a fresh install and returns defaults, so a typo is otherwise silent.
    */
   readonly data?: Record<string, unknown>;
   /** Defaults to true. Set false to skip eager construction. */
@@ -240,6 +267,17 @@ export async function testContainer(options: TestContainerOptions = {}): Promise
   const settings = container.resolve(SettingsService);
   const init = await settings.initialize();
   if (init.kind === "err") throw init.error;
+
+  const seededKeys = Object.keys(options.data ?? {});
+  if (seededKeys.length > 0) {
+    const registered = new Set([
+      "version",
+      ...container.resolve(SliceDefinitionToken).map((slice) => slice.key),
+      ...container.resolve(CollectionDefinitionToken).map((collection) => collection.key),
+    ]);
+    const unknown = seededKeys.filter((key) => !registered.has(key));
+    if (unknown.length > 0) throw new TestContainerUnknownSeedKeyError(unknown, [...registered].toSorted());
+  }
 
   if (options.allow?.dataRepair !== true) {
     const repairs = logs.records

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -51,9 +51,9 @@ const REPAIR_WARNINGS = new Set([
 
 /**
  * Thrown when a `testContainer` boot leaves host side effects (a registered command, setting
- * tab, or ribbon icon) that a CORE module never produces. The likely cause is a FULL
- * `<feature>Module` passed in `modules` instead of its core half — see the `modules` option's
- * doc comment below for why the type system does not catch this.
+ * tab, ribbon icon, or markdown code-block processor) that a CORE module never produces. The
+ * likely cause is a FULL `<feature>Module` passed in `modules` instead of its core half — see
+ * the `modules` option's doc comment below for why the type system does not catch this.
  */
 export class TestContainerLeakedHostStateError extends Error {
   constructor(leaked: readonly string[]) {
@@ -169,8 +169,8 @@ export interface TestContainerOptions {
   /**
    * Disarms a guard for a test whose subject IS the guarded thing.
    *
-   * `hostState` — the test asserts on `host.commands`/`settingTabs`/`ribbonIcons`, so it passes a
-   * FULL `<feature>Module` on purpose. Not an escape hatch for "the guard is in my way": a
+   * `hostState` — the test asserts on `host.commands`/`settingTabs`/`ribbonIcons`/
+   * `codeBlockProcessors`, so it passes a FULL `<feature>Module` on purpose. Not an escape hatch for "the guard is in my way": a
    * component test needing UI tokens takes `<feature>UiModule`, not this.
    *
    * `dataRepair` — the test exercises the settings repair path with a deliberately broken fixture.
@@ -299,6 +299,10 @@ export async function testContainer(options: TestContainerOptions = {}): Promise
     if (host.commands.size > 0) leaked.push("commands");
     if (host.settingTabs.length > 0) leaked.push("settingTabs");
     if (host.ribbonIcons.length > 0) leaked.push("ribbonIcons");
+    // CodeBlockService is eager and lives in the always-added host module, so a full feature
+    // module's CodeBlockDefinitionToken values reach the host during autoLoad — the same leak
+    // a stray command is, and invisible without this line.
+    if (host.codeBlockProcessors.size > 0) leaked.push("codeBlockProcessors");
     if (leaked.length > 0) throw new TestContainerLeakedHostStateError(leaked);
   }
 


### PR DESCRIPTION
Two harness guard fixes that must land before the `code-blocks` + `notes-calendar` sweep. Both add tests, which is why they cannot ride inside a sweep — the sweeps' gate 1 holds the test count exactly invariant.

## 1. A `data` seed key that no loaded module registers is now rejected

Sweep 2's `d3f7f65a` gave `parseSliceValue` the `raw === undefined` fresh-install carve-out that `parseCollectionValue` already had. That is the right production fix — it stopped every v3 user's console carrying a `slice reset to defaults` warning on a fresh install — but it made an absent slice key **silent**, and absence is indistinguishable from a typo:

```
before d3f7f65a:  data: { calender: {...} }  ->  TestContainerInvalidSeedError
after  d3f7f65a:  data: { calender: {...} }  ->  test silently asserts against defaults
```

The same hole has existed for collections since `parseCollectionValue`'s own carve-out, so the fix generalized a pre-existing shape rather than creating one. Either way the diagnostic belongs in the harness, not the parser.

`testContainer` now collects the registered keys off `SliceDefinitionToken` and `CollectionDefinitionToken` and throws `TestContainerUnknownSeedKeyError` for any `data` key that is not among them, naming both the offending keys and the registered set — because the second cause of the mistake is a correctly spelled key whose module was left out of `modules`, the same "the seed never reached the parse" failure wearing a different hat. `version` is accepted. There is deliberately **no** `allow` flag: unlike a repaired fixture, a key that nothing registers is never what a test meant.

**It found one on its first run.** `journal-link-handler.test.ts`'s *"leaves the token unresolved when no handler is registered under the token"* seeded `journals: ALL_JOURNALS` into a container with **no modules at all**, so the collection was never registered and the seed had never done anything. It cannot be made live either: `journalsCoreModule` registers `journalConfigCollection` and the `FunctionHandlerToken` binding together, so "collection registered, handler absent" is not a reachable wiring. Seed dropped, no assertion changed.

## 2. A registered code-block processor now counts as leaked host state

Found while sizing sweep 3. `CodeBlockService` is eager and lives in the host module `testContainer` always adds, so a full feature module's `CodeBlockDefinitionToken` values reach the fake host during `autoLoad`. The `hostState` guard checked only `commands`, `settingTabs` and `ribbonIcons` — so the one host side effect `src/code-blocks` actually produces was the one it could not see, and passing the full `codeBlocksModule` instead of its core half would have booted straight through the guard that exists to catch exactly that mistake.

The new test asserts on the message rather than the error class, because `codeBlocksModule` registers no command and no setting tab: a class-only assertion would still pass with this leak invisible.

`host.registeredViews` and `host.protocolHandlers` are the same shape and still unchecked, but neither is reachable today — only `views/view-host.ts` calls `registerView`, and `JournalUriHandler` is not eager. Left for the views sweep, where a test can prove the branch rather than assert an unreachable one.

## Verification

- `npm test` — **395 files / 4200 tests**, up from 4196 by the four tests added here.
- `npm run coverage` — 92.2 / 87.86 / 89.15 / 94.32, unchanged; no threshold moves.
- `npm run check:types`, `npm run check:lint`, prettier — clean.
- **Break-probes, both guards.** Replacing the unknown-key `throw` with a no-op turns both of its negative tests red and leaves its positive one green, so the check neither misses its case nor fires on everything:

```
     × rejects a seed key that no loaded module registers 6ms
     × names the unknown key in the error 2ms
 Test Files  1 failed (1)
      Tests  2 failed | 28 passed (30)
```

Deleting the `codeBlockProcessors` guard line turns its one test red, alone:

```
     × counts a registered code-block processor as leaked host state 6ms
      Tests  1 failed | 30 passed (31)
```

`docs/unit-testing-strategy.md`'s "The two guards" section becomes "The three guards", and the host-state list grows a fourth entry with the reason it is there.