### PR TITLE
test(decorations): move src/decorations onto testContainer (Phase 3 sweep 4)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,6 +36,7 @@ const convertedTestGlobs = [
   "src/calendar/**/*.test.ts",
   "src/code-blocks/**/*.test.ts",
   "src/notes-calendar/**/*.test.ts",
+  "src/decorations/**/*.test.ts",
 ];
 
 // `no-restricted-syntax` options replace rather than merge, so this array must carry

--- a/src/code-blocks/nav/ui/NavigationCodeBlock.test.ts
+++ b/src/code-blocks/nav/ui/NavigationCodeBlock.test.ts
@@ -7,7 +7,7 @@ import { nextTick } from "vue";
 import { anchor } from "@/calendar/testing";
 import type { CalendarDecoration, JournalDecoration } from "@/decorations";
 import { decorationsModule } from "@/decorations/module";
-import { decorationsSettingsModule } from "@/decorations/settings/module";
+import { decorationsSettingsCoreModule } from "@/decorations/settings/module";
 import { buildCalendarDecoration, buildCondition, buildDecoration, buildStyle } from "@/decorations/testing";
 import { initLocale, m } from "@/i18n";
 import { Flows } from "@/infrastructure/flows";
@@ -47,7 +47,7 @@ interface NavScenario {
 
 async function renderNav(path: string, scenario: NavScenario) {
   const harness = await testContainer({
-    modules: [journalsCoreModule, shelvesCoreModule, decorationsModule, decorationsSettingsModule],
+    modules: [journalsCoreModule, shelvesCoreModule, decorationsModule, decorationsSettingsCoreModule],
     data: {
       journals: scenario.journals,
       shelves: scenario.shelves ?? {},

--- a/src/code-blocks/timeline/ui/TimelineCalendar.test.ts
+++ b/src/code-blocks/timeline/ui/TimelineCalendar.test.ts
@@ -2,7 +2,7 @@ import { beforeAll, describe, expect, it } from "vitest";
 
 import { anchor } from "@/calendar/testing";
 import { decorationsModule } from "@/decorations/module";
-import { decorationsSettingsModule } from "@/decorations/settings/module";
+import { decorationsSettingsCoreModule } from "@/decorations/settings/module";
 import { buildCondition, buildDecoration, buildStyle } from "@/decorations/testing";
 import { initLocale } from "@/i18n";
 import { journalsCoreModule } from "@/journals/module";
@@ -17,7 +17,7 @@ const MODULES = [
   journalsCoreModule,
   shelvesCoreModule,
   decorationsModule,
-  decorationsSettingsModule,
+  decorationsSettingsCoreModule,
   notesCalendarModule,
 ];
 

--- a/src/code-blocks/timeline/ui/TimelineCodeBlock.test.ts
+++ b/src/code-blocks/timeline/ui/TimelineCodeBlock.test.ts
@@ -6,7 +6,7 @@ import { CalendarDate, type AnchorString } from "@/calendar";
 import { calendarSettingsCoreModule } from "@/calendar/settings/module";
 import { anchor } from "@/calendar/testing";
 import { decorationsModule } from "@/decorations/module";
-import { decorationsSettingsModule } from "@/decorations/settings/module";
+import { decorationsSettingsCoreModule } from "@/decorations/settings/module";
 import { initLocale } from "@/i18n";
 import type { VaultPath } from "@/infrastructure/host";
 import { JournalsIndex, type JournalConfig, type JournalEntry } from "@/journals";
@@ -25,7 +25,7 @@ const MODULES = [
   journalsCoreModule,
   shelvesCoreModule,
   decorationsModule,
-  decorationsSettingsModule,
+  decorationsSettingsCoreModule,
   notesCalendarModule,
   calendarSettingsCoreModule,
 ];

--- a/src/code-blocks/timeline/ui/TimelineMonth.test.ts
+++ b/src/code-blocks/timeline/ui/TimelineMonth.test.ts
@@ -3,7 +3,7 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 
 import { anchor } from "@/calendar/testing";
 import { decorationsModule } from "@/decorations/module";
-import { decorationsSettingsModule } from "@/decorations/settings/module";
+import { decorationsSettingsCoreModule } from "@/decorations/settings/module";
 import { initLocale } from "@/i18n";
 import { Flows } from "@/infrastructure/flows";
 import { OpenDateFlow } from "@/journals";
@@ -19,7 +19,7 @@ const MODULES = [
   journalsCoreModule,
   shelvesCoreModule,
   decorationsModule,
-  decorationsSettingsModule,
+  decorationsSettingsCoreModule,
   notesCalendarModule,
 ];
 

--- a/src/code-blocks/timeline/ui/TimelineQuarter.test.ts
+++ b/src/code-blocks/timeline/ui/TimelineQuarter.test.ts
@@ -2,7 +2,7 @@ import { beforeAll, describe, expect, it } from "vitest";
 
 import { anchor } from "@/calendar/testing";
 import { decorationsModule } from "@/decorations/module";
-import { decorationsSettingsModule } from "@/decorations/settings/module";
+import { decorationsSettingsCoreModule } from "@/decorations/settings/module";
 import { buildCondition, buildDecoration, buildStyle } from "@/decorations/testing";
 import { initLocale } from "@/i18n";
 import { journalsCoreModule } from "@/journals/module";
@@ -17,7 +17,7 @@ const MODULES = [
   journalsCoreModule,
   shelvesCoreModule,
   decorationsModule,
-  decorationsSettingsModule,
+  decorationsSettingsCoreModule,
   notesCalendarModule,
 ];
 

--- a/src/decorations/decorations-store.test.ts
+++ b/src/decorations/decorations-store.test.ts
@@ -1,28 +1,38 @@
-import { createNanoEvents } from "nanoevents";
 import { describe, expect, it } from "vitest";
-import { reactive } from "vue";
 
-import { JournalsRepository, journalDefaultsFor, type JournalConfig, type JournalsEvents } from "@/journals";
-import { createSettingsService } from "@/settings/testing";
-import { ShelvesRepository, type ShelvesEvents } from "@/shelves";
+import type { JournalConfig } from "@/journals/config";
+import { journalsCoreModule } from "@/journals/module";
+import { fixedJournal } from "@/journals/testing";
+import { ShelvesRepository } from "@/shelves";
 import type { ShelfConfig } from "@/shelves/config";
+import { shelvesCoreModule } from "@/shelves/module";
+import { buildShelf } from "@/shelves/testing";
+import { testContainer } from "@/testing";
 
 import { DecorationsStore } from "./decorations-store";
+import { decorationsModule } from "./module";
+import { decorationsSettingsCoreModule } from "./settings/module";
 import { decorationsSlice } from "./settings/slice";
 import { buildCalendarDecoration, buildCondition, buildDecoration, buildStyle } from "./testing";
 
-function build(options: { journals?: Record<string, JournalConfig>; shelves?: Record<string, ShelfConfig> } = {}) {
-  const { container, service } = createSettingsService({ slices: [decorationsSlice] });
-  const journalStorage = reactive<Record<string, JournalConfig>>({ ...options.journals });
-  const shelfStorage = reactive<Record<string, ShelfConfig>>({ ...options.shelves });
-  container
-    .register(JournalsRepository)
-    .useValue(JournalsRepository.fromParts(journalStorage, createNanoEvents<JournalsEvents>()));
-  container
-    .register(ShelvesRepository)
-    .useValue(ShelvesRepository.fromParts(shelfStorage, createNanoEvents<ShelvesEvents>()));
-  container.register(DecorationsStore).useClass(DecorationsStore);
-  return { store: container.resolve(DecorationsStore), journalStorage, shelfStorage, service };
+import type { CalendarDecoration } from "./config";
+
+async function build(
+  options: {
+    journals?: Record<string, JournalConfig>;
+    shelves?: Record<string, ShelfConfig>;
+    decorations?: readonly CalendarDecoration[];
+  } = {},
+) {
+  const harness = await testContainer({
+    modules: [journalsCoreModule, shelvesCoreModule, decorationsModule, decorationsSettingsCoreModule],
+    data: {
+      journals: options.journals ?? {},
+      shelves: options.shelves ?? {},
+      decorations: { decorations: options.decorations ?? [] },
+    },
+  });
+  return { harness, store: harness.resolve(DecorationsStore) };
 }
 
 const calendarDecoration = buildCalendarDecoration({
@@ -33,66 +43,66 @@ const calendarDecoration = buildCalendarDecoration({
 
 describe("DecorationsStore", () => {
   describe("list", () => {
-    it("returns a journal's own decorations", () => {
-      const journal = { ...journalDefaultsFor({ type: "day" }, "daily"), decorations: [buildDecoration()] };
-      const { store } = build({ journals: { daily: journal } });
+    it("returns a journal's own decorations", async () => {
+      const journal = fixedJournal("daily", { type: "day" }, { decorations: [buildDecoration()] });
+      const { store } = await build({ journals: { daily: journal } });
       expect(store.list({ kind: "journal", journalName: "daily" })).toEqual(journal.decorations);
     });
 
-    it("returns an empty list for a journal that no longer exists", () => {
-      const { store } = build();
+    it("returns an empty list for a journal that no longer exists", async () => {
+      const { store } = await build();
       expect(store.list({ kind: "journal", journalName: "gone" })).toEqual([]);
     });
   });
 
   describe("calendarList", () => {
-    it("returns a shelf's own calendar decorations", () => {
-      const { store } = build({
-        shelves: { work: { name: "work", journals: [], decorations: [calendarDecoration] } },
+    it("returns a shelf's own calendar decorations", async () => {
+      const { store } = await build({
+        shelves: { work: buildShelf("work", { decorations: [calendarDecoration] }) },
       });
       expect(store.calendarList({ kind: "shelf", shelfName: "work" })).toEqual([calendarDecoration]);
     });
 
-    it("returns the vault-wide calendar decorations", () => {
-      const { store, service } = build();
-      service.getSlice(decorationsSlice).state = { decorations: [calendarDecoration] };
+    it("returns the vault-wide calendar decorations", async () => {
+      const { store } = await build({ decorations: [calendarDecoration] });
       expect(store.calendarList({ kind: "global" })).toEqual([calendarDecoration]);
     });
   });
 
   describe("save", () => {
-    it("writes a shelf's decorations back to the shelf", () => {
-      const { store, shelfStorage } = build({ shelves: { work: { name: "work", journals: [], decorations: [] } } });
+    it("writes a shelf's decorations back to the shelf", async () => {
+      const { harness, store } = await build({ shelves: { work: buildShelf("work") } });
       store.save({ kind: "shelf", shelfName: "work" }, [calendarDecoration]);
-      expect(shelfStorage.work.decorations).toEqual([calendarDecoration]);
+      const shelf = harness.resolve(ShelvesRepository).get("work");
+      expect(shelf.isSome() && shelf.value.decorations).toEqual([calendarDecoration]);
     });
 
-    it("writes global decorations back to the settings slice", () => {
-      const { store, service } = build();
+    it("writes global decorations back to the settings slice", async () => {
+      const { harness, store } = await build();
       store.save({ kind: "global" }, [calendarDecoration]);
-      expect(service.getSlice(decorationsSlice).state.decorations).toEqual([calendarDecoration]);
+      expect(harness.settings.getSlice(decorationsSlice).state.decorations).toEqual([calendarDecoration]);
     });
   });
 
   describe("exists", () => {
-    it("reports an existing journal as present", () => {
-      const journal = journalDefaultsFor({ type: "day" }, "daily");
-      const { store } = build({ journals: { daily: journal } });
+    it("reports an existing journal as present", async () => {
+      const journal = fixedJournal("daily", { type: "day" });
+      const { store } = await build({ journals: { daily: journal } });
       expect(store.exists({ kind: "journal", journalName: "daily" })).toBe(true);
     });
 
-    it("reports a missing journal as absent", () => {
-      const { store } = build();
+    it("reports a missing journal as absent", async () => {
+      const { store } = await build();
       expect(store.exists({ kind: "journal", journalName: "gone" })).toBe(false);
     });
 
-    it("reports a missing shelf as absent", () => {
-      const { store } = build();
+    it("reports a missing shelf as absent", async () => {
+      const { store } = await build();
       expect(store.exists({ kind: "shelf", shelfName: "gone" })).toBe(false);
     });
 
-    it("always reports the global owner as present", () => {
-      const { store } = build();
+    it("always reports the global owner as present", async () => {
+      const { store } = await build();
       expect(store.exists({ kind: "global" })).toBe(true);
     });
   });

--- a/src/decorations/engine-checks.test.ts
+++ b/src/decorations/engine-checks.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { DayPeriod } from "@/calendar";
-import { date, installTestCalendar } from "@/calendar/testing";
+import { date } from "@/calendar/testing";
 import type { NoteMetadata } from "@/infrastructure/host";
 import type { CycleService } from "@/journals";
 import type { JournalConfig } from "@/journals/config";
@@ -30,14 +30,6 @@ function meta(partial: Partial<NoteMetadata>): NoteMetadata {
 }
 
 describe("engine-checks", () => {
-  let teardown: () => void;
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-  });
-
   describe("checkTitle", () => {
     it("is false when metadata is null", () => {
       const condition = buildCondition("title", { condition: "contains", value: "foo" });

--- a/src/decorations/engine.test.ts
+++ b/src/decorations/engine.test.ts
@@ -1,37 +1,35 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { DayPeriod, WeekPeriod } from "@/calendar";
 import type { AnchorString } from "@/calendar";
-import { date, installTestCalendar } from "@/calendar/testing";
-import { Container } from "@/infrastructure/di";
+import { date } from "@/calendar/testing";
 import { NoteMetadataService, NoteSizeService } from "@/infrastructure/host";
 import type { NoteSize, VaultPath } from "@/infrastructure/host";
-import { FakeNoteMetadataService, FakeNoteSizeService } from "@/infrastructure/host/testing";
-import { CycleService, JournalsIndex, JournalsRepository, TimelineService } from "@/journals";
+import { FakeNoteSizeService } from "@/infrastructure/host/testing";
+import { JournalsIndex } from "@/journals";
 import type { JournalConfig } from "@/journals/config";
-import { customJournal, fakeRepo, fixedJournal } from "@/journals/testing";
+import { journalsCoreModule } from "@/journals/module";
+import { customJournal, fixedJournal } from "@/journals/testing";
+import { shelvesCoreModule } from "@/shelves/module";
+import { overrideWith, testContainer, type TestHarness } from "@/testing";
 
 import { cellKey, DecorationEngine } from "./engine";
+import { decorationsModule } from "./module";
+import { decorationsSettingsCoreModule } from "./settings/module";
 import { buildCalendarDecoration, buildCondition, buildDecoration, buildStyle } from "./testing";
 
 import type { JournalDecoration } from "./config";
 
-function buildContainer(journals: Record<string, JournalConfig> = {}): {
-  c: Container;
-  metadata: FakeNoteMetadataService;
-  size: FakeNoteSizeService;
-} {
-  const c = new Container();
-  c.register(JournalsRepository).useValue(fakeRepo(journals));
-  c.register(JournalsIndex).useClass(JournalsIndex);
-  c.register(CycleService).useClass(CycleService);
-  c.register(TimelineService).useClass(TimelineService);
-  const metadata = new FakeNoteMetadataService();
-  c.register(NoteMetadataService).useValue(metadata as unknown as NoteMetadataService);
+async function buildHarness(
+  journals: Record<string, JournalConfig> = {},
+): Promise<{ harness: TestHarness; size: FakeNoteSizeService }> {
   const size = new FakeNoteSizeService();
-  c.register(NoteSizeService).useValue(size as unknown as NoteSizeService);
-  c.register(DecorationEngine).useClass(DecorationEngine);
-  return { c, metadata, size };
+  const harness = await testContainer({
+    modules: [journalsCoreModule, shelvesCoreModule, decorationsModule, decorationsSettingsCoreModule],
+    data: { journals, shelves: {}, decorations: { decorations: [] } },
+    overrides: [overrideWith(NoteSizeService, size as unknown as NoteSizeService)],
+  });
+  return { harness, size };
 }
 
 // A fortnightly journal bounded to a single month. Its intervals start 2026-01-05, 2026-01-19,
@@ -43,14 +41,14 @@ const sprintDecoration = buildDecoration({
   styles: [buildStyle("background")],
 });
 
-function sprintDayCells(day: string): Map<string, unknown> {
-  const { c } = buildContainer({
+async function sprintDayCells(day: string): Promise<Map<string, unknown>> {
+  const { harness } = await buildHarness({
     sprint: customJournal("sprint", "week", 2, "2026-01-05", {
       decorations: [sprintDecoration],
       timeline: { start: "2026-01-05" as AnchorString, end: { kind: "date", date: "2026-02-01" as AnchorString } },
     }),
   });
-  return c
+  return harness
     .resolve(DecorationEngine)
     .evaluateRange(
       [DayPeriod.containing(date(day))],
@@ -60,49 +58,43 @@ function sprintDayCells(day: string): Map<string, unknown> {
 
 const NOTE_PATH = "journals/2026-05-25.md" as VaultPath;
 
-function evaluateDaily(
+async function evaluateDaily(
   decoration: JournalDecoration,
   options: { registerNote: boolean; size?: NoteSize },
-): Map<string, unknown> {
-  const { c, size: sizes } = buildContainer({
+): Promise<Map<string, unknown>> {
+  const { harness, size: sizes } = await buildHarness({
     daily: fixedJournal("daily", { type: "day" }, { decorations: [decoration] }),
   });
   const period = DayPeriod.containing(date("2026-05-25"));
   if (options.registerNote) {
-    c.resolve(JournalsIndex).register({ journalName: "daily", anchor: period.anchor.toAnchor(), path: NOTE_PATH });
+    harness
+      .resolve(JournalsIndex)
+      .register({ journalName: "daily", anchor: period.anchor.toAnchor(), path: NOTE_PATH });
   }
   if (options.size !== undefined) sizes.setSize(NOTE_PATH, options.size);
-  return c
+  return harness
     .resolve(DecorationEngine)
     .evaluateRange([period], [{ kind: "journal", journalName: "daily", index: 0, decoration }]);
 }
 
 describe("DecorationEngine", () => {
-  let teardown: () => void;
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-  });
-
   describe("evaluateRange", () => {
-    it("returns an empty map for empty inputs", () => {
-      const { c } = buildContainer();
-      const engine = c.resolve(DecorationEngine);
+    it("returns an empty map for empty inputs", async () => {
+      const { harness } = await buildHarness();
+      const engine = harness.resolve(DecorationEngine);
       expect(engine.evaluateRange([], [])).toEqual(new Map());
     });
 
-    it("returns no entries when has-note condition is unmet (no journal entry seeded)", () => {
+    it("returns no entries when has-note condition is unmet (no journal entry seeded)", async () => {
       const decoration = buildDecoration({
         mode: "or",
         conditions: [buildCondition("has-note")],
         styles: [buildStyle("background")],
       });
-      const { c } = buildContainer({
+      const { harness } = await buildHarness({
         daily: fixedJournal("daily", { type: "day" }, { decorations: [decoration] }),
       });
-      const engine = c.resolve(DecorationEngine);
+      const engine = harness.resolve(DecorationEngine);
 
       const period = DayPeriod.containing(date("2026-05-25"));
       const result = engine.evaluateRange([period], [{ kind: "journal", journalName: "daily", index: 0, decoration }]);
@@ -110,16 +102,16 @@ describe("DecorationEngine", () => {
       expect(result.size).toBe(0);
     });
 
-    it("contributes a matching decoration once when the same cell is listed several times", () => {
+    it("contributes a matching decoration once when the same cell is listed several times", async () => {
       const decoration = buildDecoration({
         mode: "or",
         conditions: [buildCondition("weekday", { weekdays: [0, 1, 2, 3, 4, 5, 6] })],
         styles: [buildStyle("background")],
       });
-      const { c } = buildContainer({
+      const { harness } = await buildHarness({
         daily: fixedJournal("daily", { type: "day" }, { decorations: [decoration] }),
       });
-      const engine = c.resolve(DecorationEngine);
+      const engine = harness.resolve(DecorationEngine);
 
       const period = DayPeriod.containing(date("2026-05-25"));
       const result = engine.evaluateRange(
@@ -130,16 +122,16 @@ describe("DecorationEngine", () => {
       expect(result.get(cellKey(period.kind, period.anchor.toAnchor()))).toHaveLength(1);
     });
 
-    it("returns no entries when period kind mismatches journal write-type", () => {
+    it("returns no entries when period kind mismatches journal write-type", async () => {
       const decoration = buildDecoration({
         mode: "or",
         conditions: [buildCondition("weekday", { weekdays: [1] })],
         styles: [buildStyle("background")],
       });
-      const { c } = buildContainer({
+      const { harness } = await buildHarness({
         weekly: fixedJournal("weekly", { type: "week" }, { decorations: [decoration] }),
       });
-      const engine = c.resolve(DecorationEngine);
+      const engine = harness.resolve(DecorationEngine);
 
       const dayPeriod = DayPeriod.containing(date("2026-05-25"));
       const result = engine.evaluateRange(
@@ -150,7 +142,7 @@ describe("DecorationEngine", () => {
       expect(result.size).toBe(0);
     });
 
-    it("keeps day and week decorations in separate cells when their anchors coincide", () => {
+    it("keeps day and week decorations in separate cells when their anchors coincide", async () => {
       const dayDeco = buildDecoration({
         mode: "or",
         conditions: [buildCondition("date", { day: -1, month: -1, year: null })],
@@ -161,11 +153,11 @@ describe("DecorationEngine", () => {
         conditions: [buildCondition("date", { day: -1, month: -1, year: null })],
         styles: [buildStyle("background")],
       });
-      const { c } = buildContainer({
+      const { harness } = await buildHarness({
         daily: fixedJournal("daily", { type: "day" }, { decorations: [dayDeco] }),
         weekly: fixedJournal("weekly", { type: "week" }, { decorations: [weekDeco] }),
       });
-      const engine = c.resolve(DecorationEngine);
+      const engine = harness.resolve(DecorationEngine);
 
       const weekPeriod = WeekPeriod.containing(date("2026-05-25"));
       const dayPeriod = DayPeriod.containing(date(weekPeriod.anchor.toAnchor()));
@@ -187,7 +179,7 @@ describe("DecorationEngine", () => {
     // produce: the condition editor offers date/weekday only for day journals, and the write
     // type is fixed once a journal exists. They guard the anchor the engine evaluates against,
     // not a supported configuration.
-    it("matches a weekday condition naming the week's first day", () => {
+    it("matches a weekday condition naming the week's first day", async () => {
       // A week period evaluates weekday conditions against its anchor, which is its first day
       // (Monday under the ISO test calendar) — not the representative day {{date}} renders.
       const decoration = buildDecoration({
@@ -195,10 +187,10 @@ describe("DecorationEngine", () => {
         conditions: [buildCondition("weekday", { weekdays: [1] })],
         styles: [buildStyle("background")],
       });
-      const { c } = buildContainer({
+      const { harness } = await buildHarness({
         weekly: fixedJournal("weekly", { type: "week" }, { decorations: [decoration] }),
       });
-      const engine = c.resolve(DecorationEngine);
+      const engine = harness.resolve(DecorationEngine);
 
       const weekPeriod = WeekPeriod.containing(date("2026-05-25"));
       const result = engine.evaluateRange(
@@ -209,16 +201,16 @@ describe("DecorationEngine", () => {
       expect(result.size).toBe(1);
     });
 
-    it("does not match a weekday condition naming the week's representative day", () => {
+    it("does not match a weekday condition naming the week's representative day", async () => {
       const decoration = buildDecoration({
         mode: "or",
         conditions: [buildCondition("weekday", { weekdays: [4] })],
         styles: [buildStyle("background")],
       });
-      const { c } = buildContainer({
+      const { harness } = await buildHarness({
         weekly: fixedJournal("weekly", { type: "week" }, { decorations: [decoration] }),
       });
-      const engine = c.resolve(DecorationEngine);
+      const engine = harness.resolve(DecorationEngine);
 
       const weekPeriod = WeekPeriod.containing(date("2026-05-25"));
       const result = engine.evaluateRange(
@@ -229,12 +221,12 @@ describe("DecorationEngine", () => {
       expect(result.size).toBe(0);
     });
 
-    it("returns no entries when conditions list is empty", () => {
+    it("returns no entries when conditions list is empty", async () => {
       const decoration = buildDecoration({ styles: [buildStyle("background")] });
-      const { c } = buildContainer({
+      const { harness } = await buildHarness({
         daily: fixedJournal("daily", { type: "day" }, { decorations: [decoration] }),
       });
-      const engine = c.resolve(DecorationEngine);
+      const engine = harness.resolve(DecorationEngine);
 
       const period = DayPeriod.containing(date("2026-05-25"));
       const result = engine.evaluateRange([period], [{ kind: "journal", journalName: "daily", index: 0, decoration }]);
@@ -242,14 +234,14 @@ describe("DecorationEngine", () => {
       expect(result.size).toBe(0);
     });
 
-    it("paints a day cell from a calendar decoration", () => {
+    it("paints a day cell from a calendar decoration", async () => {
       const decoration = buildCalendarDecoration({
         mode: "or",
         conditions: [buildCondition("weekday", { weekdays: [1] })],
         styles: [buildStyle("background")],
       });
-      const { c } = buildContainer();
-      const engine = c.resolve(DecorationEngine);
+      const { harness } = await buildHarness();
+      const engine = harness.resolve(DecorationEngine);
 
       // 2026-05-25 is a Monday.
       const period = DayPeriod.containing(date("2026-05-25"));
@@ -261,14 +253,14 @@ describe("DecorationEngine", () => {
       expect(result.get(cellKey("day", period.anchor.toAnchor()))).toEqual(decoration.styles);
     });
 
-    it("leaves a week cell untouched for a calendar decoration", () => {
+    it("leaves a week cell untouched for a calendar decoration", async () => {
       const decoration = buildCalendarDecoration({
         mode: "or",
         conditions: [buildCondition("weekday", { weekdays: [1] })],
         styles: [buildStyle("background")],
       });
-      const { c } = buildContainer();
-      const engine = c.resolve(DecorationEngine);
+      const { harness } = await buildHarness();
+      const engine = harness.resolve(DecorationEngine);
 
       const period = WeekPeriod.containing(date("2026-05-25"));
       const result = engine.evaluateRange(
@@ -280,16 +272,19 @@ describe("DecorationEngine", () => {
     });
 
     describe("timeline bounds", () => {
-      it("paints an interval's first day inside the timeline", () => {
-        expect(sprintDayCells("2026-01-19").size).toBe(1);
+      it("paints an interval's first day inside the timeline", async () => {
+        const result = await sprintDayCells("2026-01-19");
+        expect(result.size).toBe(1);
       });
 
-      it("leaves an interval's first day past the timeline end undecorated", () => {
-        expect(sprintDayCells("2026-02-02").size).toBe(0);
+      it("leaves an interval's first day past the timeline end undecorated", async () => {
+        const result = await sprintDayCells("2026-02-02");
+        expect(result.size).toBe(0);
       });
 
-      it("leaves an interval's first day before the timeline start undecorated", () => {
-        expect(sprintDayCells("2025-12-22").size).toBe(0);
+      it("leaves an interval's first day before the timeline start undecorated", async () => {
+        const result = await sprintDayCells("2025-12-22");
+        expect(result.size).toBe(0);
       });
     });
 
@@ -300,32 +295,43 @@ describe("DecorationEngine", () => {
         styles: [buildStyle("background")],
       });
 
-      it("does not match a period with no note", () => {
-        expect(evaluateDaily(lessThan100, { registerNote: false }).size).toBe(0);
+      it("does not match a period with no note", async () => {
+        const result = await evaluateDaily(lessThan100, { registerNote: false });
+        expect(result.size).toBe(0);
       });
 
-      it("does not match a note whose size has not been read yet", () => {
-        expect(evaluateDaily(lessThan100, { registerNote: true }).size).toBe(0);
+      it("does not match a note whose size has not been read yet", async () => {
+        const result = await evaluateDaily(lessThan100, { registerNote: true });
+        expect(result.size).toBe(0);
       });
 
-      it("matches once the size is known", () => {
-        expect(evaluateDaily(lessThan100, { registerNote: true, size: { words: 40, characters: 220 } }).size).toBe(1);
+      it("matches once the size is known", async () => {
+        const result = await evaluateDaily(lessThan100, {
+          registerNote: true,
+          size: { words: 40, characters: 220 },
+        });
+        expect(result.size).toBe(1);
       });
 
-      it("does not match when the size is over the threshold", () => {
-        expect(evaluateDaily(lessThan100, { registerNote: true, size: { words: 400, characters: 2200 } }).size).toBe(0);
+      it("does not match when the size is over the threshold", async () => {
+        const result = await evaluateDaily(lessThan100, {
+          registerNote: true,
+          size: { words: 400, characters: 2200 },
+        });
+        expect(result.size).toBe(0);
       });
     });
 
-    it("never reads note metadata for a calendar decoration", () => {
+    it("never reads note metadata for a calendar decoration", async () => {
       const decoration = buildCalendarDecoration({
         mode: "or",
         conditions: [buildCondition("weekday", { weekdays: [1] })],
         styles: [buildStyle("background")],
       });
-      const { c, metadata } = buildContainer();
+      const { harness } = await buildHarness();
+      const metadata = harness.resolve(NoteMetadataService);
       const spy = vi.spyOn(metadata, "get");
-      const engine = c.resolve(DecorationEngine);
+      const engine = harness.resolve(DecorationEngine);
 
       engine.evaluateRange(
         [DayPeriod.containing(date("2026-05-25"))],
@@ -337,16 +343,16 @@ describe("DecorationEngine", () => {
   });
 
   describe("explainRange", () => {
-    it("labels a contribution with the decoration that produced it", () => {
+    it("labels a contribution with the decoration that produced it", async () => {
       const decoration = buildDecoration({
         mode: "or",
         conditions: [buildCondition("weekday", { weekdays: [1] })],
         styles: [buildStyle("background")],
       });
-      const { c } = buildContainer({
+      const { harness } = await buildHarness({
         daily: fixedJournal("daily", { type: "day" }, { decorations: [decoration] }),
       });
-      const engine = c.resolve(DecorationEngine);
+      const engine = harness.resolve(DecorationEngine);
 
       // 2026-05-25 is a Monday.
       const period = DayPeriod.containing(date("2026-05-25"));
@@ -357,7 +363,7 @@ describe("DecorationEngine", () => {
       ]);
     });
 
-    it("returns contributions in cascade order", () => {
+    it("returns contributions in cascade order", async () => {
       const calendarDecoration = buildCalendarDecoration({
         mode: "or",
         conditions: [buildCondition("weekday", { weekdays: [1] })],
@@ -368,10 +374,10 @@ describe("DecorationEngine", () => {
         conditions: [buildCondition("weekday", { weekdays: [1] })],
         styles: [buildStyle("corner", { placement: "top-left" })],
       });
-      const { c } = buildContainer({
+      const { harness } = await buildHarness({
         daily: fixedJournal("daily", { type: "day" }, { decorations: [journalDecoration] }),
       });
-      const engine = c.resolve(DecorationEngine);
+      const engine = harness.resolve(DecorationEngine);
 
       // 2026-05-25 is a Monday.
       const period = DayPeriod.containing(date("2026-05-25"));
@@ -387,16 +393,16 @@ describe("DecorationEngine", () => {
       expect(contributions?.map((contribution) => contribution.source.owner.kind)).toEqual(["global", "journal"]);
     });
 
-    it("returns no entry for a period nothing matched", () => {
+    it("returns no entry for a period nothing matched", async () => {
       const decoration = buildDecoration({
         mode: "or",
         conditions: [buildCondition("weekday", { weekdays: [2] })],
         styles: [buildStyle("background")],
       });
-      const { c } = buildContainer({
+      const { harness } = await buildHarness({
         daily: fixedJournal("daily", { type: "day" }, { decorations: [decoration] }),
       });
-      const engine = c.resolve(DecorationEngine);
+      const engine = harness.resolve(DecorationEngine);
 
       // 2026-05-25 is a Monday, so a Tuesday-only weekday condition never matches.
       const period = DayPeriod.containing(date("2026-05-25"));
@@ -405,16 +411,16 @@ describe("DecorationEngine", () => {
       expect(result.has(cellKey("day", period.anchor.toAnchor()))).toBe(false);
     });
 
-    it("omits a decoration that matches with no styles", () => {
+    it("omits a decoration that matches with no styles", async () => {
       const decoration = buildDecoration({
         mode: "or",
         conditions: [buildCondition("weekday", { weekdays: [1] })],
         styles: [],
       });
-      const { c } = buildContainer({
+      const { harness } = await buildHarness({
         daily: fixedJournal("daily", { type: "day" }, { decorations: [decoration] }),
       });
-      const engine = c.resolve(DecorationEngine);
+      const engine = harness.resolve(DecorationEngine);
 
       // 2026-05-25 is a Monday, so the condition matches; the decoration still contributes nothing.
       const period = DayPeriod.containing(date("2026-05-25"));

--- a/src/decorations/gather-bindings.test.ts
+++ b/src/decorations/gather-bindings.test.ts
@@ -1,37 +1,38 @@
-import { createNanoEvents } from "nanoevents";
 import { describe, expect, it } from "vitest";
-import { reactive } from "vue";
 
 import { JournalsRepository } from "@/journals";
 import type { JournalConfig } from "@/journals/config";
-import { customJournal, fakeRepo, fixedJournal } from "@/journals/testing";
-import { createSettingsService } from "@/settings/testing";
-import { ShelvesRepository, type ShelvesEvents } from "@/shelves";
-import type { ShelfConfig } from "@/shelves/config";
+import { journalsCoreModule } from "@/journals/module";
+import { customJournal, fixedJournal } from "@/journals/testing";
+import { shelvesCoreModule } from "@/shelves/module";
+import { buildShelf } from "@/shelves/testing";
+import { testContainer } from "@/testing";
 
 import { DecorationsStore } from "./decorations-store";
 import { gatherBindings, gatherFixedBindings, gatherIntervalBindings } from "./gather-bindings";
-import { decorationsSlice } from "./settings/slice";
+import { decorationsModule } from "./module";
+import { decorationsSettingsCoreModule } from "./settings/module";
 import { buildCalendarDecoration, buildCondition, buildDecoration, buildStyle } from "./testing";
 
-function build(
+async function build(
   journalDecorations: JournalConfig["decorations"] = [],
   extraJournals: Record<string, JournalConfig> = {},
 ) {
-  const { container: c, service } = createSettingsService({ slices: [decorationsSlice] });
-  service.getSlice(decorationsSlice).state = { decorations: [] };
-  const journals = fakeRepo({
-    daily: fixedJournal("daily", { type: "day" }, { decorations: journalDecorations }),
-    ...extraJournals,
+  const harness = await testContainer({
+    modules: [journalsCoreModule, shelvesCoreModule, decorationsModule, decorationsSettingsCoreModule],
+    data: {
+      journals: {
+        daily: fixedJournal("daily", { type: "day" }, { decorations: journalDecorations }),
+        ...extraJournals,
+      },
+      shelves: {
+        work: buildShelf("work"),
+        home: buildShelf("home"),
+      },
+      decorations: { decorations: [] },
+    },
   });
-  c.register(JournalsRepository).useValue(journals);
-  const shelfStorage = reactive<Record<string, ShelfConfig>>({
-    work: { name: "work", journals: [], decorations: [] },
-    home: { name: "home", journals: [], decorations: [] },
-  });
-  c.register(ShelvesRepository).useValue(ShelvesRepository.fromParts(shelfStorage, createNanoEvents<ShelvesEvents>()));
-  c.register(DecorationsStore).useClass(DecorationsStore);
-  return { journals, store: c.resolve(DecorationsStore) };
+  return { journals: harness.resolve(JournalsRepository), store: harness.resolve(DecorationsStore) };
 }
 
 const weekday = () => buildCondition("weekday", { weekdays: [1] });
@@ -51,8 +52,8 @@ function buildWithSprint() {
 }
 
 describe("gatherBindings", () => {
-  it("orders vault-wide bindings before journal bindings", () => {
-    const { journals, store } = build([
+  it("orders vault-wide bindings before journal bindings", async () => {
+    const { journals, store } = await build([
       buildDecoration({ mode: "or", conditions: [weekday()], styles: [buildStyle("background")] }),
     ]);
     store.save({ kind: "global" }, [
@@ -64,8 +65,8 @@ describe("gatherBindings", () => {
     expect(bindings.map((b) => b.kind)).toEqual(["calendar", "journal"]);
   });
 
-  it("orders shelf bindings before journal bindings", () => {
-    const { journals, store } = build([
+  it("orders shelf bindings before journal bindings", async () => {
+    const { journals, store } = await build([
       buildDecoration({ mode: "or", conditions: [weekday()], styles: [buildStyle("background")] }),
     ]);
     store.save({ kind: "shelf", shelfName: "work" }, [
@@ -77,8 +78,8 @@ describe("gatherBindings", () => {
     expect(bindings.map((b) => b.kind)).toEqual(["calendar", "journal"]);
   });
 
-  it("labels a vault-wide binding with the global owner", () => {
-    const { journals, store } = build();
+  it("labels a vault-wide binding with the global owner", async () => {
+    const { journals, store } = await build();
     store.save({ kind: "global" }, [buildCalendarDecoration({ mode: "or", conditions: [weekday()], styles: [] })]);
 
     const [binding] = gatherBindings(journals, store, { journalNames: [], shelf: null, includeCalendar: true });
@@ -86,8 +87,8 @@ describe("gatherBindings", () => {
     expect(binding?.kind === "calendar" ? binding.owner : null).toEqual({ kind: "global" });
   });
 
-  it("labels a shelf binding with its shelf owner", () => {
-    const { journals, store } = build();
+  it("labels a shelf binding with its shelf owner", async () => {
+    const { journals, store } = await build();
     store.save({ kind: "shelf", shelfName: "work" }, [
       buildCalendarDecoration({ mode: "or", conditions: [weekday()], styles: [] }),
     ]);
@@ -97,18 +98,18 @@ describe("gatherBindings", () => {
     expect(binding?.kind === "calendar" ? binding.owner : null).toEqual({ kind: "shelf", shelfName: "work" });
   });
 
-  it("numbers each binding by its position in its owner's list", () => {
+  it("numbers each binding by its position in its owner's list", async () => {
     const first = buildDecoration({ mode: "or", conditions: [weekday()], styles: [] });
     const second = buildDecoration({ mode: "or", conditions: [weekday()], styles: [] });
-    const { journals, store } = build([first, second]);
+    const { journals, store } = await build([first, second]);
 
     const bindings = gatherBindings(journals, store, { journalNames: ["daily"], shelf: null, includeCalendar: false });
 
     expect(bindings.map((b) => b.index)).toEqual([0, 1]);
   });
 
-  it("gathers every shelf's bindings when no shelf is in scope", () => {
-    const { journals, store } = build();
+  it("gathers every shelf's bindings when no shelf is in scope", async () => {
+    const { journals, store } = await build();
     store.save({ kind: "shelf", shelfName: "work" }, [
       buildCalendarDecoration({ mode: "or", conditions: [weekday()], styles: [] }),
     ]);
@@ -124,8 +125,8 @@ describe("gatherBindings", () => {
     ]);
   });
 
-  it("omits other shelves' bindings when one shelf is in scope", () => {
-    const { journals, store } = build();
+  it("omits other shelves' bindings when one shelf is in scope", async () => {
+    const { journals, store } = await build();
     store.save({ kind: "shelf", shelfName: "home" }, [
       buildCalendarDecoration({ mode: "or", conditions: [weekday()], styles: [] }),
     ]);
@@ -135,8 +136,8 @@ describe("gatherBindings", () => {
     expect(bindings).toEqual([]);
   });
 
-  it("orders vault-wide bindings before shelf bindings", () => {
-    const { journals, store } = build();
+  it("orders vault-wide bindings before shelf bindings", async () => {
+    const { journals, store } = await build();
     store.save({ kind: "global" }, [buildCalendarDecoration({ mode: "or", conditions: [weekday()], styles: [] })]);
     store.save({ kind: "shelf", shelfName: "work" }, [
       buildCalendarDecoration({ mode: "or", conditions: [weekday()], styles: [] }),
@@ -147,8 +148,8 @@ describe("gatherBindings", () => {
     expect(bindings.map((b) => (b.kind === "calendar" ? b.owner.kind : null))).toEqual(["global", "shelf"]);
   });
 
-  it("omits every calendar binding when the surface does not opt in", () => {
-    const { journals, store } = build();
+  it("omits every calendar binding when the surface does not opt in", async () => {
+    const { journals, store } = await build();
     store.save({ kind: "global" }, [buildCalendarDecoration({ mode: "or", conditions: [weekday()], styles: [] })]);
 
     const bindings = gatherBindings(journals, store, { journalNames: [], shelf: null, includeCalendar: false });
@@ -156,8 +157,8 @@ describe("gatherBindings", () => {
     expect(bindings).toEqual([]);
   });
 
-  it("drops journal bindings the filter rejects", () => {
-    const { journals, store } = build([buildDecoration({ mode: "or", conditions: [weekday()], styles: [] })]);
+  it("drops journal bindings the filter rejects", async () => {
+    const { journals, store } = await build([buildDecoration({ mode: "or", conditions: [weekday()], styles: [] })]);
 
     const bindings = gatherBindings(journals, store, {
       journalNames: ["daily"],
@@ -169,8 +170,8 @@ describe("gatherBindings", () => {
     expect(bindings).toEqual([]);
   });
 
-  it("spares calendar bindings from a filter meant only for journal bindings", () => {
-    const { journals, store } = build([buildDecoration({ mode: "or", conditions: [weekday()], styles: [] })]);
+  it("spares calendar bindings from a filter meant only for journal bindings", async () => {
+    const { journals, store } = await build([buildDecoration({ mode: "or", conditions: [weekday()], styles: [] })]);
     store.save({ kind: "global" }, [buildCalendarDecoration({ mode: "or", conditions: [weekday()], styles: [] })]);
 
     const bindings = gatherBindings(journals, store, {
@@ -185,40 +186,40 @@ describe("gatherBindings", () => {
 });
 
 describe("gatherFixedBindings and gatherIntervalBindings", () => {
-  it("excludes a custom journal's non-offset decoration from a fixed cell", () => {
-    const { journals, store } = buildWithSprint();
+  it("excludes a custom journal's non-offset decoration from a fixed cell", async () => {
+    const { journals, store } = await buildWithSprint();
 
     const bindings = gatherFixedBindings(journals, store, { journalNames: ["sprint"], shelf: null });
 
     expect(bindings.some((b) => b.kind === "journal" && b.index === NON_OFFSET_INDEX)).toBe(false);
   });
 
-  it("admits a custom journal's offset decoration to a fixed cell", () => {
-    const { journals, store } = buildWithSprint();
+  it("admits a custom journal's offset decoration to a fixed cell", async () => {
+    const { journals, store } = await buildWithSprint();
 
     const bindings = gatherFixedBindings(journals, store, { journalNames: ["sprint"], shelf: null });
 
     expect(bindings.some((b) => b.kind === "journal" && b.index === OFFSET_INDEX)).toBe(true);
   });
 
-  it("excludes a custom journal's offset decoration from an interval", () => {
-    const { journals } = buildWithSprint();
+  it("excludes a custom journal's offset decoration from an interval", async () => {
+    const { journals } = await buildWithSprint();
 
     const bindings = gatherIntervalBindings(journals, { journalName: "sprint" });
 
     expect(bindings.some((b) => b.kind === "journal" && b.index === OFFSET_INDEX)).toBe(false);
   });
 
-  it("admits a custom journal's non-offset decoration to an interval", () => {
-    const { journals } = buildWithSprint();
+  it("admits a custom journal's non-offset decoration to an interval", async () => {
+    const { journals } = await buildWithSprint();
 
     const bindings = gatherIntervalBindings(journals, { journalName: "sprint" });
 
     expect(bindings.some((b) => b.kind === "journal" && b.index === NON_OFFSET_INDEX)).toBe(true);
   });
 
-  it("keeps a non-custom journal's decorations in a fixed cell regardless of offset", () => {
-    const { journals, store } = buildWithSprint();
+  it("keeps a non-custom journal's decorations in a fixed cell regardless of offset", async () => {
+    const { journals, store } = await buildWithSprint();
 
     const bindings = gatherFixedBindings(journals, store, { journalNames: ["daily"], shelf: null });
 

--- a/src/decorations/match-service.test.ts
+++ b/src/decorations/match-service.test.ts
@@ -1,59 +1,29 @@
-import { createNanoEvents } from "nanoevents";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CalendarDate } from "@/calendar";
-import { installTestCalendar } from "@/calendar/testing";
-import type { Container } from "@/infrastructure/di";
-import { NoteMetadataService, NoteSizeService, type VaultPath } from "@/infrastructure/host";
-import { FakeNoteMetadataService, FakeNoteSizeService } from "@/infrastructure/host/testing";
-import { CycleService, JournalsIndex, JournalsRepository, TimelineService } from "@/journals";
+import type { VaultPath } from "@/infrastructure/host";
+import { JournalsIndex } from "@/journals";
 import type { JournalConfig } from "@/journals/config";
-import { customJournal, fakeRepo, fixedJournal } from "@/journals/testing";
-import { createSettingsService } from "@/settings/testing";
-import { ShelvesRepository, type ShelfConfig, type ShelvesEvents } from "@/shelves";
+import { journalsCoreModule } from "@/journals/module";
+import { customJournal, fixedJournal } from "@/journals/testing";
+import { shelvesCoreModule } from "@/shelves/module";
+import { testContainer, type TestHarness } from "@/testing";
 
 import { DecorationsStore } from "./decorations-store";
-import { DecorationEngine } from "./engine";
 import { DecorationMatchService } from "./match-service";
 import { CUSTOM_MATCH_HORIZON } from "./match-window";
-import { decorationsSlice } from "./settings/slice";
+import { decorationsModule } from "./module";
+import { decorationsSettingsCoreModule } from "./settings/module";
 import { buildCalendarDecoration, buildCondition, buildDecoration, buildStyle } from "./testing";
 
 import type { JournalDecoration } from "./config";
 import type { MatchBadge } from "./match-service";
 
-interface Harness {
-  c: Container;
-  store: DecorationsStore;
-  index: JournalsIndex;
-  fakeMetadata: FakeNoteMetadataService;
-  service: DecorationMatchService;
-}
-
-// Mirrors use-cell-decorations.test.ts's harness: same registrations, minus the Vue-only pieces
-// this service never touches (no NotesService emitter, no cell-map rendering).
-function buildHarness(journals: Record<string, JournalConfig> = {}): Harness {
-  const { container: c, service: settings } = createSettingsService({ slices: [decorationsSlice] });
-  settings.getSlice(decorationsSlice).state = { decorations: [] };
-  c.register(JournalsRepository).useValue(fakeRepo(journals));
-  c.register(JournalsIndex).useClass(JournalsIndex);
-  c.register(CycleService).useClass(CycleService);
-  c.register(TimelineService).useClass(TimelineService);
-  const fakeMetadata = new FakeNoteMetadataService();
-  c.register(NoteMetadataService).useValue(fakeMetadata as unknown as NoteMetadataService);
-  c.register(NoteSizeService).useValue(new FakeNoteSizeService() as unknown as NoteSizeService);
-  c.register(DecorationEngine).useClass(DecorationEngine);
-  const shelfStorage: Record<string, ShelfConfig> = {};
-  c.register(ShelvesRepository).useValue(ShelvesRepository.fromParts(shelfStorage, createNanoEvents<ShelvesEvents>()));
-  c.register(DecorationsStore).useClass(DecorationsStore);
-  c.register(DecorationMatchService).useClass(DecorationMatchService);
-  return {
-    c,
-    store: c.resolve(DecorationsStore),
-    index: c.resolve(JournalsIndex),
-    fakeMetadata,
-    service: c.resolve(DecorationMatchService),
-  };
+async function buildHarness(journals: Record<string, JournalConfig> = {}): Promise<TestHarness> {
+  return testContainer({
+    modules: [journalsCoreModule, shelvesCoreModule, decorationsModule, decorationsSettingsCoreModule],
+    data: { journals, shelves: {}, decorations: { decorations: [] } },
+  });
 }
 
 function date(s: string): CalendarDate {
@@ -84,21 +54,18 @@ function neverMatches(): JournalDecoration {
   });
 }
 
-let teardown: () => void;
 beforeEach(() => {
-  ({ teardown } = installTestCalendar());
-  vi.useFakeTimers();
   // 2026-05-25 is a Monday.
+  vi.useFakeTimers();
   vi.setSystemTime(new Date(2026, 4, 25, 9, 0, 0));
 });
 afterEach(() => {
   vi.useRealTimers();
-  teardown();
 });
 
 describe("DecorationMatchService", () => {
   describe("counting", () => {
-    it("counts the periods a decoration matched", () => {
+    it("counts the periods a decoration matched", async () => {
       // A weekday-only decoration matches on schedule rather than every period, so a broken
       // implementation that reports total instead of the real match count (or matches every
       // period regardless of condition) fails this: 13 Mondays fall in the last 90 days ending
@@ -108,18 +75,21 @@ describe("DecorationMatchService", () => {
         conditions: [buildCondition("weekday", { weekdays: [1] })],
         styles: [buildStyle("background")],
       });
-      const h = buildHarness({ daily: fixedJournal("daily", { type: "day" }, { decorations: [decoration] }) });
+      const harness = await buildHarness({
+        daily: fixedJournal("daily", { type: "day" }, { decorations: [decoration] }),
+      });
+      const service = harness.resolve(DecorationMatchService);
 
-      const badge = expectMatched(h.service.describe({ kind: "journal", journalName: "daily" }, 0));
+      const badge = expectMatched(service.describe({ kind: "journal", journalName: "daily" }, 0));
       expect(badge.matched).toBe(13);
       expect(badge.total).toBe(90);
     });
 
-    it("reports the clipped total for a journal younger than its horizon", () => {
+    it("reports the clipped total for a journal younger than its horizon", async () => {
       // Without clipping the denominator to the timeline, a 12-week-old journal would report
       // against the full 26-week horizon instead of the 12 weeks it has actually existed.
       const decoration = neverMatches();
-      const h = buildHarness({
+      const harness = await buildHarness({
         weekly: fixedJournal(
           "weekly",
           { type: "week" },
@@ -129,29 +99,33 @@ describe("DecorationMatchService", () => {
           },
         ),
       });
+      const service = harness.resolve(DecorationMatchService);
 
-      const badge = expectSilent(h.service.describe({ kind: "journal", journalName: "weekly" }, 0));
+      const badge = expectSilent(service.describe({ kind: "journal", journalName: "weekly" }, 0));
       expect(badge.total).toBe(12);
     });
 
-    it("reports silent for a decoration that matched nothing", () => {
+    it("reports silent for a decoration that matched nothing", async () => {
       // Flips the > 0 branch: a decoration with zero matches must not read as "matched".
       const decoration = neverMatches();
-      const h = buildHarness({ daily: fixedJournal("daily", { type: "day" }, { decorations: [decoration] }) });
+      const harness = await buildHarness({
+        daily: fixedJournal("daily", { type: "day" }, { decorations: [decoration] }),
+      });
+      const service = harness.resolve(DecorationMatchService);
 
-      const badge = h.service.describe({ kind: "journal", journalName: "daily" }, 0);
+      const badge = service.describe({ kind: "journal", journalName: "daily" }, 0);
       expect(badge.kind).toBe("silent");
     });
   });
 
   describe("finished journals", () => {
-    it("reports a real match count for a journal whose timeline has already ended", () => {
+    it("reports a real match count for a journal whose timeline has already ended", async () => {
       // Anchoring at today instead of the timeline's own end would clip this journal's
       // entire 2020-2021 history away and misreport it as having none: today's window
       // (roughly 2026-02-25 through 2026-05-25) shares no periods with a timeline that ended
       // in mid-2021, so every one of those periods would fail the end-bound check.
       const decoration = buildDecoration({ mode: "or", conditions: [wildcard], styles: [buildStyle("background")] });
-      const h = buildHarness({
+      const harness = await buildHarness({
         daily: fixedJournal(
           "daily",
           { type: "day" },
@@ -164,8 +138,9 @@ describe("DecorationMatchService", () => {
           },
         ),
       });
+      const service = harness.resolve(DecorationMatchService);
 
-      const badge = expectMatched(h.service.describe({ kind: "journal", journalName: "daily" }, 0));
+      const badge = expectMatched(service.describe({ kind: "journal", journalName: "daily" }, 0));
       expect(badge.matched).toBe(90);
       expect(badge.total).toBe(90);
       expect(badge.direction).toBe("past");
@@ -173,26 +148,27 @@ describe("DecorationMatchService", () => {
   });
 
   describe("evidence", () => {
-    it("reports a single-period total for a journal whose timeline starts today", () => {
+    it("reports a single-period total for a journal whose timeline starts today", async () => {
       // The design was corrected to say a journal starting today still has today's own period —
       // it reports against a denominator of one rather than emptying into "no history yet". A
       // one-character regression in TimelineService.contains that starts excluding a journal's
       // own start date (e.g. flipping >= to >) would silently turn every fresh journal's badge
       // into "no history yet", the exact state the design says must not be the fresh-journal case.
       const decoration = neverMatches();
-      const h = buildHarness({
+      const harness = await buildHarness({
         daily: fixedJournal(
           "daily",
           { type: "day" },
           { decorations: [decoration], timeline: { start: date("2026-05-25").toAnchor(), end: { kind: "never" } } },
         ),
       });
+      const service = harness.resolve(DecorationMatchService);
 
-      const badge = expectSilent(h.service.describe({ kind: "journal", journalName: "daily" }, 0));
+      const badge = expectSilent(service.describe({ kind: "journal", journalName: "daily" }, 0));
       expect(badge.total).toBe(1);
     });
 
-    it("reports no notes for a note-needing decoration over a note-free window", () => {
+    it("reports no notes for a note-needing decoration over a note-free window", async () => {
       // Without the notes gate, an empty index would silently read as "silent" (0 matched)
       // rather than the "we cannot tell yet" state the note-based condition demands.
       const decoration = buildDecoration({
@@ -200,13 +176,16 @@ describe("DecorationMatchService", () => {
         conditions: [buildCondition("has-note")],
         styles: [buildStyle("background")],
       });
-      const h = buildHarness({ daily: fixedJournal("daily", { type: "day" }, { decorations: [decoration] }) });
+      const harness = await buildHarness({
+        daily: fixedJournal("daily", { type: "day" }, { decorations: [decoration] }),
+      });
+      const service = harness.resolve(DecorationMatchService);
 
-      const badge = h.service.describe({ kind: "journal", journalName: "daily" }, 0);
+      const badge = service.describe({ kind: "journal", journalName: "daily" }, 0);
       expect(badge.kind).toBe("no-notes");
     });
 
-    it("counts normally for a note-needing decoration once one note exists", () => {
+    it("counts normally for a note-needing decoration once one note exists", async () => {
       // Seeding a single entry must flip the state machine out of "no-notes" and back into
       // ordinary counting — this catches an implementation that ignores the index entirely.
       const decoration = buildDecoration({
@@ -214,24 +193,30 @@ describe("DecorationMatchService", () => {
         conditions: [buildCondition("has-note")],
         styles: [buildStyle("background")],
       });
-      const h = buildHarness({ daily: fixedJournal("daily", { type: "day" }, { decorations: [decoration] }) });
+      const harness = await buildHarness({
+        daily: fixedJournal("daily", { type: "day" }, { decorations: [decoration] }),
+      });
       const path = "Daily/2026-05-25.md" as VaultPath;
-      h.index.register({ journalName: "daily", anchor: date("2026-05-25").toAnchor(), path });
-      h.fakeMetadata.setMetadata(path, { title: "2026-05-25", tags: [], properties: {}, tasks: [] });
+      harness.resolve(JournalsIndex).register({ journalName: "daily", anchor: date("2026-05-25").toAnchor(), path });
+      harness.host.putFile(path);
+      const service = harness.resolve(DecorationMatchService);
 
-      const badge = expectMatched(h.service.describe({ kind: "journal", journalName: "daily" }, 0));
+      const badge = expectMatched(service.describe({ kind: "journal", journalName: "daily" }, 0));
       expect(badge.matched).toBe(1);
     });
 
-    it("reports silent rather than no notes for a date-only decoration over a note-free window", () => {
+    it("reports silent rather than no notes for a date-only decoration over a note-free window", async () => {
       // The one test that pins needsNotes into the service: a decoration that never needs a
       // note must report "silent" over a note-free window, not "no-notes". An implementation
       // that reports "no-notes" for any note-free window regardless of the decoration would
       // pass every other evidence test but fail this one.
       const decoration = neverMatches();
-      const h = buildHarness({ daily: fixedJournal("daily", { type: "day" }, { decorations: [decoration] }) });
+      const harness = await buildHarness({
+        daily: fixedJournal("daily", { type: "day" }, { decorations: [decoration] }),
+      });
+      const service = harness.resolve(DecorationMatchService);
 
-      const badge = h.service.describe({ kind: "journal", journalName: "daily" }, 0);
+      const badge = service.describe({ kind: "journal", journalName: "daily" }, 0);
       expect(badge.kind).toBe("silent");
     });
   });
@@ -243,21 +228,24 @@ describe("DecorationMatchService", () => {
       styles: [buildStyle("background")],
     });
 
-    it("does not preview a decoration carrying a note-size condition", () => {
+    it("does not preview a decoration carrying a note-size condition", async () => {
       // The window is not warm and a count would be a guess, so no badge is offered.
       const path = "Daily/2026-05-25.md" as VaultPath;
-      const h = buildHarness({ daily: fixedJournal("daily", { type: "day" }, { decorations: [noteSizeDecoration] }) });
-      h.index.register({ journalName: "daily", anchor: date("2026-05-25").toAnchor(), path });
-      h.fakeMetadata.setMetadata(path, { title: "2026-05-25", tags: [], properties: {}, tasks: [] });
+      const harness = await buildHarness({
+        daily: fixedJournal("daily", { type: "day" }, { decorations: [noteSizeDecoration] }),
+      });
+      harness.resolve(JournalsIndex).register({ journalName: "daily", anchor: date("2026-05-25").toAnchor(), path });
+      harness.host.putFile(path);
+      const service = harness.resolve(DecorationMatchService);
 
-      const badge = h.service.describe({ kind: "journal", journalName: "daily" }, 0);
+      const badge = service.describe({ kind: "journal", journalName: "daily" }, 0);
       expect(badge.kind).toBe("not-previewable");
     });
 
-    it("still reports no-history for a note-size rule on a journal with no history", () => {
+    it("still reports no-history for a note-size rule on a journal with no history", async () => {
       // The early return sits below the no-history check, so a journal whose timeline never
       // overlaps the window still gets the more actionable verdict rather than going silent.
-      const h = buildHarness({
+      const harness = await buildHarness({
         daily: fixedJournal(
           "daily",
           { type: "day" },
@@ -270,30 +258,32 @@ describe("DecorationMatchService", () => {
           },
         ),
       });
+      const service = harness.resolve(DecorationMatchService);
 
-      const badge = h.service.describe({ kind: "journal", journalName: "daily" }, 0);
+      const badge = service.describe({ kind: "journal", journalName: "daily" }, 0);
       expect(badge.kind).toBe("no-history");
     });
 
-    it("still reports no-notes for a note-size rule when the window holds no notes", () => {
+    it("still reports no-notes for a note-size rule when the window holds no notes", async () => {
       // The early return sits below the no-notes check too: needsNotes still fires for a
       // note-size-only rule because match-window.ts's NOTE_BASED set carries "note-size".
-      const h = buildHarness({
+      const harness = await buildHarness({
         daily: fixedJournal("daily", { type: "day" }, { decorations: [noteSizeDecoration] }),
       });
+      const service = harness.resolve(DecorationMatchService);
 
-      const badge = h.service.describe({ kind: "journal", journalName: "daily" }, 0);
+      const badge = service.describe({ kind: "journal", journalName: "daily" }, 0);
       expect(badge.kind).toBe("no-notes");
     });
   });
 
   describe("direction", () => {
-    it("looks forward for a journal whose timeline starts in the future", () => {
+    it("looks forward for a journal whose timeline starts in the future", async () => {
       // Swapping the isAfter comparison (or dropping the future branch entirely) leaves this
       // reporting "past", so the window would look backward from today into a history that
       // does not exist yet.
       const decoration = buildDecoration({ mode: "or", conditions: [wildcard], styles: [buildStyle("background")] });
-      const h = buildHarness({
+      const harness = await buildHarness({
         daily: fixedJournal(
           "daily",
           { type: "day" },
@@ -303,22 +293,26 @@ describe("DecorationMatchService", () => {
           },
         ),
       });
+      const service = harness.resolve(DecorationMatchService);
 
-      const badge = expectMatched(h.service.describe({ kind: "journal", journalName: "daily" }, 0));
+      const badge = expectMatched(service.describe({ kind: "journal", journalName: "daily" }, 0));
       expect(badge.direction).toBe("future");
     });
 
-    it("looks backward for a journal with history", () => {
+    it("looks backward for a journal with history", async () => {
       const decoration = buildDecoration({ mode: "or", conditions: [wildcard], styles: [buildStyle("background")] });
-      const h = buildHarness({ daily: fixedJournal("daily", { type: "day" }, { decorations: [decoration] }) });
+      const harness = await buildHarness({
+        daily: fixedJournal("daily", { type: "day" }, { decorations: [decoration] }),
+      });
+      const service = harness.resolve(DecorationMatchService);
 
-      const badge = expectMatched(h.service.describe({ kind: "journal", journalName: "daily" }, 0));
+      const badge = expectMatched(service.describe({ kind: "journal", journalName: "daily" }, 0));
       expect(badge.direction).toBe("past");
     });
   });
 
   describe("custom-interval clipping", () => {
-    it("clips a day-granular window by the interval owning each day, not the day itself", () => {
+    it("clips a day-granular window by the interval owning each day, not the day itself", async () => {
       // The timeline start (2026-03-15) falls inside the interval anchored 2026-03-09, which
       // straddles it and so stays entirely in-timeline — including its six pre-start days. The
       // interval anchored 2026-02-23 ends (2026-03-08) before the start and is dropped whole.
@@ -332,29 +326,33 @@ describe("DecorationMatchService", () => {
         conditions: [buildCondition("offset", { offset: 1 })],
         styles: [buildStyle("background")],
       });
-      const h = buildHarness({
+      const harness = await buildHarness({
         sprint: customJournal("sprint", "week", 2, "2020-01-06", {
           decorations: [decoration],
           timeline: { start: date("2026-03-15").toAnchor(), end: { kind: "never" } },
         }),
       });
+      const service = harness.resolve(DecorationMatchService);
 
-      const badge = expectMatched(h.service.describe({ kind: "journal", journalName: "sprint" }, 0));
+      const badge = expectMatched(service.describe({ kind: "journal", journalName: "sprint" }, 0));
       expect(badge.total).toBe(78);
       expect(badge.matched).toBe(6);
     });
   });
 
   describe("units", () => {
-    it("reports weeks for a weekly journal", () => {
+    it("reports weeks for a weekly journal", async () => {
       const decoration = buildDecoration({ mode: "or", conditions: [wildcard], styles: [buildStyle("background")] });
-      const h = buildHarness({ weekly: fixedJournal("weekly", { type: "week" }, { decorations: [decoration] }) });
+      const harness = await buildHarness({
+        weekly: fixedJournal("weekly", { type: "week" }, { decorations: [decoration] }),
+      });
+      const service = harness.resolve(DecorationMatchService);
 
-      const badge = expectMatched(h.service.describe({ kind: "journal", journalName: "weekly" }, 0));
+      const badge = expectMatched(service.describe({ kind: "journal", journalName: "weekly" }, 0));
       expect(badge.unit).toBe("week");
     });
 
-    it("reports intervals for a custom journal", () => {
+    it("reports intervals for a custom journal", async () => {
       // periodKindForWrite("custom") is "day"; a service that reports that raw value instead
       // of overriding to "interval" fails the unit assertion. And a service that substitutes
       // a day-granular window of the right length (right total, wrong spacing) fails the
@@ -365,17 +363,18 @@ describe("DecorationMatchService", () => {
         conditions: [buildCondition("weekday", { weekdays: [1] })],
         styles: [buildStyle("background")],
       });
-      const h = buildHarness({
+      const harness = await buildHarness({
         sprint: customJournal("sprint", "week", 2, "2020-01-06", { decorations: [decoration] }),
       });
+      const service = harness.resolve(DecorationMatchService);
 
-      const badge = expectMatched(h.service.describe({ kind: "journal", journalName: "sprint" }, 0));
+      const badge = expectMatched(service.describe({ kind: "journal", journalName: "sprint" }, 0));
       expect(badge.total).toBe(CUSTOM_MATCH_HORIZON);
       expect(badge.matched).toBe(CUSTOM_MATCH_HORIZON);
       expect(badge.unit).toBe("interval");
     });
 
-    it("reports days for an offset decoration on a custom journal", () => {
+    it("reports days for an offset decoration on a custom journal", async () => {
       // periodForJournal maps every interval to its own first day, so an interval-anchored
       // window can only ever satisfy offset 1 — reusing it for an offset-3 decoration would
       // report "silent" forever. A day-granular window is the only way this can fire, and
@@ -385,25 +384,27 @@ describe("DecorationMatchService", () => {
         conditions: [buildCondition("offset", { offset: 3 })],
         styles: [buildStyle("background")],
       });
-      const h = buildHarness({
+      const harness = await buildHarness({
         sprint: customJournal("sprint", "week", 2, "2020-01-06", { decorations: [decoration] }),
       });
+      const service = harness.resolve(DecorationMatchService);
 
-      const badge = expectMatched(h.service.describe({ kind: "journal", journalName: "sprint" }, 0));
+      const badge = expectMatched(service.describe({ kind: "journal", journalName: "sprint" }, 0));
       expect(badge.matched).toBe(7);
       expect(badge.unit).toBe("day");
     });
 
-    it("reports days for a vault-wide decoration", () => {
+    it("reports days for a vault-wide decoration", async () => {
       const decoration = buildCalendarDecoration({
         mode: "or",
         conditions: [wildcard],
         styles: [buildStyle("background")],
       });
-      const h = buildHarness();
-      h.store.save({ kind: "global" }, [decoration]);
+      const harness = await buildHarness();
+      harness.resolve(DecorationsStore).save({ kind: "global" }, [decoration]);
+      const service = harness.resolve(DecorationMatchService);
 
-      const badge = expectMatched(h.service.describe({ kind: "global" }, 0));
+      const badge = expectMatched(service.describe({ kind: "global" }, 0));
       expect(badge.unit).toBe("day");
     });
   });

--- a/src/decorations/match-window.test.ts
+++ b/src/decorations/match-window.test.ts
@@ -1,18 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { CalendarDate } from "@/calendar";
-import { installTestCalendar } from "@/calendar/testing";
 
 import { fixedWindow, needsNotes, MATCH_HORIZON } from "./match-window";
 import { buildCondition, buildDecoration } from "./testing";
-
-let teardown: () => void;
-beforeEach(() => {
-  ({ teardown } = installTestCalendar());
-});
-afterEach(() => {
-  teardown();
-});
 
 function date(s: string): CalendarDate {
   const r = CalendarDate.parse(s);

--- a/src/decorations/settings/flows/delete-decoration.flow.test.ts
+++ b/src/decorations/settings/flows/delete-decoration.flow.test.ts
@@ -1,6 +1,4 @@
-import { createNanoEvents } from "nanoevents";
 import { describe, expect, it } from "vitest";
-import { reactive } from "vue";
 
 import {
   DecorationLifecycleFlowError,
@@ -8,41 +6,37 @@ import {
   UnknownDecorationOwnerError,
 } from "@/decorations/errors";
 import { Flows, UserAborted } from "@/infrastructure/flows";
-import { NoticeService } from "@/infrastructure/host";
-import { ModalService } from "@/infrastructure/host/modals";
-import { FakeModalService } from "@/infrastructure/host/modals/testing";
-import { FakeNoticeService } from "@/infrastructure/host/testing";
-import { JournalsRepository, journalDefaultsFor, type JournalConfig, type JournalsEvents } from "@/journals";
-import { createSettingsService } from "@/settings/testing";
-import { ShelvesRepository, type ShelvesEvents } from "@/shelves";
+import type { JournalConfig } from "@/journals/config";
+import { journalsCoreModule } from "@/journals/module";
+import { JournalsRepository } from "@/journals/repository";
+import { fixedJournal } from "@/journals/testing";
 import type { ShelfConfig } from "@/shelves/config";
+import { shelvesCoreModule } from "@/shelves/module";
+import { testContainer } from "@/testing";
 
 import { DecorationsStore } from "../../decorations-store";
-import { decorationsSlice } from "../../settings/slice";
+import { decorationsModule } from "../../module";
 import { buildCalendarDecoration, buildDecoration } from "../../testing";
+import { decorationsSettingsCoreModule } from "../module";
 
 import { DeleteDecorationFlow } from "./delete-decoration.flow";
 
-function buildJournal(name: string, decorations: JournalConfig["decorations"]): JournalConfig {
-  return { ...journalDefaultsFor({ type: "day" }, name), decorations };
-}
-
-function build(options: { journals?: Record<string, JournalConfig>; shelves?: Record<string, ShelfConfig> } = {}) {
-  const { container } = createSettingsService({ slices: [decorationsSlice] });
-  const storage = reactive<Record<string, JournalConfig>>({ ...options.journals });
-  const shelfStorage = reactive<Record<string, ShelfConfig>>({ ...options.shelves });
-  const events = createNanoEvents<JournalsEvents>();
-  const repo = JournalsRepository.fromParts(storage, events);
-  const shelves = ShelvesRepository.fromParts(shelfStorage, createNanoEvents<ShelvesEvents>());
-  const modals = new FakeModalService();
-  container.register(ModalService).useValue(modals as unknown as ModalService);
-  container.register(JournalsRepository).useValue(repo);
-  container.register(ShelvesRepository).useValue(shelves);
-  container.register(DecorationsStore).useClass(DecorationsStore);
-  container.register(NoticeService).useValue(new FakeNoticeService());
-  container.register(Flows).useClass(Flows);
-  container.register(DeleteDecorationFlow).useClass(DeleteDecorationFlow);
-  return { storage, modals, flows: container.resolve(Flows), store: container.resolve(DecorationsStore) };
+async function build(
+  options: { journals?: Record<string, JournalConfig>; shelves?: Record<string, ShelfConfig> } = {},
+) {
+  const harness = await testContainer({
+    modules: [journalsCoreModule, shelvesCoreModule, decorationsModule, decorationsSettingsCoreModule],
+    data: {
+      journals: options.journals ?? {},
+      shelves: options.shelves ?? {},
+    },
+  });
+  return {
+    harness,
+    flows: harness.resolve(Flows),
+    store: harness.resolve(DecorationsStore),
+    journals: harness.resolve(JournalsRepository),
+  };
 }
 
 const sampleDecoration = buildDecoration({
@@ -57,7 +51,7 @@ const sampleCalendarDecoration = buildCalendarDecoration({
 
 describe("DeleteDecorationFlow", () => {
   it("reports an unknown owner when the journal is gone", async () => {
-    const { flows } = build();
+    const { flows } = await build();
     const result = await flows.invoke(DeleteDecorationFlow, {
       owner: { kind: "journal", journalName: "missing" },
       index: 0,
@@ -69,7 +63,7 @@ describe("DeleteDecorationFlow", () => {
   });
 
   it("returns UnknownDecorationError when the index is out of range", async () => {
-    const { flows } = build({ journals: { daily: buildJournal("daily", []) } });
+    const { flows } = await build({ journals: { daily: fixedJournal("daily", { type: "day" }, { decorations: [] }) } });
     const result = await flows.invoke(DeleteDecorationFlow, {
       owner: { kind: "journal", journalName: "daily" },
       index: 0,
@@ -81,27 +75,31 @@ describe("DeleteDecorationFlow", () => {
   });
 
   it("returns UserAborted when the user cancels", async () => {
-    const { flows, modals } = build({ journals: { daily: buildJournal("daily", [sampleDecoration]) } });
+    const { harness, flows } = await build({
+      journals: { daily: fixedJournal("daily", { type: "day" }, { decorations: [sampleDecoration] }) },
+    });
     const promise = flows.invoke(DeleteDecorationFlow, { owner: { kind: "journal", journalName: "daily" }, index: 0 });
-    modals.lastOpen().cancel();
+    harness.modals.lastOpen().cancel();
     const result = await promise;
     expect(result.kind === "err" && result.error).toBeInstanceOf(UserAborted);
   });
 
   it("removes the decoration when the user confirms", async () => {
-    const { flows, modals, storage } = build({ journals: { daily: buildJournal("daily", [sampleDecoration]) } });
+    const { harness, flows, journals } = await build({
+      journals: { daily: fixedJournal("daily", { type: "day" }, { decorations: [sampleDecoration] }) },
+    });
     const promise = flows.invoke(DeleteDecorationFlow, { owner: { kind: "journal", journalName: "daily" }, index: 0 });
-    modals.lastOpen().submit({ confirmed: true });
+    harness.modals.lastOpen().submit({ confirmed: true });
     const result = await promise;
     expect(result.kind === "ok" && result.value.deleted).toEqual(sampleDecoration);
-    expect(storage.daily?.decorations).toEqual([]);
+    expect(journals.get("daily").getOrUndefined()?.decorations).toEqual([]);
   });
 
   it("removes a global decoration from the vault-wide list", async () => {
-    const { flows, modals, store } = build();
+    const { harness, flows, store } = await build();
     store.save({ kind: "global" }, [sampleCalendarDecoration]);
     const promise = flows.invoke(DeleteDecorationFlow, { owner: { kind: "global" }, index: 0 });
-    modals.lastOpen().submit({ confirmed: true });
+    harness.modals.lastOpen().submit({ confirmed: true });
     await promise;
 
     expect(store.list({ kind: "global" })).toEqual([]);

--- a/src/decorations/settings/flows/edit-decoration.flow.test.ts
+++ b/src/decorations/settings/flows/edit-decoration.flow.test.ts
@@ -1,8 +1,5 @@
-import { createNanoEvents } from "nanoevents";
 import { describe, expect, it } from "vitest";
-import { reactive } from "vue";
 
-import type { AnchorString } from "@/calendar";
 import type { JournalDecoration } from "@/decorations";
 import {
   DecorationLifecycleFlowError,
@@ -10,51 +7,41 @@ import {
   UnknownDecorationOwnerError,
 } from "@/decorations/errors";
 import { Flows, UserAborted } from "@/infrastructure/flows";
-import { NoticeService } from "@/infrastructure/host";
-import { ModalService } from "@/infrastructure/host/modals";
-import { FakeModalService } from "@/infrastructure/host/modals/testing";
-import { FakeNoticeService } from "@/infrastructure/host/testing";
-import { JournalsRepository, journalDefaultsFor, type JournalConfig, type JournalsEvents } from "@/journals";
-import { createSettingsService } from "@/settings/testing";
-import { ShelvesRepository, type ShelvesEvents } from "@/shelves";
+import type { JournalConfig } from "@/journals/config";
+import { journalsCoreModule } from "@/journals/module";
+import { JournalsRepository } from "@/journals/repository";
+import { customJournal, fixedJournal } from "@/journals/testing";
 import type { ShelfConfig } from "@/shelves/config";
+import { shelvesCoreModule } from "@/shelves/module";
+import { buildShelf } from "@/shelves/testing";
+import { testContainer } from "@/testing";
 
 import { DecorationsStore } from "../../decorations-store";
-import { decorationsSlice } from "../../settings/slice";
+import { decorationsModule } from "../../module";
 import { buildCalendarDecoration, buildDecoration } from "../../testing";
+import { decorationsSettingsCoreModule } from "../module";
 import { CALENDAR_CONDITION_TYPES, conditionTypeOptions } from "../ui/condition-types";
 
 import { EditDecorationFlow } from "./edit-decoration.flow";
 
 import type { EditDecorationModalProps } from "../ui/modals";
 
-function buildJournal(name: string, decorations: JournalDecoration[]): JournalConfig {
-  return { ...journalDefaultsFor({ type: "day" }, name), decorations };
-}
-
-function buildCustomJournal(name: string): JournalConfig {
-  return journalDefaultsFor(
-    { type: "custom", every: "week", duration: 2, anchorDate: "2024-01-01" as AnchorString },
-    name,
-  );
-}
-
-function build(options: { journals?: Record<string, JournalConfig>; shelves?: Record<string, ShelfConfig> } = {}) {
-  const { container } = createSettingsService({ slices: [decorationsSlice] });
-  const storage = reactive<Record<string, JournalConfig>>({ ...options.journals });
-  const shelfStorage = reactive<Record<string, ShelfConfig>>({ ...options.shelves });
-  const events = createNanoEvents<JournalsEvents>();
-  const repo = JournalsRepository.fromParts(storage, events);
-  const shelves = ShelvesRepository.fromParts(shelfStorage, createNanoEvents<ShelvesEvents>());
-  const modals = new FakeModalService();
-  container.register(ModalService).useValue(modals as unknown as ModalService);
-  container.register(JournalsRepository).useValue(repo);
-  container.register(ShelvesRepository).useValue(shelves);
-  container.register(DecorationsStore).useClass(DecorationsStore);
-  container.register(NoticeService).useValue(new FakeNoticeService());
-  container.register(Flows).useClass(Flows);
-  container.register(EditDecorationFlow).useClass(EditDecorationFlow);
-  return { storage, modals, flows: container.resolve(Flows), store: container.resolve(DecorationsStore) };
+async function build(
+  options: { journals?: Record<string, JournalConfig>; shelves?: Record<string, ShelfConfig> } = {},
+) {
+  const harness = await testContainer({
+    modules: [journalsCoreModule, shelvesCoreModule, decorationsModule, decorationsSettingsCoreModule],
+    data: {
+      journals: options.journals ?? {},
+      shelves: options.shelves ?? {},
+    },
+  });
+  return {
+    harness,
+    flows: harness.resolve(Flows),
+    store: harness.resolve(DecorationsStore),
+    journals: harness.resolve(JournalsRepository),
+  };
 }
 
 const sampleDecoration = buildDecoration({
@@ -69,7 +56,7 @@ const sampleCalendarDecoration = buildCalendarDecoration({
 
 describe("EditDecorationFlow", () => {
   it("reports an unknown owner when the journal does not exist", async () => {
-    const { flows } = build();
+    const { flows } = await build();
     const result = await flows.invoke(EditDecorationFlow, { owner: { kind: "journal", journalName: "missing" } });
     expect(result.kind === "err" && result.error).toBeInstanceOf(DecorationLifecycleFlowError);
     expect(result.kind === "err" && (result.error as DecorationLifecycleFlowError).cause).toBeInstanceOf(
@@ -78,7 +65,7 @@ describe("EditDecorationFlow", () => {
   });
 
   it("returns UnknownDecorationError for an out-of-range edit index", async () => {
-    const { flows } = build({ journals: { daily: buildJournal("daily", []) } });
+    const { flows } = await build({ journals: { daily: fixedJournal("daily", { type: "day" }, { decorations: [] }) } });
     const result = await flows.invoke(EditDecorationFlow, {
       owner: { kind: "journal", journalName: "daily" },
       index: 5,
@@ -90,38 +77,46 @@ describe("EditDecorationFlow", () => {
   });
 
   it("returns UserAborted when the modal is cancelled", async () => {
-    const { flows, modals } = build({ journals: { daily: buildJournal("daily", []) } });
+    const { harness, flows } = await build({
+      journals: { daily: fixedJournal("daily", { type: "day" }, { decorations: [] }) },
+    });
     const promise = flows.invoke(EditDecorationFlow, { owner: { kind: "journal", journalName: "daily" } });
-    modals.lastOpen().cancel();
+    harness.modals.lastOpen().cancel();
     const result = await promise;
     expect(result.kind === "err" && result.error).toBeInstanceOf(UserAborted);
   });
 
   it("appends and returns the new index when no index is provided", async () => {
-    const { flows, modals, storage } = build({ journals: { daily: buildJournal("daily", [sampleDecoration]) } });
+    const { harness, flows, journals } = await build({
+      journals: { daily: fixedJournal("daily", { type: "day" }, { decorations: [sampleDecoration] }) },
+    });
     const promise = flows.invoke(EditDecorationFlow, { owner: { kind: "journal", journalName: "daily" } });
-    modals.lastOpen<unknown, { decoration: JournalDecoration }>().submit({ decoration: sampleDecoration });
+    harness.modals.lastOpen<unknown, { decoration: JournalDecoration }>().submit({ decoration: sampleDecoration });
     const result = await promise;
     expect(result.kind === "ok" && result.value.index).toBe(1);
-    expect(storage.daily?.decorations.length).toBe(2);
+    expect(journals.get("daily").getOrUndefined()?.decorations.length).toBe(2);
   });
 
   it("replaces the decoration at index when an index is provided", async () => {
     const updated: JournalDecoration = { ...sampleDecoration, mode: "or" };
-    const { flows, modals, storage } = build({ journals: { daily: buildJournal("daily", [sampleDecoration]) } });
+    const { harness, flows, journals } = await build({
+      journals: { daily: fixedJournal("daily", { type: "day" }, { decorations: [sampleDecoration] }) },
+    });
     const promise = flows.invoke(EditDecorationFlow, { owner: { kind: "journal", journalName: "daily" }, index: 0 });
-    modals.lastOpen<unknown, { decoration: JournalDecoration }>().submit({ decoration: updated });
+    harness.modals.lastOpen<unknown, { decoration: JournalDecoration }>().submit({ decoration: updated });
     const result = await promise;
     expect(result.kind === "ok" && result.value.index).toBe(0);
-    expect(storage.daily?.decorations[0]).toEqual(updated);
+    expect(journals.get("daily").getOrUndefined()?.decorations[0]).toEqual(updated);
   });
 
   it("appends a new decoration to a shelf's list", async () => {
-    const { flows, modals, store } = build({
-      shelves: { work: { name: "work", journals: [], decorations: [] } },
+    const { harness, flows, store } = await build({
+      shelves: { work: buildShelf("work") },
     });
     const promise = flows.invoke(EditDecorationFlow, { owner: { kind: "shelf", shelfName: "work" } });
-    modals.lastOpen<unknown, { decoration: JournalDecoration }>().submit({ decoration: sampleCalendarDecoration });
+    harness.modals
+      .lastOpen<unknown, { decoration: JournalDecoration }>()
+      .submit({ decoration: sampleCalendarDecoration });
     const result = await promise;
 
     expect(result.kind === "ok" && result.value.index).toBe(0);
@@ -130,9 +125,11 @@ describe("EditDecorationFlow", () => {
 
   describe("condition types offered to the modal", () => {
     it("offers a custom journal's write-type condition set", async () => {
-      const { flows, modals } = build({ journals: { daily: buildCustomJournal("daily") } });
+      const { harness, flows } = await build({
+        journals: { daily: customJournal("daily", "week", 2, "2024-01-01") },
+      });
       const promise = flows.invoke(EditDecorationFlow, { owner: { kind: "journal", journalName: "daily" } });
-      const opened = modals.lastOpen<EditDecorationModalProps, { decoration: JournalDecoration }>();
+      const opened = harness.modals.lastOpen<EditDecorationModalProps, { decoration: JournalDecoration }>();
       opened.submit({ decoration: sampleDecoration });
       await promise;
 
@@ -140,11 +137,11 @@ describe("EditDecorationFlow", () => {
     });
 
     it("offers only calendar condition types for a shelf owner", async () => {
-      const { flows, modals } = build({
-        shelves: { work: { name: "work", journals: [], decorations: [] } },
+      const { harness, flows } = await build({
+        shelves: { work: buildShelf("work") },
       });
       const promise = flows.invoke(EditDecorationFlow, { owner: { kind: "shelf", shelfName: "work" } });
-      const opened = modals.lastOpen<EditDecorationModalProps, { decoration: JournalDecoration }>();
+      const opened = harness.modals.lastOpen<EditDecorationModalProps, { decoration: JournalDecoration }>();
       opened.submit({ decoration: sampleCalendarDecoration });
       await promise;
 

--- a/src/decorations/settings/module.ts
+++ b/src/decorations/settings/module.ts
@@ -1,28 +1,22 @@
 import type { Module } from "@/infrastructure/di";
-import { JournalEditSectionToken, defineJournalEditSection } from "@/journals";
-import { DashboardBlockToken, SliceDefinitionToken, defineDashboardBlock } from "@/settings";
-import { ShelfEditSectionToken, defineShelfEditSection } from "@/shelves/ui/shelf-edit-section";
+import { SliceDefinitionToken } from "@/settings";
 
 import { DeleteDecorationFlow } from "./flows/delete-decoration.flow";
 import { EditDecorationFlow } from "./flows/edit-decoration.flow";
 import { decorationsSlice } from "./slice";
-import CalendarDecorationsBlock from "./ui/CalendarDecorationsBlock.vue";
-import JournalDecorationsSection from "./ui/JournalDecorationsSection.vue";
-import ShelfDecorationsSection from "./ui/ShelfDecorationsSection.vue";
+import { decorationsSettingsUiModule } from "./ui-module";
 
-export const decorationsSettingsModule: Module = {
+export const decorationsSettingsCoreModule: Module = {
   register(c) {
     c.register(EditDecorationFlow).useClass(EditDecorationFlow);
     c.register(DeleteDecorationFlow).useClass(DeleteDecorationFlow);
     c.register(SliceDefinitionToken).useValue(decorationsSlice);
-    c.register(JournalEditSectionToken).useValue(
-      defineJournalEditSection({ key: "decorations", order: 100, component: JournalDecorationsSection }),
-    );
-    c.register(ShelfEditSectionToken).useValue(
-      defineShelfEditSection({ key: "decorations", order: 100, component: ShelfDecorationsSection }),
-    );
-    c.register(DashboardBlockToken).useValue(
-      defineDashboardBlock({ key: "calendar-decorations", component: CalendarDecorationsBlock, order: 11 }),
-    );
+  },
+};
+
+export const decorationsSettingsModule: Module = {
+  register(c) {
+    decorationsSettingsCoreModule.register(c);
+    decorationsSettingsUiModule.register(c);
   },
 };

--- a/src/decorations/settings/ui-module.ts
+++ b/src/decorations/settings/ui-module.ts
@@ -1,0 +1,22 @@
+import type { Module } from "@/infrastructure/di";
+import { JournalEditSectionToken, defineJournalEditSection } from "@/journals";
+import { DashboardBlockToken, defineDashboardBlock } from "@/settings";
+import { ShelfEditSectionToken, defineShelfEditSection } from "@/shelves/ui/shelf-edit-section";
+
+import CalendarDecorationsBlock from "./ui/CalendarDecorationsBlock.vue";
+import JournalDecorationsSection from "./ui/JournalDecorationsSection.vue";
+import ShelfDecorationsSection from "./ui/ShelfDecorationsSection.vue";
+
+export const decorationsSettingsUiModule: Module = {
+  register(c) {
+    c.register(JournalEditSectionToken).useValue(
+      defineJournalEditSection({ key: "decorations", order: 100, component: JournalDecorationsSection }),
+    );
+    c.register(ShelfEditSectionToken).useValue(
+      defineShelfEditSection({ key: "decorations", order: 100, component: ShelfDecorationsSection }),
+    );
+    c.register(DashboardBlockToken).useValue(
+      defineDashboardBlock({ key: "calendar-decorations", component: CalendarDecorationsBlock, order: 11 }),
+    );
+  },
+};

--- a/src/decorations/settings/ui/CanvasRegionBorder.test.ts
+++ b/src/decorations/settings/ui/CanvasRegionBorder.test.ts
@@ -1,12 +1,10 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { afterEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
 
 import { defaultStyle } from "../../defaults";
 
 import CanvasRegionBorder from "./CanvasRegionBorder.vue";
-
-afterEach(() => cleanup());
 
 const linked = defaultStyle("border");
 const perSide = { ...defaultStyle("border"), border: "different" as const };

--- a/src/decorations/settings/ui/CanvasRegionCorners.test.ts
+++ b/src/decorations/settings/ui/CanvasRegionCorners.test.ts
@@ -1,10 +1,8 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { afterEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
 
 import CanvasRegionCorners from "./CanvasRegionCorners.vue";
-
-afterEach(() => cleanup());
 
 describe("CanvasRegionCorners", () => {
   it("offers a region for every corner", () => {

--- a/src/decorations/settings/ui/CanvasRegionSlots.test.ts
+++ b/src/decorations/settings/ui/CanvasRegionSlots.test.ts
@@ -1,10 +1,8 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { afterEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
 
 import CanvasRegionSlots from "./CanvasRegionSlots.vue";
-
-afterEach(() => cleanup());
 
 describe("CanvasRegionSlots", () => {
   it("offers a region for every placement", () => {

--- a/src/decorations/settings/ui/ConditionDate.test.ts
+++ b/src/decorations/settings/ui/ConditionDate.test.ts
@@ -1,28 +1,24 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
+import { screen } from "@testing-library/vue";
 import { toTypedSchema } from "@vee-validate/valibot";
 import * as v from "valibot";
 import { useForm } from "vee-validate";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { defineComponent, h } from "vue";
 
-import { Calendar } from "@/calendar";
 import { decorationConditionSchema, type JournalDecorationCondition } from "@/decorations";
 import { m } from "@/i18n";
-import { Container, provideInjectorOnApp } from "@/infrastructure/di";
+import { testContainer } from "@/testing";
 
 import ConditionDate from "./ConditionDate.vue";
 
 const renderConditionDateHost = () => h(ConditionDate, { name: "c" });
 
-afterEach(() => cleanup());
-
 type DateCond = Extract<JournalDecorationCondition, { type: "date" }>;
 
-function mount(initial: DateCond) {
+async function mount(initial: DateCond) {
   const exposed: { values: { c: DateCond } } = { values: { c: initial } };
-  const container = new Container();
-  container.register(Calendar).useValue(new Calendar());
+  const harness = await testContainer();
   const Host = defineComponent({
     setup() {
       const form = useForm({
@@ -33,55 +29,53 @@ function mount(initial: DateCond) {
       return renderConditionDateHost;
     },
   });
-  render(Host, {
-    global: { plugins: [{ install: (app) => provideInjectorOnApp(app, container) }] },
-  });
+  harness.render(Host);
   return exposed;
 }
 
 describe("ConditionDate", () => {
-  it("names its day field for assistive tech", () => {
-    mount({ type: "date", day: 1, month: 1, year: null });
+  it("names its day field for assistive tech", async () => {
+    await mount({ type: "date", day: 1, month: 1, year: null });
     expect(
       screen.getByRole("combobox", { name: m.decoration_condition_date_unit_label({ unit: "day" }) }),
     ).toBeTruthy();
   });
 
-  it("names its month field for assistive tech", () => {
-    mount({ type: "date", day: 1, month: 1, year: null });
+  it("names its month field for assistive tech", async () => {
+    await mount({ type: "date", day: 1, month: 1, year: null });
     expect(
       screen.getByRole("combobox", { name: m.decoration_condition_date_unit_label({ unit: "month" }) }),
     ).toBeTruthy();
   });
 
-  it("names its year field for assistive tech", () => {
-    mount({ type: "date", day: 1, month: 1, year: null });
+  it("names its year field for assistive tech", async () => {
+    await mount({ type: "date", day: 1, month: 1, year: null });
     expect(
       screen.getByRole("spinbutton", { name: m.decoration_condition_date_unit_label({ unit: "year" }) }),
     ).toBeTruthy();
   });
 
   it("stores the selected day verbatim", async () => {
-    const host = mount({ type: "date", day: 1, month: 1, year: null });
+    const host = await mount({ type: "date", day: 1, month: 1, year: null });
     const [dayDropdown] = screen.getAllByRole("combobox");
     await userEvent.selectOptions(dayDropdown, "14");
     expect(host.values.c.day).toBe(14);
   });
 
-  it("displays the month one-based in the dropdown", () => {
-    mount({ type: "date", day: 1, month: 2, year: null });
+  it("displays the month one-based in the dropdown", async () => {
+    await mount({ type: "date", day: 1, month: 2, year: null });
     const monthDropdown = screen.getAllByRole<HTMLSelectElement>("combobox")[1];
     expect(monthDropdown.value).toBe("3");
   });
 
   it("stores the selected month zero-based", async () => {
-    const host = mount({ type: "date", day: 1, month: 2, year: null });
+    const host = await mount({ type: "date", day: 1, month: 2, year: null });
     await userEvent.selectOptions(screen.getAllByRole("combobox")[1], "5");
     expect(host.values.c.month).toBe(4);
   });
 
   it("stores the typed year verbatim", async () => {
-    const host = mount({ type: "date", day: 1, month: 1, year: null });
+    const host = await mount({ type: "date", day: 1, month: 1, year: null });
     const yearInput = screen.getByRole("spinbutton");
     await userEvent.clear(yearInput);
     await userEvent.type(yearInput, "2026");
@@ -89,36 +83,36 @@ describe("ConditionDate", () => {
   });
 
   it("stores the wildcard sentinel when the day is set to any", async () => {
-    const host = mount({ type: "date", day: 14, month: 1, year: null });
+    const host = await mount({ type: "date", day: 14, month: 1, year: null });
     await userEvent.selectOptions(screen.getAllByRole("combobox")[0], "");
     expect(host.values.c.day).toBe(-1);
   });
 
   it("stores the wildcard sentinel when the month is set to any", async () => {
-    const host = mount({ type: "date", day: 1, month: 5, year: null });
+    const host = await mount({ type: "date", day: 1, month: 5, year: null });
     await userEvent.selectOptions(screen.getAllByRole("combobox")[1], "");
     expect(host.values.c.month).toBe(-1);
   });
 
   it("stores null for a year cleared to empty", async () => {
-    const host = mount({ type: "date", day: 1, month: 1, year: 2026 });
+    const host = await mount({ type: "date", day: 1, month: 1, year: 2026 });
     const yearInput = screen.getByRole("spinbutton");
     await userEvent.clear(yearInput);
     expect(host.values.c.year).toBeNull();
   });
 
-  it("selects the any-day option for a wildcard day", () => {
-    mount({ type: "date", day: -1, month: -1, year: null });
+  it("selects the any-day option for a wildcard day", async () => {
+    await mount({ type: "date", day: -1, month: -1, year: null });
     expect(screen.getAllByRole<HTMLSelectElement>("combobox")[0].value).toBe("");
   });
 
-  it("selects the any-month option for a wildcard month", () => {
-    mount({ type: "date", day: -1, month: -1, year: null });
+  it("selects the any-month option for a wildcard month", async () => {
+    await mount({ type: "date", day: -1, month: -1, year: null });
     expect(screen.getAllByRole<HTMLSelectElement>("combobox")[1].value).toBe("");
   });
 
-  it("renders an empty year input for a wildcard condition", () => {
-    mount({ type: "date", day: -1, month: -1, year: null });
+  it("renders an empty year input for a wildcard condition", async () => {
+    await mount({ type: "date", day: -1, month: -1, year: null });
     expect(screen.getByRole<HTMLInputElement>("spinbutton").value).toBe("");
   });
 });

--- a/src/decorations/settings/ui/ConditionItem.test.ts
+++ b/src/decorations/settings/ui/ConditionItem.test.ts
@@ -1,28 +1,18 @@
-import { cleanup, render, screen } from "@testing-library/vue";
+import { screen } from "@testing-library/vue";
 import { toTypedSchema } from "@vee-validate/valibot";
 import * as v from "valibot";
 import { useForm } from "vee-validate";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { defineComponent, h } from "vue";
 
-import { Calendar } from "@/calendar";
 import { decorationConditionSchema, type JournalDecorationCondition } from "@/decorations";
 import { m } from "@/i18n";
-import { Container, provideInjectorOnApp } from "@/infrastructure/di";
-import { InputSuggestService, MetadataTypeService } from "@/infrastructure/host";
-import { FakeInputSuggestService } from "@/infrastructure/host/input-suggests/testing";
+import { testContainer } from "@/testing";
 
 import ConditionItem from "./ConditionItem.vue";
 
-afterEach(() => cleanup());
-
-function mount(initial: JournalDecorationCondition) {
-  const container = new Container();
-  container.register(Calendar).useValue(new Calendar());
-  container
-    .register(MetadataTypeService)
-    .useValue({ getPropertyType: () => null, listProperties: () => [] } as unknown as MetadataTypeService);
-  container.register(InputSuggestService).useValue(new FakeInputSuggestService() as unknown as InputSuggestService);
+async function mount(initial: JournalDecorationCondition) {
+  const harness = await testContainer();
   const renderHost = () => h(ConditionItem, { name: "c", condition: initial });
   const Host = defineComponent({
     setup() {
@@ -33,67 +23,57 @@ function mount(initial: JournalDecorationCondition) {
       return renderHost;
     },
   });
-  render(Host, {
-    global: {
-      plugins: [
-        {
-          install(app) {
-            provideInjectorOnApp(app, container);
-          },
-        },
-      ],
-    },
-  });
+  harness.render(Host);
 }
 
 describe("ConditionItem", () => {
-  it("renders ConditionTitle for a title condition", () => {
-    mount({ type: "title", condition: "contains", value: "" });
+  it("renders ConditionTitle for a title condition", async () => {
+    await mount({ type: "title", condition: "contains", value: "" });
     expect(screen.getByText(m.decoration_string_op_label({ op: "contains" }))).toBeTruthy();
   });
 
-  it("renders ConditionTag for a tag condition", () => {
-    mount({ type: "tag", condition: "contains", value: "" });
+  it("renders ConditionTag for a tag condition", async () => {
+    await mount({ type: "tag", condition: "contains", value: "" });
     expect(screen.getByText(m.decoration_string_op_label({ op: "contains" }))).toBeTruthy();
   });
 
-  it("renders ConditionProperty for a property condition", () => {
-    mount({ type: "property", name: "x", valueType: "text", condition: "exists", value: "" });
+  it("renders ConditionProperty for a property condition", async () => {
+    await mount({ type: "property", name: "x", valueType: "text", condition: "exists", value: "" });
     expect(screen.getByText(m.decoration_string_op_label({ op: "exists" }))).toBeTruthy();
   });
 
-  it("renders ConditionDate for a date condition", () => {
-    mount({ type: "date", day: 1, month: 1, year: null });
+  it("renders ConditionDate for a date condition", async () => {
+    await mount({ type: "date", day: 1, month: 1, year: null });
     expect(screen.getByText(m.decoration_condition_date_any_unit({ unit: "day" }))).toBeTruthy();
   });
 
-  it("renders ConditionWeekday for a weekday condition", () => {
-    mount({ type: "weekday", weekdays: [] });
+  it("renders ConditionWeekday for a weekday condition", async () => {
+    await mount({ type: "weekday", weekdays: [] });
     expect(screen.getAllByRole("button")).toHaveLength(7);
   });
 
-  it("renders ConditionOffset for an offset condition", () => {
-    mount({ type: "offset", offset: 1 });
+  it("renders ConditionOffset for an offset condition", async () => {
+    await mount({ type: "offset", offset: 1 });
     expect(screen.getByRole("spinbutton")).toBeTruthy();
   });
 
-  it("renders ConditionNoteSize for a note-size condition", () => {
-    mount({ type: "note-size", unit: "words", condition: "gt", value: 0 });
+  it("renders ConditionNoteSize for a note-size condition", async () => {
+    await mount({ type: "note-size", unit: "words", condition: "gt", value: 0 });
     expect(screen.getByLabelText(m.decoration_condition_note_size_value_label())).toBeTruthy();
   });
 
-  it("renders ConditionTypeOnly for has-note", () => {
-    mount({ type: "has-note" });
+  it("renders ConditionTypeOnly for has-note", async () => {
+    await mount({ type: "has-note" });
     expect(screen.getByText(m.decoration_condition_has_note_describe())).toBeTruthy();
   });
 
-  it("renders ConditionTypeOnly for has-open-task", () => {
-    mount({ type: "has-open-task" });
+  it("renders ConditionTypeOnly for has-open-task", async () => {
+    await mount({ type: "has-open-task" });
     expect(screen.getByText(m.decoration_condition_has_open_task_describe())).toBeTruthy();
   });
 
-  it("renders ConditionTypeOnly for all-tasks-completed", () => {
-    mount({ type: "all-tasks-completed" });
+  it("renders ConditionTypeOnly for all-tasks-completed", async () => {
+    await mount({ type: "all-tasks-completed" });
     expect(screen.getByText(m.decoration_condition_all_tasks_completed_describe())).toBeTruthy();
   });
 });

--- a/src/decorations/settings/ui/ConditionNoteSize.test.ts
+++ b/src/decorations/settings/ui/ConditionNoteSize.test.ts
@@ -1,9 +1,9 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
+import { render, screen } from "@testing-library/vue";
 import { toTypedSchema } from "@vee-validate/valibot";
 import * as v from "valibot";
 import { useForm } from "vee-validate";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { defineComponent, h } from "vue";
 
 import { m } from "@/i18n";
@@ -11,8 +11,6 @@ import { m } from "@/i18n";
 import ConditionNoteSize from "./ConditionNoteSize.vue";
 
 const renderHost = () => h(ConditionNoteSize, { name: "c" });
-
-afterEach(() => cleanup());
 
 interface InitialNoteSize {
   unit: "words" | "characters";

--- a/src/decorations/settings/ui/ConditionOffset.test.ts
+++ b/src/decorations/settings/ui/ConditionOffset.test.ts
@@ -1,9 +1,9 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
+import { render, screen } from "@testing-library/vue";
 import { toTypedSchema } from "@vee-validate/valibot";
 import * as v from "valibot";
 import { useForm } from "vee-validate";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { defineComponent, h } from "vue";
 
 import { decorationConditionSchema, type JournalDecorationCondition } from "@/decorations";
@@ -12,8 +12,6 @@ import { m } from "@/i18n";
 import ConditionOffset from "./ConditionOffset.vue";
 
 const renderConditionOffsetHost = () => h(ConditionOffset, { name: "c" });
-
-afterEach(() => cleanup());
 
 type Offset = Extract<JournalDecorationCondition, { type: "offset" }>;
 

--- a/src/decorations/settings/ui/ConditionProperty.test.ts
+++ b/src/decorations/settings/ui/ConditionProperty.test.ts
@@ -1,36 +1,27 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
+import { screen } from "@testing-library/vue";
 import { toTypedSchema } from "@vee-validate/valibot";
 import * as v from "valibot";
 import { useForm } from "vee-validate";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { defineComponent, h, nextTick } from "vue";
 
 import { decorationConditionSchema, type JournalDecorationCondition } from "@/decorations";
 import { m } from "@/i18n";
-import { Container, provideInjectorOnApp } from "@/infrastructure/di";
-import { InputSuggestService, MetadataTypeService, type VaultProperty } from "@/infrastructure/host";
-import { FakeInputSuggestService } from "@/infrastructure/host/input-suggests/testing";
-import { createFakeHost, type FakeHost } from "@/infrastructure/host/internal/testing";
-import { InternalObsidianAppToken } from "@/infrastructure/host/internal/tokens";
+import type { VaultProperty } from "@/infrastructure/host";
+import type { FakeHost } from "@/infrastructure/host/internal/testing";
+import { testContainer } from "@/testing";
 
 import ConditionProperty from "./ConditionProperty.vue";
 
 const renderConditionPropertyHost = () => h(ConditionProperty, { name: "c" });
 
-afterEach(() => cleanup());
-
 type Property = Extract<JournalDecorationCondition, { type: "property" }>;
 
-function mount(initial: Property, seed: (host: FakeHost) => void = () => undefined) {
+async function mount(initial: Property, seed: (host: FakeHost) => void = () => undefined) {
   const exposed: { values: { c: Property } } = { values: { c: initial } };
-  const host = createFakeHost();
-  seed(host);
-  const inputSuggest = new FakeInputSuggestService();
-  const container = new Container();
-  container.register(InternalObsidianAppToken).useValue(host.app);
-  container.register(MetadataTypeService).useClass(MetadataTypeService);
-  container.register(InputSuggestService).useValue(inputSuggest as unknown as InputSuggestService);
+  const harness = await testContainer();
+  seed(harness.host);
   const Host = defineComponent({
     setup() {
       const form = useForm({
@@ -41,36 +32,34 @@ function mount(initial: Property, seed: (host: FakeHost) => void = () => undefin
       return renderConditionPropertyHost;
     },
   });
-  const utilities = render(Host, {
-    global: { plugins: [{ install: (app) => provideInjectorOnApp(app, container) }] },
-  });
-  return { exposed, inputSuggest, ...utilities };
+  const utilities = harness.render(Host);
+  return { exposed, inputSuggest: harness.inputSuggests, ...utilities };
 }
 
 describe("ConditionProperty", () => {
-  it("names its property-name field for assistive tech", () => {
-    mount({ type: "property", name: "", valueType: "text", condition: "exists", value: "" });
+  it("names its property-name field for assistive tech", async () => {
+    await mount({ type: "property", name: "", valueType: "text", condition: "exists", value: "" });
     expect(screen.getByRole("textbox", { name: m.common_label_property_name() })).toBeTruthy();
   });
 
-  it("names its condition dropdown for assistive tech", () => {
-    mount({ type: "property", name: "", valueType: "text", condition: "exists", value: "" });
+  it("names its condition dropdown for assistive tech", async () => {
+    await mount({ type: "property", name: "", valueType: "text", condition: "exists", value: "" });
     expect(screen.getByRole("combobox", { name: m.decoration_condition_property_condition_label() })).toBeTruthy();
   });
 
-  it("names its value field for assistive tech", () => {
-    mount({ type: "property", name: "mood", valueType: "text", condition: "contains", value: "" });
+  it("names its value field for assistive tech", async () => {
+    await mount({ type: "property", name: "mood", valueType: "text", condition: "contains", value: "" });
     expect(screen.getByRole("textbox", { name: m.decoration_condition_property_value_label() })).toBeTruthy();
   });
 
   it("updates the property name as the user types", async () => {
-    const { exposed } = mount({ type: "property", name: "", valueType: "text", condition: "exists", value: "" });
+    const { exposed } = await mount({ type: "property", name: "", valueType: "text", condition: "exists", value: "" });
     await userEvent.type(screen.getAllByRole("textbox")[0], "mood");
     expect(exposed.values.c.name).toBe("mood");
   });
 
   it("fills the property name from a picked suggestion", async () => {
-    const { exposed, inputSuggest } = mount(
+    const { exposed, inputSuggest } = await mount(
       { type: "property", name: "", valueType: "text", condition: "exists", value: "" },
       (host) => host.setPropertyType("mood", "text"),
     );
@@ -81,7 +70,7 @@ describe("ConditionProperty", () => {
   });
 
   it("derives the number value type from the vault property", async () => {
-    const { exposed } = mount(
+    const { exposed } = await mount(
       { type: "property", name: "", valueType: "text", condition: "exists", value: "" },
       (host) => host.setPropertyType("rating", "number"),
     );
@@ -96,7 +85,7 @@ describe("ConditionProperty", () => {
   });
 
   it("derives the date value type from the vault property", async () => {
-    const { exposed, container } = mount(
+    const { exposed, container } = await mount(
       { type: "property", name: "", valueType: "text", condition: "exists", value: "" },
       (host) => host.setPropertyType("due", "date"),
     );
@@ -108,29 +97,29 @@ describe("ConditionProperty", () => {
   });
 
   it("falls back to the text value type for an unknown property", async () => {
-    const { exposed } = mount({ type: "property", name: "", valueType: "text", condition: "exists", value: "" });
+    const { exposed } = await mount({ type: "property", name: "", valueType: "text", condition: "exists", value: "" });
     await userEvent.type(screen.getAllByRole("textbox")[0], "whatever");
     expect(exposed.values.c.valueType).toBe("text");
   });
 
-  it("renders a number input when the value type is number", () => {
-    mount({ type: "property", name: "x", valueType: "number", condition: "eq", value: 0 });
+  it("renders a number input when the value type is number", async () => {
+    await mount({ type: "property", name: "x", valueType: "number", condition: "eq", value: 0 });
     expect(screen.getByRole("spinbutton")).toBeTruthy();
   });
 
-  it("renders only the name input and operator for checkbox type", () => {
-    mount({ type: "property", name: "x", valueType: "checkbox", condition: "is-true" });
+  it("renders only the name input and operator for checkbox type", async () => {
+    await mount({ type: "property", name: "x", valueType: "checkbox", condition: "is-true" });
     expect(screen.getAllByRole("textbox")).toHaveLength(1);
     expect(screen.queryByRole("spinbutton")).toBeNull();
   });
 
-  it("hides the text value input for the exists operator", () => {
-    mount({ type: "property", name: "x", valueType: "text", condition: "exists", value: "" });
+  it("hides the text value input for the exists operator", async () => {
+    await mount({ type: "property", name: "x", valueType: "text", condition: "exists", value: "" });
     expect(screen.getAllByRole("textbox")).toHaveLength(1);
   });
 
-  it("hides the number value input for the does-not-exist operator", () => {
-    mount({ type: "property", name: "x", valueType: "number", condition: "does-not-exist", value: 0 });
+  it("hides the number value input for the does-not-exist operator", async () => {
+    await mount({ type: "property", name: "x", valueType: "number", condition: "does-not-exist", value: 0 });
     expect(screen.queryByRole("spinbutton")).toBeNull();
   });
 });

--- a/src/decorations/settings/ui/ConditionTag.test.ts
+++ b/src/decorations/settings/ui/ConditionTag.test.ts
@@ -1,9 +1,9 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
+import { render, screen } from "@testing-library/vue";
 import { toTypedSchema } from "@vee-validate/valibot";
 import * as v from "valibot";
 import { useForm } from "vee-validate";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { defineComponent, h } from "vue";
 
 import { m } from "@/i18n";
@@ -11,8 +11,6 @@ import { m } from "@/i18n";
 import ConditionTag from "./ConditionTag.vue";
 
 const renderConditionTagHost = () => h(ConditionTag, { name: "c" });
-
-afterEach(() => cleanup());
 
 interface InitialTag {
   condition: "contains" | "starts-with" | "ends-with";

--- a/src/decorations/settings/ui/ConditionTitle.test.ts
+++ b/src/decorations/settings/ui/ConditionTitle.test.ts
@@ -1,9 +1,9 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
+import { render, screen } from "@testing-library/vue";
 import { toTypedSchema } from "@vee-validate/valibot";
 import * as v from "valibot";
 import { useForm } from "vee-validate";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { defineComponent, h } from "vue";
 
 import { m } from "@/i18n";
@@ -11,8 +11,6 @@ import { m } from "@/i18n";
 import ConditionTitle from "./ConditionTitle.vue";
 
 const renderConditionTitleHost = () => h(ConditionTitle, { name: "c" });
-
-afterEach(() => cleanup());
 
 interface InitialTitle {
   condition: "contains" | "starts-with" | "ends-with";

--- a/src/decorations/settings/ui/ConditionTypeOnly.test.ts
+++ b/src/decorations/settings/ui/ConditionTypeOnly.test.ts
@@ -1,29 +1,14 @@
-import { cleanup, render, screen } from "@testing-library/vue";
-import { afterEach, describe, expect, it } from "vitest";
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
 
-import { Calendar } from "@/calendar";
 import { m } from "@/i18n";
-import { Container, provideInjectorOnApp } from "@/infrastructure/di";
+import { testContainer } from "@/testing";
 
 import ConditionTypeOnly from "./ConditionTypeOnly.vue";
 
-afterEach(() => cleanup());
-
-function mount(type: "has-note" | "has-open-task" | "all-tasks-completed") {
-  const container = new Container();
-  container.register(Calendar).useValue(new Calendar());
-  return render(ConditionTypeOnly, {
-    props: { type },
-    global: {
-      plugins: [
-        {
-          install(app) {
-            provideInjectorOnApp(app, container);
-          },
-        },
-      ],
-    },
-  });
+async function mount(type: "has-note" | "has-open-task" | "all-tasks-completed") {
+  const harness = await testContainer();
+  return harness.render(ConditionTypeOnly, { props: { type } });
 }
 
 describe("ConditionTypeOnly", () => {
@@ -31,8 +16,8 @@ describe("ConditionTypeOnly", () => {
     ["has-note", m.decoration_condition_has_note_describe()] as const,
     ["has-open-task", m.decoration_condition_has_open_task_describe()] as const,
     ["all-tasks-completed", m.decoration_condition_all_tasks_completed_describe()] as const,
-  ])("renders the description for %s", (type, expected) => {
-    mount(type);
+  ])("renders the description for %s", async (type, expected) => {
+    await mount(type);
     expect(screen.getByText(expected)).toBeTruthy();
   });
 });

--- a/src/decorations/settings/ui/ConditionWeekday.test.ts
+++ b/src/decorations/settings/ui/ConditionWeekday.test.ts
@@ -1,28 +1,24 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
+import { screen } from "@testing-library/vue";
 import { toTypedSchema } from "@vee-validate/valibot";
 import * as v from "valibot";
 import { useForm } from "vee-validate";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { defineComponent, h } from "vue";
 
-import { Calendar } from "@/calendar";
 import { decorationConditionSchema, type JournalDecorationCondition } from "@/decorations";
 import { m } from "@/i18n";
-import { Container, provideInjectorOnApp } from "@/infrastructure/di";
+import { testContainer } from "@/testing";
 
 import ConditionWeekday from "./ConditionWeekday.vue";
 
 const renderConditionWeekdayHost = () => h(ConditionWeekday, { name: "c" });
 
-afterEach(() => cleanup());
-
 type Weekday = Extract<JournalDecorationCondition, { type: "weekday" }>;
 
-function mount(initial: Weekday) {
+async function mount(initial: Weekday) {
   const exposed: { values: { c: Weekday } } = { values: { c: initial } };
-  const container = new Container();
-  container.register(Calendar).useValue(new Calendar());
+  const harness = await testContainer();
   const Host = defineComponent({
     setup() {
       const form = useForm({
@@ -33,46 +29,36 @@ function mount(initial: Weekday) {
       return renderConditionWeekdayHost;
     },
   });
-  render(Host, {
-    global: {
-      plugins: [
-        {
-          install(app) {
-            provideInjectorOnApp(app, container);
-          },
-        },
-      ],
-    },
-  });
+  harness.render(Host);
   return exposed;
 }
 
 describe("ConditionWeekday", () => {
-  it("names the weekday group for assistive tech", () => {
-    mount({ type: "weekday", weekdays: [] });
+  it("names the weekday group for assistive tech", async () => {
+    await mount({ type: "weekday", weekdays: [] });
     expect(screen.getByRole("group", { name: m.decoration_condition_weekday_label() })).toBeTruthy();
   });
 
   it("adds a weekday index when its segment is clicked", async () => {
-    const host = mount({ type: "weekday", weekdays: [] });
+    const host = await mount({ type: "weekday", weekdays: [] });
     await userEvent.click(screen.getByRole("button", { name: "Mon" }));
     expect(host.values.c.weekdays).toEqual([1]);
   });
 
   it("removes a weekday index when its active segment is clicked", async () => {
-    const host = mount({ type: "weekday", weekdays: [1] });
+    const host = await mount({ type: "weekday", weekdays: [1] });
     await userEvent.click(screen.getByRole("button", { name: "Mon" }));
     expect(host.values.c.weekdays).toEqual([]);
   });
 
   it("keeps selected weekday indices sorted", async () => {
-    const host = mount({ type: "weekday", weekdays: [3] });
+    const host = await mount({ type: "weekday", weekdays: [3] });
     await userEvent.click(screen.getByRole("button", { name: "Mon" }));
     expect(host.values.c.weekdays).toEqual([1, 3]);
   });
 
-  it("marks the segment of a selected weekday as pressed", () => {
-    mount({ type: "weekday", weekdays: [1] });
+  it("marks the segment of a selected weekday as pressed", async () => {
+    await mount({ type: "weekday", weekdays: [1] });
     expect(screen.getByRole("button", { name: "Mon" }).getAttribute("aria-pressed")).toBe("true");
   });
 });

--- a/src/decorations/settings/ui/DecorationCanvas.test.ts
+++ b/src/decorations/settings/ui/DecorationCanvas.test.ts
@@ -1,22 +1,18 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
+import { screen } from "@testing-library/vue";
 import { toTypedSchema } from "@vee-validate/valibot";
 import * as v from "valibot";
 import { useForm } from "vee-validate";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { defineComponent, h } from "vue";
 
 import { decorationSchema, type JournalDecoration } from "@/decorations";
 import { m } from "@/i18n";
-import { Container, provideInjectorOnApp } from "@/infrastructure/di";
-import { InputSuggestService } from "@/infrastructure/host";
-import { FakeInputSuggestService } from "@/infrastructure/host/input-suggests/testing";
+import { testContainer } from "@/testing";
 
 import { STYLE_SLOT_KEYS, type StyleSlotKey } from "../../style-slots";
 
 import DecorationCanvas from "./DecorationCanvas.vue";
-
-afterEach(() => cleanup());
 
 function layerChipLabel(type: StyleSlotKey, occupied: boolean): string {
   return m.decoration_layer_chip_label({ type, state: occupied ? "occupied" : "empty" });
@@ -33,10 +29,9 @@ const createStyleIn: Record<StyleSlotKey, () => Promise<void>> = {
   corner: () => userEvent.click(screen.getByRole("button", { name: "Top left" })),
 };
 
-function mount(styles: JournalDecoration["styles"] = []) {
+async function mount(styles: JournalDecoration["styles"] = []) {
   const exposed = {} as { values: JournalDecoration };
-  const container = new Container();
-  container.register(InputSuggestService).useValue(new FakeInputSuggestService() as unknown as InputSuggestService);
+  const harness = await testContainer();
   const Host = defineComponent({
     setup() {
       const form = useForm<JournalDecoration>({
@@ -47,23 +42,13 @@ function mount(styles: JournalDecoration["styles"] = []) {
       return () => h(DecorationCanvas, { name: "styles", styles: form.values.styles });
     },
   });
-  render(Host, {
-    global: {
-      plugins: [
-        {
-          install(app) {
-            provideInjectorOnApp(app, container);
-          },
-        },
-      ],
-    },
-  });
+  harness.render(Host);
   return exposed;
 }
 
 describe("DecorationCanvas", () => {
-  it("opens an existing decoration on its first occupied layer", () => {
-    mount([{ type: "corner", placement: "top-left", color: { type: "theme", name: "text-accent" } }]);
+  it("opens an existing decoration on its first occupied layer", async () => {
+    await mount([{ type: "corner", placement: "top-left", color: { type: "theme", name: "text-accent" } }]);
     expect(screen.getByRole("tab", { name: layerChipLabel("corner", true) }).getAttribute("aria-selected")).toBe(
       "true",
     );
@@ -71,8 +56,8 @@ describe("DecorationCanvas", () => {
 
   // Strip order, not the order the styles were authored in: the tab that lights up is the
   // leftmost filled one, which is what the user sees rather than what data.json happens to list.
-  it("opens on the leftmost occupied layer rather than the first authored style", () => {
-    mount([
+  it("opens on the leftmost occupied layer rather than the first authored style", async () => {
+    await mount([
       { type: "corner", placement: "top-left", color: { type: "theme", name: "text-accent" } },
       { type: "background", color: { type: "theme", name: "interactive-accent" } },
     ]);
@@ -82,13 +67,13 @@ describe("DecorationCanvas", () => {
   });
 
   it("creates a background when the empty cell is clicked", async () => {
-    const host = mount();
+    const host = await mount();
     await userEvent.click(screen.getByRole("button", { name: "Cell background" }));
     expect(host.values.styles.map((s) => s.type)).toEqual(["background"]);
   });
 
   it("creates a shape at the position that was clicked", async () => {
-    const host = mount();
+    const host = await mount();
     await userEvent.click(screen.getByRole("tab", { name: "Shape" }));
     await userEvent.click(screen.getByRole("button", { name: "Top left" }));
     expect(host.values.styles.at(0)).toMatchObject({
@@ -99,7 +84,7 @@ describe("DecorationCanvas", () => {
   });
 
   it("moves an existing shape rather than adding a second", async () => {
-    const host = mount();
+    const host = await mount();
     await userEvent.click(screen.getByRole("tab", { name: "Shape" }));
     await userEvent.click(screen.getByRole("button", { name: "Top left" }));
     await userEvent.click(screen.getByRole("button", { name: "Bottom right" }));
@@ -107,7 +92,7 @@ describe("DecorationCanvas", () => {
   });
 
   it("places the moved shape at the new position", async () => {
-    const host = mount();
+    const host = await mount();
     await userEvent.click(screen.getByRole("tab", { name: "Shape" }));
     await userEvent.click(screen.getByRole("button", { name: "Top left" }));
     await userEvent.click(screen.getByRole("button", { name: "Bottom right" }));
@@ -115,7 +100,7 @@ describe("DecorationCanvas", () => {
   });
 
   it("moves an existing corner rather than adding a second", async () => {
-    const host = mount();
+    const host = await mount();
     await userEvent.click(screen.getByRole("tab", { name: "Corner" }));
     await userEvent.click(screen.getByRole("button", { name: "Top left" }));
     await userEvent.click(screen.getByRole("button", { name: "Bottom right" }));
@@ -123,34 +108,34 @@ describe("DecorationCanvas", () => {
   });
 
   it("empties the slot when the layer is removed", async () => {
-    const host = mount();
+    const host = await mount();
     await userEvent.click(screen.getByRole("button", { name: "Cell background" }));
     await userEvent.click(screen.getByRole("button", { name: "Remove" }));
     expect(host.values.styles).toEqual([]);
   });
 
   it("shows a hint while the active layer is empty", async () => {
-    mount();
+    await mount();
     await userEvent.click(screen.getByRole("tab", { name: "Icon" }));
     expect(screen.getByText("Click a position to add an icon.")).toBeTruthy();
   });
 
   it("only exposes the active layer's regions", async () => {
-    mount();
+    await mount();
     await userEvent.click(screen.getByRole("tab", { name: "Corner" }));
     expect(screen.queryByRole("button", { name: "Middle left" })).toBeNull();
   });
 
   describe("border", () => {
     it("creates a linked border when the ring is clicked", async () => {
-      const host = mount();
+      const host = await mount();
       await userEvent.click(screen.getByRole("tab", { name: "Border" }));
       await userEvent.click(screen.getByRole("button", { name: "Cell outline" }));
       expect(host.values.styles.at(0)).toMatchObject({ type: "border", border: "uniform" });
     });
 
     it("switches the stored mode when per side is chosen", async () => {
-      const host = mount();
+      const host = await mount();
       await userEvent.click(screen.getByRole("tab", { name: "Border" }));
       await userEvent.click(screen.getByRole("button", { name: "Cell outline" }));
       await userEvent.click(screen.getByRole("radio", { name: "Per side" }));
@@ -158,7 +143,7 @@ describe("DecorationCanvas", () => {
     });
 
     it("turns a hidden side on when its edge is clicked", async () => {
-      const host = mount([
+      const host = await mount([
         {
           type: "border",
           border: "different",
@@ -175,7 +160,7 @@ describe("DecorationCanvas", () => {
     });
 
     it("empties the border slot when the last shown side is removed", async () => {
-      const host = mount([
+      const host = await mount([
         {
           type: "border",
           border: "different",
@@ -195,7 +180,7 @@ describe("DecorationCanvas", () => {
     // only shown side is something else — without first clicking that side's edge — must still
     // reconcile before Remove runs, or Remove silently rewrites the already-hidden "top" side.
     it("removes the only shown side when the layer is opened without selecting it first", async () => {
-      const host = mount([
+      const host = await mount([
         {
           type: "border",
           border: "different",
@@ -213,7 +198,7 @@ describe("DecorationCanvas", () => {
 
   describe("switching layers", () => {
     it("keeps the previous layer's fields after adding a second layer", async () => {
-      const host = mount();
+      const host = await mount();
       await userEvent.click(screen.getByRole("button", { name: "Cell background" }));
       await userEvent.click(screen.getByRole("tab", { name: "Shape" }));
       await userEvent.click(screen.getByRole("button", { name: "Top left" }));
@@ -222,7 +207,7 @@ describe("DecorationCanvas", () => {
     });
 
     it("leaves a decoration that parses cleanly after adding a second layer", async () => {
-      const host = mount();
+      const host = await mount();
       await userEvent.click(screen.getByRole("button", { name: "Cell background" }));
       await userEvent.click(screen.getByRole("tab", { name: "Shape" }));
       await userEvent.click(screen.getByRole("button", { name: "Top left" }));
@@ -230,7 +215,7 @@ describe("DecorationCanvas", () => {
     });
 
     it("keeps the active border side's fields after switching to another layer", async () => {
-      const host = mount();
+      const host = await mount();
       await userEvent.click(screen.getByRole("tab", { name: "Border" }));
       await userEvent.click(screen.getByRole("button", { name: "Cell outline" }));
       await userEvent.click(screen.getByRole("tab", { name: "Shape" }));
@@ -242,7 +227,7 @@ describe("DecorationCanvas", () => {
     // its inspector unmounts on a layer switch. Only exercising a couple of leaves would let the
     // flag silently go missing from the rest, so this covers all six.
     it.each(STYLE_SLOT_KEYS)("keeps a %s style parseable after switching layers", async (layer) => {
-      const host = mount();
+      const host = await mount();
       await userEvent.click(screen.getByRole("tab", { name: layerChipLabel(layer, false) }));
       await createStyleIn[layer]();
       const other = STYLE_SLOT_KEYS.find((key) => key !== layer);
@@ -253,7 +238,7 @@ describe("DecorationCanvas", () => {
     });
 
     it("keeps the second style parseable after removing the first", async () => {
-      const host = mount();
+      const host = await mount();
       await userEvent.click(screen.getByRole("tab", { name: layerChipLabel("background", false) }));
       await createStyleIn.background();
       await userEvent.click(screen.getByRole("tab", { name: layerChipLabel("shape", false) }));

--- a/src/decorations/settings/ui/DecorationLayerStrip.test.ts
+++ b/src/decorations/settings/ui/DecorationLayerStrip.test.ts
@@ -1,12 +1,10 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { afterEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
 
 import DecorationLayerStrip from "./DecorationLayerStrip.vue";
 
 import type { StyleSlotKey } from "../../style-slots";
-
-afterEach(() => cleanup());
 
 function renderStrip(modelValue: StyleSlotKey, occupied: StyleSlotKey[] = []) {
   return render(DecorationLayerStrip, {

--- a/src/decorations/settings/ui/DecorationsSection.test.ts
+++ b/src/decorations/settings/ui/DecorationsSection.test.ts
@@ -1,55 +1,31 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { createNanoEvents } from "nanoevents";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { reactive } from "vue";
+import { screen } from "@testing-library/vue";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { Calendar, CalendarDate } from "@/calendar";
-import { installTestCalendar, testCalendar } from "@/calendar/testing";
-import {
-  DecorationEngine,
-  DecorationMatchService,
-  DecorationsStore,
-  decorationsSlice,
-  type CalendarDecoration,
-  type DecorationOwner,
-  type JournalDecoration,
-} from "@/decorations";
+import { CalendarDate } from "@/calendar";
+import type { CalendarDecoration, DecorationOwner, JournalDecoration } from "@/decorations";
 import { m } from "@/i18n";
-import { provideInjectorOnApp } from "@/infrastructure/di";
 import { Flows } from "@/infrastructure/flows";
-import { NoteMetadataService, NoteSizeService, NoticeService, type VaultPath } from "@/infrastructure/host";
-import { ModalService } from "@/infrastructure/host/modals";
-import { FakeModalService } from "@/infrastructure/host/modals/testing";
-import { FakeNoteMetadataService, FakeNoteSizeService, FakeNoticeService } from "@/infrastructure/host/testing";
-import {
-  CycleService,
-  JournalsIndex,
-  JournalsRepository,
-  TimelineService,
-  journalDefaultsFor,
-  type JournalConfig,
-  type JournalsEvents,
-} from "@/journals";
-import { createSettingsService } from "@/settings/testing";
-import { ShelvesRepository, type ShelvesEvents } from "@/shelves";
-import type { ShelfConfig } from "@/shelves/config";
+import type { VaultPath } from "@/infrastructure/host";
+import { AsyncResult } from "@/infrastructure/result";
+import { JournalsIndex } from "@/journals";
+import { journalsCoreModule } from "@/journals/module";
+import { fixedJournal } from "@/journals/testing";
+import { shelvesCoreModule } from "@/shelves/module";
+import { buildShelf } from "@/shelves/testing";
+import { testContainer } from "@/testing";
 
+import { decorationsModule } from "../../module";
 import { buildCondition, buildDecoration, buildStyle } from "../../testing";
 import { decorationBreakdownModal } from "../../ui/modals";
 import { DeleteDecorationFlow } from "../flows/delete-decoration.flow";
 import { EditDecorationFlow } from "../flows/edit-decoration.flow";
+import { decorationsSettingsCoreModule } from "../module";
 
 import DecorationsSection from "./DecorationsSection.vue";
 
-let teardown: () => void;
-beforeEach(() => {
-  ({ teardown } = installTestCalendar());
-});
 afterEach(() => {
   vi.useRealTimers();
-  teardown();
-  cleanup();
 });
 
 const transparent = { type: "transparent" as const };
@@ -64,88 +40,62 @@ const sampleCalendarDecoration: CalendarDecoration = {
   styles: [{ type: "background", color: transparent }],
 };
 
-function buildJournal(name: string, decorations: JournalDecoration[]): JournalConfig {
-  return { ...journalDefaultsFor({ type: "day" }, name), decorations };
-}
-
 // Seeds decorations only into the storage backing the owner under test, so a mismatched owner
 // (e.g. a journal owner while a shelf has decorations) would surface as a genuine test failure.
-function mount(owner: DecorationOwner, decorations: readonly JournalDecoration[], options: { hasNote?: boolean } = {}) {
-  const { container, service } = createSettingsService({ slices: [decorationsSlice] });
-
-  const journalDecorations = owner.kind === "journal" ? [...decorations] : [];
-  const journalStorage = reactive<Record<string, JournalConfig>>({
-    daily: buildJournal("daily", journalDecorations),
+async function mount(
+  owner: DecorationOwner,
+  decorations: readonly JournalDecoration[],
+  options: { hasNote?: boolean } = {},
+) {
+  const harness = await testContainer({
+    modules: [journalsCoreModule, shelvesCoreModule, decorationsModule, decorationsSettingsCoreModule],
+    data: {
+      journals: {
+        daily: fixedJournal(
+          "daily",
+          { type: "day" },
+          owner.kind === "journal" ? { decorations: [...decorations] } : {},
+        ),
+      },
+      shelves: {
+        work: buildShelf(
+          "work",
+          owner.kind === "shelf" ? { decorations: [...(decorations as CalendarDecoration[])] } : {},
+        ),
+      },
+      decorations: { decorations: owner.kind === "global" ? [...(decorations as CalendarDecoration[])] : [] },
+    },
   });
-  const journals = JournalsRepository.fromParts(journalStorage, createNanoEvents<JournalsEvents>());
 
-  const shelfDecorations = owner.kind === "shelf" ? (decorations as CalendarDecoration[]) : [];
-  const shelfStorage = reactive<Record<string, ShelfConfig>>({
-    work: { name: "work", journals: [], decorations: [...shelfDecorations] },
-  });
-  const shelves = ShelvesRepository.fromParts(shelfStorage, createNanoEvents<ShelvesEvents>());
-
-  if (owner.kind === "global") {
-    service.getSlice(decorationsSlice).state = { decorations: [...(decorations as CalendarDecoration[])] };
-  }
-
-  const flows = { invoke: vi.fn() };
-  const modals = new FakeModalService();
-  const fakeMetadata = new FakeNoteMetadataService();
-  container.register(JournalsRepository).useValue(journals);
-  container.register(ShelvesRepository).useValue(shelves);
-  container.register(DecorationsStore).useClass(DecorationsStore);
-  container.register(NoticeService).useValue(new FakeNoticeService());
-  container.register(Flows).useValue(flows as unknown as Flows);
-  container.register(Calendar).useValue(testCalendar());
-  container.register(ModalService).useValue(modals as unknown as ModalService);
-  const index = new JournalsIndex();
   if (options.hasNote) {
     const anchor = CalendarDate.today().toAnchor();
     const path = `Daily/${anchor}.md` as VaultPath;
-    index.register({ journalName: "daily", anchor, path });
-    fakeMetadata.setMetadata(path, { title: "daily", tags: [], properties: {}, tasks: [] });
+    harness.host.putFile(path);
+    harness.resolve(JournalsIndex).register({ journalName: "daily", anchor, path });
   }
-  container.register(JournalsIndex).useValue(index);
-  container.register(CycleService).useClass(CycleService);
-  container.register(TimelineService).useClass(TimelineService);
-  container.register(NoteMetadataService).useValue(fakeMetadata as unknown as NoteMetadataService);
-  container.register(NoteSizeService).useValue(new FakeNoteSizeService() as unknown as NoteSizeService);
-  container.register(DecorationEngine).useClass(DecorationEngine);
-  container.register(DecorationMatchService).useClass(DecorationMatchService);
 
-  const store = container.resolve(DecorationsStore);
+  const flows = vi.spyOn(harness.resolve(Flows), "invoke").mockReturnValue(AsyncResult.ok(undefined));
 
-  render(DecorationsSection, {
-    props: { owner },
-    global: {
-      plugins: [
-        {
-          install(app) {
-            provideInjectorOnApp(app, container);
-          },
-        },
-      ],
-    },
-  });
-  return { flows, modals, store };
+  harness.render(DecorationsSection, { props: { owner } });
+
+  return { harness, flows };
 }
 
 describe("DecorationsSection", () => {
   it("renders the empty state when there are no decorations", async () => {
-    mount({ kind: "journal", journalName: "daily" }, []);
+    await mount({ kind: "journal", journalName: "daily" }, []);
     await userEvent.click(screen.getByText(m.decoration_section_title_journal()));
     expect(screen.getByText(m.decoration_section_empty())).toBeTruthy();
   });
 
   it("renders a row description for each decoration", async () => {
-    mount({ kind: "journal", journalName: "daily" }, [sampleDecoration]);
+    await mount({ kind: "journal", journalName: "daily" }, [sampleDecoration]);
     await userEvent.click(screen.getByText(m.decoration_section_title_journal()));
     expect(screen.getByText(m.decoration_condition_has_note_describe())).toBeTruthy();
   });
 
   it("renders a preview swatch for each decoration", async () => {
-    mount({ kind: "journal", journalName: "daily" }, [sampleDecoration]);
+    await mount({ kind: "journal", journalName: "daily" }, [sampleDecoration]);
     await userEvent.click(screen.getByText(m.decoration_section_title_journal()));
     // Every other row assertion targets describeCondition text, which renders regardless of
     // whether DecorationPreview resolves — an unresolved component still renders its slot
@@ -155,54 +105,54 @@ describe("DecorationsSection", () => {
   });
 
   it("invokes EditDecorationFlow with no index when Add is clicked", async () => {
-    const { flows } = mount({ kind: "journal", journalName: "daily" }, [sampleDecoration]);
+    const { flows } = await mount({ kind: "journal", journalName: "daily" }, [sampleDecoration]);
     await userEvent.click(screen.getByLabelText(m.decoration_add()));
-    expect(flows.invoke).toHaveBeenCalledWith(EditDecorationFlow, {
+    expect(flows).toHaveBeenCalledWith(EditDecorationFlow, {
       owner: { kind: "journal", journalName: "daily" },
     });
   });
 
   it("invokes EditDecorationFlow with the index when Edit is clicked", async () => {
-    const { flows } = mount({ kind: "journal", journalName: "daily" }, [sampleDecoration]);
+    const { flows } = await mount({ kind: "journal", journalName: "daily" }, [sampleDecoration]);
     await userEvent.click(screen.getByText(m.decoration_section_title_journal()));
     await userEvent.click(screen.getByLabelText(m.decoration_edit()));
-    expect(flows.invoke).toHaveBeenCalledWith(EditDecorationFlow, {
+    expect(flows).toHaveBeenCalledWith(EditDecorationFlow, {
       owner: { kind: "journal", journalName: "daily" },
       index: 0,
     });
   });
 
   it("invokes DeleteDecorationFlow when Delete is clicked", async () => {
-    const { flows } = mount({ kind: "journal", journalName: "daily" }, [sampleDecoration]);
+    const { flows } = await mount({ kind: "journal", journalName: "daily" }, [sampleDecoration]);
     await userEvent.click(screen.getByText(m.decoration_section_title_journal()));
     await userEvent.click(screen.getByLabelText(m.decoration_delete()));
-    expect(flows.invoke).toHaveBeenCalledWith(DeleteDecorationFlow, {
+    expect(flows).toHaveBeenCalledWith(DeleteDecorationFlow, {
       owner: { kind: "journal", journalName: "daily" },
       index: 0,
     });
   });
 
   it("titles the section for a shelf owner", async () => {
-    mount({ kind: "shelf", shelfName: "work" }, [sampleCalendarDecoration]);
+    await mount({ kind: "shelf", shelfName: "work" }, [sampleCalendarDecoration]);
     expect(screen.getByText(m.decoration_section_title_shelf())).toBeTruthy();
   });
 
   it("lists a shelf's decorations", async () => {
-    mount({ kind: "shelf", shelfName: "work" }, [sampleCalendarDecoration]);
+    await mount({ kind: "shelf", shelfName: "work" }, [sampleCalendarDecoration]);
     await userEvent.click(screen.getByText(m.decoration_section_title_shelf()));
     expect(screen.getAllByLabelText(m.decoration_edit())).toHaveLength(1);
   });
 
   it("invokes the edit flow with the global owner", async () => {
-    const { flows } = mount({ kind: "global" }, []);
+    const { flows } = await mount({ kind: "global" }, []);
     await userEvent.click(screen.getByLabelText(m.decoration_add()));
-    expect(flows.invoke).toHaveBeenCalledWith(EditDecorationFlow, { owner: { kind: "global" } });
+    expect(flows).toHaveBeenCalledWith(EditDecorationFlow, { owner: { kind: "global" } });
   });
 
   it("opens the breakdown modal from the inspect button", async () => {
-    const { modals } = mount({ kind: "journal", journalName: "daily" }, [sampleDecoration]);
+    const { harness } = await mount({ kind: "journal", journalName: "daily" }, [sampleDecoration]);
     await userEvent.click(screen.getByLabelText(m.decoration_breakdown_open()));
-    expect(modals.lastOpen().definition).toBe(decorationBreakdownModal);
+    expect(harness.modals.lastOpen().definition).toBe(decorationBreakdownModal);
   });
 
   it("shows the match count on a decoration that fires", async () => {
@@ -218,7 +168,7 @@ describe("DecorationsSection", () => {
       conditions: [buildCondition("weekday", { weekdays: [1] })],
       styles: [buildStyle("background")],
     });
-    mount({ kind: "journal", journalName: "daily" }, [decoration]);
+    await mount({ kind: "journal", journalName: "daily" }, [decoration]);
     await user.click(screen.getByText(m.decoration_section_title_journal()));
 
     expect(screen.getByText(m.decoration_badge_matched_past({ matched: 13, total: 90, unit: "day" }))).toBeTruthy();
@@ -227,7 +177,7 @@ describe("DecorationsSection", () => {
   it("shows the no-notes badge on a note-needing decoration with no notes in the window", async () => {
     // has-note is the only condition, and no note is registered in the index, so the row must
     // report "no notes yet" rather than misreading the empty index as a silent (0-match) badge.
-    mount({ kind: "journal", journalName: "daily" }, [sampleDecoration]);
+    await mount({ kind: "journal", journalName: "daily" }, [sampleDecoration]);
     await userEvent.click(screen.getByText(m.decoration_section_title_journal()));
 
     expect(screen.getByText(m.decoration_badge_no_notes())).toBeTruthy();
@@ -241,7 +191,7 @@ describe("DecorationsSection", () => {
       conditions: [buildCondition("note-size", { condition: "gt", value: 100 })],
       styles: [buildStyle("background")],
     });
-    mount({ kind: "journal", journalName: "daily" }, [noteSizeDecoration], { hasNote: true });
+    await mount({ kind: "journal", journalName: "daily" }, [noteSizeDecoration], { hasNote: true });
     await userEvent.click(screen.getByText(m.decoration_section_title_journal()));
 
     expect(document.querySelector(".row-badge")).toBeNull();

--- a/src/decorations/settings/ui/DeleteDecorationModal.test.ts
+++ b/src/decorations/settings/ui/DeleteDecorationModal.test.ts
@@ -1,47 +1,29 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
 
 import { m } from "@/i18n";
-import type { ModalApi } from "@/infrastructure/host/modals";
-import { provideModalApiOnApp } from "@/infrastructure/host/modals/testing";
+import { testContainer } from "@/testing";
 
 import DeleteDecorationModal from "./DeleteDecorationModal.vue";
 
-afterEach(() => cleanup());
-
-function mountModal() {
-  const submit = vi.fn();
-  const cancel = vi.fn();
-  const api: ModalApi<{ confirmed: true }> = { submit, cancel };
-  render(DeleteDecorationModal, {
-    global: {
-      plugins: [
-        {
-          install(app) {
-            provideModalApiOnApp(app, api as ModalApi<unknown>);
-          },
-        },
-      ],
-    },
-  });
-  return { submit, cancel };
-}
-
 describe("DeleteDecorationModal", () => {
-  it("renders the warning text", () => {
-    mountModal();
+  it("renders the warning text", async () => {
+    const harness = await testContainer();
+    harness.renderModal(DeleteDecorationModal);
     expect(screen.getByText(m.decoration_delete_modal_warning())).toBeTruthy();
   });
 
   it("submits confirmed:true when Delete is clicked", async () => {
-    const { submit } = mountModal();
+    const harness = await testContainer();
+    const { submit } = harness.renderModal(DeleteDecorationModal);
     await userEvent.click(screen.getByText(m.common_action_delete()));
     expect(submit).toHaveBeenCalledWith({ confirmed: true });
   });
 
   it("cancels when Cancel is clicked", async () => {
-    const { cancel } = mountModal();
+    const harness = await testContainer();
+    const { cancel } = harness.renderModal(DeleteDecorationModal);
     await userEvent.click(screen.getByText(m.common_action_cancel()));
     expect(cancel).toHaveBeenCalledTimes(1);
   });

--- a/src/decorations/settings/ui/EditDecorationModal.test.ts
+++ b/src/decorations/settings/ui/EditDecorationModal.test.ts
@@ -1,24 +1,15 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen, waitFor } from "@testing-library/vue";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
 
-import { Calendar } from "@/calendar";
 import type { JournalDecoration, JournalDecorationCondition } from "@/decorations";
 import { m } from "@/i18n";
-import { Container, provideInjectorOnApp } from "@/infrastructure/di";
-import { InputSuggestService, MetadataTypeService } from "@/infrastructure/host";
-import { FakeInputSuggestService } from "@/infrastructure/host/input-suggests/testing";
-import { createFakeHost } from "@/infrastructure/host/internal/testing";
-import { InternalObsidianAppToken } from "@/infrastructure/host/internal/tokens";
-import type { ModalApi } from "@/infrastructure/host/modals";
-import { provideModalApiOnApp } from "@/infrastructure/host/modals/testing";
+import { testContainer } from "@/testing";
 
 import { buildCondition } from "../../testing";
 
 import { CALENDAR_CONDITION_TYPES, conditionTypeOptions } from "./condition-types";
 import EditDecorationModal from "./EditDecorationModal.vue";
-
-afterEach(() => cleanup());
 
 const transparent = { type: "transparent" as const };
 const minimalDecoration: JournalDecoration = {
@@ -27,32 +18,14 @@ const minimalDecoration: JournalDecoration = {
   styles: [{ type: "background", color: transparent }],
 };
 
-function mountModal(options: {
+async function mountModal(options: {
   conditionTypes: readonly JournalDecorationCondition["type"][];
   decoration?: JournalDecoration;
 }) {
-  const submit = vi.fn();
-  const cancel = vi.fn();
-  const api: ModalApi<{ decoration: JournalDecoration }> = { submit, cancel };
-  const container = new Container();
-  container.register(Calendar).useValue(new Calendar());
-  container.register(InputSuggestService).useValue(new FakeInputSuggestService() as unknown as InputSuggestService);
-  container.register(InternalObsidianAppToken).useValue(createFakeHost().app);
-  container.register(MetadataTypeService).useClass(MetadataTypeService);
-  render(EditDecorationModal, {
+  const harness = await testContainer();
+  return harness.renderModal(EditDecorationModal, {
     props: { conditionTypes: options.conditionTypes, decoration: options.decoration },
-    global: {
-      plugins: [
-        {
-          install(app) {
-            provideInjectorOnApp(app, container);
-            provideModalApiOnApp(app, api as ModalApi<unknown>);
-          },
-        },
-      ],
-    },
   });
-  return { submit, cancel };
 }
 
 const ALL_CONDITION_TYPES: readonly JournalDecorationCondition["type"][] = [
@@ -69,7 +42,7 @@ const ALL_CONDITION_TYPES: readonly JournalDecorationCondition["type"][] = [
 ];
 
 async function mountWith(options: { conditions: JournalDecorationCondition[] }) {
-  mountModal({
+  await mountModal({
     conditionTypes: ALL_CONDITION_TYPES,
     decoration: { mode: "and", conditions: options.conditions, styles: [{ type: "background", color: transparent }] },
   });
@@ -82,16 +55,16 @@ async function mountWith(options: { conditions: JournalDecorationCondition[] }) 
 
 describe("EditDecorationModal", () => {
   describe("submit gating", () => {
-    it("disables Save when no conditions are defined", () => {
-      mountModal({
+    it("disables Save when no conditions are defined", async () => {
+      await mountModal({
         conditionTypes: conditionTypeOptions.day,
         decoration: { mode: "and", conditions: [], styles: [{ type: "background", color: transparent }] },
       });
       expect(screen.getByText(m.common_action_submit()).closest("button")?.disabled).toBe(true);
     });
 
-    it("disables Save when no styles are defined", () => {
-      mountModal({
+    it("disables Save when no styles are defined", async () => {
+      await mountModal({
         conditionTypes: conditionTypeOptions.day,
         decoration: { mode: "and", conditions: [{ type: "has-note" }], styles: [] },
       });
@@ -99,7 +72,7 @@ describe("EditDecorationModal", () => {
     });
 
     it("submits when both arrays are populated", async () => {
-      const { submit } = mountModal({ conditionTypes: conditionTypeOptions.day, decoration: minimalDecoration });
+      const { submit } = await mountModal({ conditionTypes: conditionTypeOptions.day, decoration: minimalDecoration });
       await userEvent.click(screen.getByText(m.common_action_submit()));
       await waitFor(() => {
         expect(submit).toHaveBeenCalledWith({ decoration: expect.objectContaining({ mode: "and" }) as unknown });
@@ -107,7 +80,7 @@ describe("EditDecorationModal", () => {
     });
 
     it("blocks submit and shows an error when a property condition has a blank name", async () => {
-      const { submit } = mountModal({
+      const { submit } = await mountModal({
         conditionTypes: conditionTypeOptions.day,
         decoration: {
           mode: "and",
@@ -123,7 +96,7 @@ describe("EditDecorationModal", () => {
 
   describe("add-condition options", () => {
     it("offers date and weekday for day write type", async () => {
-      mountModal({ conditionTypes: conditionTypeOptions.day, decoration: minimalDecoration });
+      await mountModal({ conditionTypes: conditionTypeOptions.day, decoration: minimalDecoration });
       await userEvent.click(screen.getByText(m.decoration_modal_add_condition()));
       expect(screen.getByText(m.decoration_condition_type_label({ type: "date" }))).toBeTruthy();
       expect(screen.getByText(m.decoration_condition_type_label({ type: "weekday" }))).toBeTruthy();
@@ -131,21 +104,21 @@ describe("EditDecorationModal", () => {
     });
 
     it("offers offset for custom write type but not date or weekday", async () => {
-      mountModal({ conditionTypes: conditionTypeOptions.custom, decoration: minimalDecoration });
+      await mountModal({ conditionTypes: conditionTypeOptions.custom, decoration: minimalDecoration });
       await userEvent.click(screen.getByText(m.decoration_modal_add_condition()));
       expect(screen.getByText(m.decoration_condition_type_label({ type: "offset" }))).toBeTruthy();
       expect(screen.queryByText(m.decoration_condition_type_label({ type: "date" }))).toBeNull();
     });
 
     it("offers only common types for week write type", async () => {
-      mountModal({ conditionTypes: conditionTypeOptions.week, decoration: minimalDecoration });
+      await mountModal({ conditionTypes: conditionTypeOptions.week, decoration: minimalDecoration });
       await userEvent.click(screen.getByText(m.decoration_modal_add_condition()));
       expect(screen.queryByText(m.decoration_condition_type_label({ type: "date" }))).toBeNull();
       expect(screen.queryByText(m.decoration_condition_type_label({ type: "offset" }))).toBeNull();
     });
 
     it("offers only date and weekday for a calendar owner", async () => {
-      mountModal({ conditionTypes: CALENDAR_CONDITION_TYPES });
+      await mountModal({ conditionTypes: CALENDAR_CONDITION_TYPES });
       await userEvent.click(screen.getByText(m.decoration_modal_add_condition()));
       expect(screen.getByText(m.decoration_condition_type_label({ type: "date" }))).toBeTruthy();
       expect(screen.getByText(m.decoration_condition_type_label({ type: "weekday" }))).toBeTruthy();
@@ -171,7 +144,7 @@ describe("EditDecorationModal", () => {
 
   describe("mode change", () => {
     it("reflects the chosen mode in the submitted decoration", async () => {
-      const { submit } = mountModal({
+      const { submit } = await mountModal({
         conditionTypes: conditionTypeOptions.day,
         decoration: { ...minimalDecoration, mode: "and" },
       });
@@ -188,7 +161,7 @@ describe("EditDecorationModal", () => {
 
   describe("removing a condition", () => {
     it("does not leak the removed condition's fields into the one that shifts into its place", async () => {
-      const { submit } = mountModal({
+      const { submit } = await mountModal({
         conditionTypes: conditionTypeOptions.day,
         decoration: {
           mode: "and",
@@ -213,7 +186,7 @@ describe("EditDecorationModal", () => {
 
   describe("style canvas", () => {
     it("keeps the submit button disabled until the decoration has a style", async () => {
-      mountModal({ conditionTypes: conditionTypeOptions.day });
+      await mountModal({ conditionTypes: conditionTypeOptions.day });
       await userEvent.click(screen.getByRole("button", { name: m.decoration_modal_add_condition() }));
       await userEvent.click(
         screen.getByRole("button", { name: m.decoration_condition_type_label({ type: "has-note" }) }),
@@ -222,7 +195,7 @@ describe("EditDecorationModal", () => {
     });
 
     it("enables submit once a condition and a style are present", async () => {
-      mountModal({ conditionTypes: conditionTypeOptions.day });
+      await mountModal({ conditionTypes: conditionTypeOptions.day });
       await userEvent.click(screen.getByRole("button", { name: m.decoration_modal_add_condition() }));
       await userEvent.click(
         screen.getByRole("button", { name: m.decoration_condition_type_label({ type: "has-note" }) }),
@@ -233,8 +206,8 @@ describe("EditDecorationModal", () => {
       expect(screen.getByRole<HTMLButtonElement>("button", { name: m.common_action_create() }).disabled).toBe(false);
     });
 
-    it("no longer offers an add-style dropdown", () => {
-      mountModal({ conditionTypes: conditionTypeOptions.day });
+    it("no longer offers an add-style dropdown", async () => {
+      await mountModal({ conditionTypes: conditionTypeOptions.day });
       expect(screen.queryByRole("button", { name: m.decoration_modal_add_style() })).toBeNull();
     });
   });

--- a/src/decorations/settings/ui/StyleBackground.test.ts
+++ b/src/decorations/settings/ui/StyleBackground.test.ts
@@ -1,9 +1,9 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
+import { render, screen } from "@testing-library/vue";
 import { toTypedSchema } from "@vee-validate/valibot";
 import * as v from "valibot";
 import { useForm } from "vee-validate";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { defineComponent, h } from "vue";
 
 import { decorationStyleSchema, type JournalDecorationStyle } from "@/decorations";
@@ -13,8 +13,6 @@ import StyleBackground from "./StyleBackground.vue";
 type Background = Extract<JournalDecorationStyle, { type: "background" }>;
 
 const renderStyleBackgroundHost = () => h(StyleBackground, { name: "s" });
-
-afterEach(() => cleanup());
 
 function mount(initial: Background) {
   const exposed: { values: { s: Background } } = { values: { s: initial } };

--- a/src/decorations/settings/ui/StyleBorder.test.ts
+++ b/src/decorations/settings/ui/StyleBorder.test.ts
@@ -1,9 +1,9 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
+import { render, screen } from "@testing-library/vue";
 import { toTypedSchema } from "@vee-validate/valibot";
 import * as v from "valibot";
 import { useForm } from "vee-validate";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { defineComponent, h } from "vue";
 
 import { decorationStyleSchema, type JournalDecorationStyle } from "@/decorations";
@@ -15,8 +15,6 @@ import StyleBorder from "./StyleBorder.vue";
 type Border = Extract<JournalDecorationStyle, { type: "border" }>;
 
 const renderStyleBorderHost = () => h(StyleBorder, { name: "s", side: "top" });
-
-afterEach(() => cleanup());
 
 function mount(initial: Border) {
   const exposed: { values: { s: Border } } = { values: { s: initial } };

--- a/src/decorations/settings/ui/StyleBorderSide.test.ts
+++ b/src/decorations/settings/ui/StyleBorderSide.test.ts
@@ -1,9 +1,9 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
+import { render, screen } from "@testing-library/vue";
 import { toTypedSchema } from "@vee-validate/valibot";
 import * as v from "valibot";
 import { useForm } from "vee-validate";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { defineComponent, h } from "vue";
 
 import { borderSideSchema, type BorderSide } from "@/decorations";
@@ -11,8 +11,6 @@ import { borderSideSchema, type BorderSide } from "@/decorations";
 import StyleBorderSide from "./StyleBorderSide.vue";
 
 const renderStyleBorderSideHost = () => h(StyleBorderSide, { name: "s" });
-
-afterEach(() => cleanup());
 
 function mount(initial: BorderSide) {
   const exposed: { values: { s: BorderSide } } = { values: { s: initial } };

--- a/src/decorations/settings/ui/StyleColor.test.ts
+++ b/src/decorations/settings/ui/StyleColor.test.ts
@@ -1,9 +1,9 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
+import { render, screen } from "@testing-library/vue";
 import { toTypedSchema } from "@vee-validate/valibot";
 import * as v from "valibot";
 import { useForm } from "vee-validate";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { defineComponent, h } from "vue";
 
 import { decorationStyleSchema, type JournalDecorationStyle } from "@/decorations";
@@ -13,8 +13,6 @@ import StyleColor from "./StyleColor.vue";
 type ColorStyle = Extract<JournalDecorationStyle, { type: "color" }>;
 
 const renderStyleColorHost = () => h(StyleColor, { name: "s" });
-
-afterEach(() => cleanup());
 
 function mount(initial: ColorStyle) {
   const exposed: { values: { s: ColorStyle } } = { values: { s: initial } };

--- a/src/decorations/settings/ui/StyleCorner.test.ts
+++ b/src/decorations/settings/ui/StyleCorner.test.ts
@@ -1,9 +1,9 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
+import { render, screen } from "@testing-library/vue";
 import { toTypedSchema } from "@vee-validate/valibot";
 import * as v from "valibot";
 import { useForm } from "vee-validate";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { defineComponent, h } from "vue";
 
 import { decorationStyleSchema, type JournalDecorationStyle } from "@/decorations";
@@ -13,8 +13,6 @@ import StyleCorner from "./StyleCorner.vue";
 type Corner = Extract<JournalDecorationStyle, { type: "corner" }>;
 
 const renderStyleCornerHost = () => h(StyleCorner, { name: "s" });
-
-afterEach(() => cleanup());
 
 function mount(initial: Corner) {
   const exposed: { values: { s: Corner } } = { values: { s: initial } };

--- a/src/decorations/settings/ui/StyleIcon.test.ts
+++ b/src/decorations/settings/ui/StyleIcon.test.ts
@@ -1,16 +1,14 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen, within } from "@testing-library/vue";
+import { screen, within } from "@testing-library/vue";
 import { toTypedSchema } from "@vee-validate/valibot";
 import * as v from "valibot";
 import { useForm } from "vee-validate";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { defineComponent, h } from "vue";
 
 import { decorationStyleSchema, type JournalDecorationStyle } from "@/decorations";
 import { m } from "@/i18n";
-import { Container, provideInjectorOnApp } from "@/infrastructure/di";
-import { InputSuggestService } from "@/infrastructure/host";
-import { FakeInputSuggestService } from "@/infrastructure/host/input-suggests/testing";
+import { testContainer } from "@/testing";
 
 import StyleIcon from "./StyleIcon.vue";
 
@@ -27,12 +25,9 @@ const initialIcon: Icon = {
 
 const renderStyleIconHost = () => h(StyleIcon, { name: "s" });
 
-afterEach(() => cleanup());
-
-function mount(initial: Icon) {
+async function mount(initial: Icon) {
   const exposed: { values: { s: Icon } } = { values: { s: initial } };
-  const container = new Container();
-  container.register(InputSuggestService).useValue(new FakeInputSuggestService() as unknown as InputSuggestService);
+  const harness = await testContainer();
   const Host = defineComponent({
     setup() {
       const form = useForm({
@@ -43,17 +38,7 @@ function mount(initial: Icon) {
       return renderStyleIconHost;
     },
   });
-  render(Host, {
-    global: {
-      plugins: [
-        {
-          install(app) {
-            provideInjectorOnApp(app, container);
-          },
-        },
-      ],
-    },
-  });
+  harness.render(Host);
   return exposed;
 }
 
@@ -66,7 +51,7 @@ function rowFor(label: string): HTMLElement {
 
 describe("StyleIcon", () => {
   it("updates the size as the user changes the number", async () => {
-    const host = mount(initialIcon);
+    const host = await mount(initialIcon);
     const sizeRow = rowFor(m.common_label_size());
     const number = within(sizeRow).getByRole("spinbutton");
     await userEvent.clear(number);

--- a/src/decorations/settings/ui/StyleShape.test.ts
+++ b/src/decorations/settings/ui/StyleShape.test.ts
@@ -1,9 +1,9 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen, within } from "@testing-library/vue";
+import { render, screen, within } from "@testing-library/vue";
 import { toTypedSchema } from "@vee-validate/valibot";
 import * as v from "valibot";
 import { useForm } from "vee-validate";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { defineComponent, h } from "vue";
 
 import { decorationStyleSchema, type JournalDecorationStyle } from "@/decorations";
@@ -23,8 +23,6 @@ const initialShape: Shape = {
 };
 
 const renderStyleShapeHost = () => h(StyleShape, { name: "s" });
-
-afterEach(() => cleanup());
 
 function mount(initial: Shape) {
   const exposed: { values: { s: Shape } } = { values: { s: initial } };

--- a/src/decorations/settings/ui/use-style-slots.test.ts
+++ b/src/decorations/settings/ui/use-style-slots.test.ts
@@ -1,14 +1,12 @@
-import { cleanup, render } from "@testing-library/vue";
+import { render } from "@testing-library/vue";
 import { toTypedSchema } from "@vee-validate/valibot";
 import { useForm } from "vee-validate";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { defineComponent, h } from "vue";
 
 import { decorationSchema, type JournalDecoration } from "@/decorations";
 
 import { useStyleSlots } from "./use-style-slots";
-
-afterEach(() => cleanup());
 
 const renderHost = () => h("div");
 

--- a/src/decorations/ui/CellDecoration.test.ts
+++ b/src/decorations/ui/CellDecoration.test.ts
@@ -1,9 +1,9 @@
 import { cleanup, render } from "@testing-library/vue";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { defineComponent, h, provide, shallowRef } from "vue";
 
 import { DayPeriod } from "@/calendar";
-import { date, installTestCalendar } from "@/calendar/testing";
+import { date } from "@/calendar/testing";
 
 import { cellKey } from "../engine";
 import { buildStyle } from "../testing";
@@ -26,12 +26,7 @@ function makeHost(period: DayPeriod, cells: ReadonlyMap<string, CellStyleRef>) {
 }
 
 describe("CellDecoration", () => {
-  let teardown: () => void;
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
   afterEach(() => {
-    teardown();
     cleanup();
   });
 

--- a/src/decorations/ui/CellDecoration.test.ts
+++ b/src/decorations/ui/CellDecoration.test.ts
@@ -1,5 +1,5 @@
-import { cleanup, render } from "@testing-library/vue";
-import { afterEach, describe, expect, it } from "vitest";
+import { render } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
 import { defineComponent, h, provide, shallowRef } from "vue";
 
 import { DayPeriod } from "@/calendar";
@@ -26,10 +26,6 @@ function makeHost(period: DayPeriod, cells: ReadonlyMap<string, CellStyleRef>) {
 }
 
 describe("CellDecoration", () => {
-  afterEach(() => {
-    cleanup();
-  });
-
   it("renders slot content unchanged when no decorations are provided", () => {
     const period = DayPeriod.containing(date("2026-05-25"));
     const { getByText } = render(CellDecoration, {

--- a/src/decorations/ui/DecorationBreakdownModal.test.ts
+++ b/src/decorations/ui/DecorationBreakdownModal.test.ts
@@ -1,31 +1,23 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen, within } from "@testing-library/vue";
-import { createNanoEvents } from "nanoevents";
+import { screen, within } from "@testing-library/vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { nextTick, reactive } from "vue";
 
-import { Calendar, DayPeriod, type AnchorString } from "@/calendar";
-import { date, installTestCalendar, testCalendar } from "@/calendar/testing";
-import {
-  DecorationEngine,
-  DecorationsStore,
-  decorationsSlice,
-  type CalendarDecoration,
-  type JournalDecoration,
-} from "@/decorations";
+import { DayPeriod, type AnchorString } from "@/calendar";
+import { date } from "@/calendar/testing";
+import type { CalendarDecoration, JournalDecoration } from "@/decorations";
 import { m } from "@/i18n";
-import { provideInjectorOnApp } from "@/infrastructure/di";
-import { NoteMetadataService, NoteSizeService, type VaultPath } from "@/infrastructure/host";
-import { ModalService } from "@/infrastructure/host/modals";
-import { FakeModalService } from "@/infrastructure/host/modals/testing";
-import { FakeNoteMetadataService, FakeNoteSizeService } from "@/infrastructure/host/testing";
-import { CycleService, JournalsIndex, JournalsRepository, TimelineService, type JournalsEvents } from "@/journals";
+import type { VaultPath } from "@/infrastructure/host";
+import { JournalsIndex } from "@/journals";
 import type { JournalConfig } from "@/journals/config";
+import { journalsCoreModule } from "@/journals/module";
 import { customJournal, fixedJournal } from "@/journals/testing";
-import { createSettingsService } from "@/settings/testing";
-import { ShelvesRepository, type ShelvesEvents } from "@/shelves";
 import type { ShelfConfig } from "@/shelves/config";
+import { shelvesCoreModule } from "@/shelves/module";
+import { buildShelf } from "@/shelves/testing";
+import { testContainer, type TestHarness } from "@/testing";
 
+import { decorationsModule } from "../module";
+import { decorationsSettingsCoreModule } from "../settings/module";
 import { buildCalendarDecoration, buildCondition, buildDecoration, buildStyle } from "../testing";
 
 import DecorationBreakdownModal from "./DecorationBreakdownModal.vue";
@@ -33,6 +25,10 @@ import DecorationBreakdownModal from "./DecorationBreakdownModal.vue";
 interface Note {
   readonly journalName: string;
   readonly anchor: DayPeriod;
+  // Empty by default: has-note/title conditions only need the file to exist. The note-size
+  // test overrides this so the real NoteSizeService's async fill (triggered by the modal's
+  // own first read) has a size to land on.
+  readonly content?: string;
 }
 
 interface MountOptions {
@@ -46,52 +42,39 @@ interface MountOptions {
   notes?: readonly Note[];
 }
 
-function mount(options: MountOptions = {}) {
-  const { container, service } = createSettingsService({ slices: [decorationsSlice] });
-  service.getSlice(decorationsSlice).state = { decorations: [...(options.globalDecorations ?? [])] };
+// NoteSizeService.get() schedules its own async fill on a miss (note-size-service.ts's
+// #fill), and DecorationEngine.explainRange's first read during mount already triggers that
+// fill for any note-size condition in scope, so waiting out the promise chain is enough —
+// the same pattern note-size-service.test.ts's own `settle` uses. Measured: no
+// FakeNoteSizeService or manual vault event is needed; see the report for the evidence this
+// corrects an earlier ruling that assumed the real service could not be driven deterministically.
+async function settle(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
 
-  const journalStorage = reactive<Record<string, JournalConfig>>({ ...options.journals });
-  const journals = JournalsRepository.fromParts(journalStorage, createNanoEvents<JournalsEvents>());
-
-  const shelfStorage = reactive<Record<string, ShelfConfig>>({ ...options.shelves });
-  const shelves = ShelvesRepository.fromParts(shelfStorage, createNanoEvents<ShelvesEvents>());
-
-  const fakeMetadata = new FakeNoteMetadataService();
-  const index = new JournalsIndex();
-  const notes = options.notes ?? [];
-  for (const note of notes) {
-    const path = `${note.journalName}/${note.anchor.anchor.toAnchor()}.md` as VaultPath;
-    index.register({ journalName: note.journalName, anchor: note.anchor.anchor.toAnchor(), path });
-    fakeMetadata.setMetadata(path, { title: note.journalName, tags: [], properties: {}, tasks: [] });
-  }
-
-  container.register(JournalsRepository).useValue(journals);
-  container.register(ShelvesRepository).useValue(shelves);
-  container.register(DecorationsStore).useClass(DecorationsStore);
-  container.register(JournalsIndex).useValue(index);
-  container.register(CycleService).useClass(CycleService);
-  container.register(TimelineService).useClass(TimelineService);
-  container.register(NoteMetadataService).useValue(fakeMetadata as unknown as NoteMetadataService);
-  const size = new FakeNoteSizeService();
-  container.register(NoteSizeService).useValue(size as unknown as NoteSizeService);
-  container.register(DecorationEngine).useClass(DecorationEngine);
-  container.register(Calendar).useValue(testCalendar());
-  container.register(ModalService).useValue(new FakeModalService() as unknown as ModalService);
-
-  render(DecorationBreakdownModal, {
-    props: { shelf: options.shelf },
-    global: {
-      plugins: [
-        {
-          install(app) {
-            provideInjectorOnApp(app, container);
-          },
-        },
-      ],
+async function mount(options: MountOptions = {}): Promise<{ harness: TestHarness }> {
+  const harness = await testContainer({
+    modules: [journalsCoreModule, shelvesCoreModule, decorationsModule, decorationsSettingsCoreModule],
+    data: {
+      journals: options.journals ?? {},
+      shelves: options.shelves ?? {},
+      decorations: { decorations: [...(options.globalDecorations ?? [])] },
     },
   });
 
-  return { size };
+  const index = harness.resolve(JournalsIndex);
+  const notes = options.notes ?? [];
+  for (const note of notes) {
+    const path = `${note.journalName}/${note.anchor.anchor.toAnchor()}.md` as VaultPath;
+    harness.host.putFile(path, note.content ?? "");
+    index.register({ journalName: note.journalName, anchor: note.anchor.anchor.toAnchor(), path });
+  }
+
+  harness.render(DecorationBreakdownModal, { props: { shelf: options.shelf } });
+
+  return { harness };
 }
 
 const anyDayDecoration: JournalDecoration = buildDecoration({
@@ -119,22 +102,18 @@ const noteSizeDecoration: JournalDecoration = buildDecoration({
 });
 
 describe("DecorationBreakdownModal", () => {
-  let teardown: () => void;
   beforeEach(() => {
     // The explorer defaults its anchor to CalendarDate.today(), so the fixtures' custom-journal
     // intervals (anchored at 2026-05-25) need the system clock pinned there to stay date-stable.
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(new Date("2026-05-25T10:00:00Z"));
-    ({ teardown } = installTestCalendar());
   });
   afterEach(() => {
-    teardown();
-    cleanup();
     vi.useRealTimers();
   });
 
-  it("shows a section for each decorated cell the date belongs to", () => {
-    mount({
+  it("shows a section for each decorated cell the date belongs to", async () => {
+    await mount({
       journals: {
         daily: fixedJournal("daily", { type: "day" }, { decorations: [anyDayDecoration] }),
         weekly: fixedJournal("weekly", { type: "week" }, { decorations: [anyDayDecoration] }),
@@ -144,8 +123,8 @@ describe("DecorationBreakdownModal", () => {
     expect(screen.getAllByTestId("decoration-preview")).toHaveLength(2);
   });
 
-  it("omits a cell no decoration matched", () => {
-    mount({
+  it("omits a cell no decoration matched", async () => {
+    await mount({
       journals: {
         daily: fixedJournal("daily", { type: "day" }, { decorations: [anyDayDecoration] }),
         weekly: fixedJournal("weekly", { type: "week" }, { decorations: [] }),
@@ -155,13 +134,13 @@ describe("DecorationBreakdownModal", () => {
     expect(screen.getAllByTestId("decoration-preview")).toHaveLength(1);
   });
 
-  it("admits a custom journal's offset decoration to the day cell", () => {
+  it("admits a custom journal's offset decoration to the day cell", async () => {
     const offsetDecoration: JournalDecoration = buildDecoration({
       mode: "or",
       conditions: [buildCondition("offset", { offset: 1 })],
       styles: [buildStyle("background")],
     });
-    mount({
+    await mount({
       journals: {
         sprint: customJournal("sprint", "week", 2, "2026-05-25", { decorations: [offsetDecoration] }),
       },
@@ -170,14 +149,14 @@ describe("DecorationBreakdownModal", () => {
     expect(screen.getByText(m.decoration_condition_offset_describe({ side: "start", day: 1 }))).toBeTruthy();
   });
 
-  it("excludes a custom journal's non-offset decoration from the day cell", () => {
+  it("excludes a custom journal's non-offset decoration from the day cell", async () => {
     const day = DayPeriod.containing(date("2026-05-25"));
     const nonOffsetDecoration: JournalDecoration = buildDecoration({
       mode: "or",
       conditions: [buildCondition("has-note")],
       styles: [buildStyle("background")],
     });
-    mount({
+    await mount({
       journals: {
         sprint: customJournal("sprint", "week", 2, "2026-05-25", { decorations: [nonOffsetDecoration] }),
       },
@@ -189,9 +168,9 @@ describe("DecorationBreakdownModal", () => {
     expect(screen.queryByText(m.decoration_breakdown_cell_heading({ kind: "day", label: "2026-05-25" }))).toBeNull();
   });
 
-  it("shows an interval section for a custom journal's non-offset decoration", () => {
+  it("shows an interval section for a custom journal's non-offset decoration", async () => {
     const day = DayPeriod.containing(date("2026-05-25"));
-    mount({
+    await mount({
       journals: {
         sprint: customJournal("sprint", "week", 2, "2026-05-25", { decorations: [hasNoteDecoration] }),
       },
@@ -206,14 +185,14 @@ describe("DecorationBreakdownModal", () => {
     expect(within(region as HTMLElement).getByText(m.decoration_condition_has_note_describe())).toBeTruthy();
   });
 
-  it("keeps a custom journal's offset decoration out of the interval section", () => {
+  it("keeps a custom journal's offset decoration out of the interval section", async () => {
     const day = DayPeriod.containing(date("2026-05-25"));
     const offsetDecoration: JournalDecoration = buildDecoration({
       mode: "or",
       conditions: [buildCondition("offset", { offset: 1 })],
       styles: [buildStyle("background")],
     });
-    mount({
+    await mount({
       journals: {
         sprint: customJournal("sprint", "week", 2, "2026-05-25", {
           decorations: [hasNoteDecoration, offsetDecoration],
@@ -232,9 +211,9 @@ describe("DecorationBreakdownModal", () => {
     ).toBeNull();
   });
 
-  it("omits an interval section for a journal whose timeline excludes the interval", () => {
+  it("omits an interval section for a journal whose timeline excludes the interval", async () => {
     const day = DayPeriod.containing(date("2026-05-25"));
-    mount({
+    await mount({
       journals: {
         sprint: customJournal("sprint", "week", 2, "2026-05-25", {
           decorations: [hasNoteDecoration],
@@ -250,10 +229,10 @@ describe("DecorationBreakdownModal", () => {
   });
 
   it("re-resolves when the shelf selection changes", async () => {
-    mount({
+    await mount({
       shelves: {
-        work: { name: "work", journals: [], decorations: [] },
-        home: { name: "home", journals: [], decorations: [anyDayCalendarDecoration] },
+        work: buildShelf("work"),
+        home: buildShelf("home", { decorations: [anyDayCalendarDecoration] }),
       },
     });
 
@@ -266,10 +245,10 @@ describe("DecorationBreakdownModal", () => {
   });
 
   it("resolves against the shelf it was opened under", async () => {
-    mount({
+    await mount({
       shelves: {
-        work: { name: "work", journals: [], decorations: [] },
-        home: { name: "home", journals: [], decorations: [anyDayCalendarDecoration] },
+        work: buildShelf("work"),
+        home: buildShelf("home", { decorations: [anyDayCalendarDecoration] }),
       },
       shelf: "work",
     });
@@ -283,26 +262,25 @@ describe("DecorationBreakdownModal", () => {
     expect(screen.getByTestId("decoration-preview")).toBeTruthy();
   });
 
-  it("shows the empty state for a date nothing decorates", () => {
-    mount({});
+  it("shows the empty state for a date nothing decorates", async () => {
+    await mount({});
 
     expect(screen.getByText(m.decoration_breakdown_empty())).toBeTruthy();
   });
 
   it("shows a note-size decoration once its size lands", async () => {
     const day = DayPeriod.containing(date("2026-05-25"));
-    const path = "daily/2026-05-25.md" as VaultPath;
-    const { size } = mount({
+    await mount({
       journals: {
         daily: fixedJournal("daily", { type: "day" }, { decorations: [noteSizeDecoration] }),
       },
-      notes: [{ journalName: "daily", anchor: day }],
+      // 400 "word"s clears the condition's gt:100 threshold once NoteSizeService reads it.
+      notes: [{ journalName: "daily", anchor: day, content: "word ".repeat(400) }],
     });
 
     expect(screen.getByText(m.decoration_breakdown_empty())).toBeTruthy();
 
-    size.setSize(path, { words: 400, characters: 2200 });
-    await nextTick();
+    await settle();
 
     expect(screen.getByTestId("decoration-preview")).toBeTruthy();
   });

--- a/src/decorations/ui/DecorationBreakdownModal.test.ts
+++ b/src/decorations/ui/DecorationBreakdownModal.test.ts
@@ -42,18 +42,6 @@ interface MountOptions {
   notes?: readonly Note[];
 }
 
-// NoteSizeService.get() schedules its own async fill on a miss (note-size-service.ts's
-// #fill), and DecorationEngine.explainRange's first read during mount already triggers that
-// fill for any note-size condition in scope, so waiting out the promise chain is enough —
-// the same pattern note-size-service.test.ts's own `settle` uses. Measured: no
-// FakeNoteSizeService or manual vault event is needed; see the report for the evidence this
-// corrects an earlier ruling that assumed the real service could not be driven deterministically.
-async function settle(): Promise<void> {
-  await Promise.resolve();
-  await Promise.resolve();
-  await Promise.resolve();
-}
-
 async function mount(options: MountOptions = {}): Promise<{ harness: TestHarness }> {
   const harness = await testContainer({
     modules: [journalsCoreModule, shelvesCoreModule, decorationsModule, decorationsSettingsCoreModule],
@@ -280,8 +268,10 @@ describe("DecorationBreakdownModal", () => {
 
     expect(screen.getByText(m.decoration_breakdown_empty())).toBeTruthy();
 
-    await settle();
-
-    expect(screen.getByTestId("decoration-preview")).toBeTruthy();
+    // NoteSizeService.get() schedules its own async fill on a miss (note-size-service.ts's
+    // #fill), and DecorationEngine.explainRange's first read during mount already triggers that
+    // fill for any note-size condition in scope, so waiting the fill out is enough — no
+    // FakeNoteSizeService or manual vault event is needed.
+    await vi.waitFor(() => expect(screen.getByTestId("decoration-preview")).toBeTruthy());
   });
 });

--- a/src/decorations/ui/DecorationBreakdownSection.test.ts
+++ b/src/decorations/ui/DecorationBreakdownSection.test.ts
@@ -1,20 +1,19 @@
-import { cleanup, render, screen, within } from "@testing-library/vue";
-import { createNanoEvents } from "nanoevents";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { screen, within } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
 import { markRaw } from "vue";
 
-import { Calendar, DayPeriod } from "@/calendar";
-import { date, installTestCalendar, testCalendar } from "@/calendar/testing";
+import { DayPeriod } from "@/calendar";
+import { date } from "@/calendar/testing";
 import { m } from "@/i18n";
-import { provideInjectorOnApp } from "@/infrastructure/di";
-import { JournalsRepository, type JournalsEvents } from "@/journals";
+import type { JournalConfig } from "@/journals/config";
+import { journalsCoreModule } from "@/journals/module";
 import { fixedJournal } from "@/journals/testing";
-import { createSettingsService } from "@/settings/testing";
-import { ShelvesRepository, type ShelvesEvents } from "@/shelves";
+import { shelvesCoreModule } from "@/shelves/module";
+import { testContainer, type TestHarness } from "@/testing";
 
 import { attributeCell } from "../attribute-cell";
-import { DecorationsStore } from "../decorations-store";
-import { decorationsSlice } from "../settings/slice";
+import { decorationsModule } from "../module";
+import { decorationsSettingsCoreModule } from "../settings/module";
 import { buildCalendarDecoration, buildCondition, buildDecoration, buildStyle } from "../testing";
 
 import DecorationBreakdownSection from "./DecorationBreakdownSection.vue";
@@ -41,29 +40,32 @@ const anyDayCalendarDecoration: CalendarDecoration = buildCalendarDecoration({
   styles: [buildStyle("background")],
 });
 
+async function buildHarness(
+  options: { journals?: Record<string, JournalConfig>; globalDecorations?: readonly CalendarDecoration[] } = {},
+): Promise<TestHarness> {
+  return testContainer({
+    modules: [journalsCoreModule, shelvesCoreModule, decorationsModule, decorationsSettingsCoreModule],
+    data: {
+      journals: options.journals ?? {},
+      shelves: {},
+      decorations: { decorations: [...(options.globalDecorations ?? [])] },
+    },
+  });
+}
+
 // The section reads decorations back out of DecorationsStore by owner + index to render their
 // condition text, so the fixtures must be registered there, not just referenced by the cell.
-function mountSection(options: {
+async function mountSection(options: {
   journalDecorations?: readonly JournalDecoration[];
   globalDecorations?: readonly CalendarDecoration[];
   contributions: readonly Contribution[];
-}) {
-  const { container, service } = createSettingsService({ slices: [decorationsSlice] });
-  service.getSlice(decorationsSlice).state = { decorations: [...(options.globalDecorations ?? [])] };
-
-  const journals = JournalsRepository.fromParts(
-    {
+}): Promise<void> {
+  const harness = await buildHarness({
+    journals: {
       daily: fixedJournal("daily", { type: "day" }, { decorations: [...(options.journalDecorations ?? [])] }),
     },
-    createNanoEvents<JournalsEvents>(),
-  );
-
-  const shelves = ShelvesRepository.fromParts({}, createNanoEvents<ShelvesEvents>());
-
-  container.register(JournalsRepository).useValue(journals);
-  container.register(ShelvesRepository).useValue(shelves);
-  container.register(DecorationsStore).useClass(DecorationsStore);
-  container.register(Calendar).useValue(testCalendar());
+    globalDecorations: options.globalDecorations,
+  });
 
   // @vue/test-utils stores props on a reactive() object, so an unmarked cell would get its
   // Period lazily wrapped in a Proxy on read — and calling a private-field method (e.g.
@@ -76,32 +78,12 @@ function mountSection(options: {
     styles: options.contributions.map((contribution) => contribution.style),
   });
 
-  render(DecorationBreakdownSection, {
-    props: { cell, index: 0 },
-    global: {
-      plugins: [
-        {
-          install(app) {
-            provideInjectorOnApp(app, container);
-          },
-        },
-      ],
-    },
-  });
+  harness.render(DecorationBreakdownSection, { props: { cell, index: 0 } });
 }
 
 describe("DecorationBreakdownSection", () => {
-  let teardown: () => void;
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-    cleanup();
-  });
-
-  it("names the winning decoration for a resolved property", () => {
-    mountSection({
+  it("names the winning decoration for a resolved property", async () => {
+    await mountSection({
       globalDecorations: [anyDayCalendarDecoration],
       journalDecorations: [hasNoteDecoration],
       contributions: [
@@ -119,8 +101,8 @@ describe("DecorationBreakdownSection", () => {
     ).toBeTruthy();
   });
 
-  it("lists a contribution that lost a property under the overridden heading", () => {
-    mountSection({
+  it("lists a contribution that lost a property under the overridden heading", async () => {
+    await mountSection({
       globalDecorations: [anyDayCalendarDecoration],
       journalDecorations: [hasNoteDecoration],
       contributions: [
@@ -138,13 +120,13 @@ describe("DecorationBreakdownSection", () => {
     expect(within(overriddenGroup).getByText(m.decoration_breakdown_owner({ kind: "global", name: "" }))).toBeTruthy();
   });
 
-  it("interleaves the mode word between an OR decoration's conditions", () => {
+  it("interleaves the mode word between an OR decoration's conditions", async () => {
     const orDecoration: JournalDecoration = buildDecoration({
       mode: "or",
       conditions: [buildCondition("has-note"), buildCondition("date", { day: -1, month: -1, year: null })],
       styles: [buildStyle("background")],
     });
-    mountSection({
+    await mountSection({
       journalDecorations: [orDecoration],
       contributions: [
         { source: { owner: { kind: "journal", journalName: "daily" }, index: 0 }, style: buildStyle("background") },
@@ -156,7 +138,7 @@ describe("DecorationBreakdownSection", () => {
     expect(screen.getByText(m.decoration_describe_mode({ kind: "or" }))).toBeTruthy();
   });
 
-  it("lists marks without naming a winner", () => {
+  it("lists marks without naming a winner", async () => {
     const journalMark: JournalDecoration = buildDecoration({
       mode: "or",
       conditions: [buildCondition("has-note")],
@@ -167,7 +149,7 @@ describe("DecorationBreakdownSection", () => {
       conditions: [buildCondition("date", { day: -1, month: -1, year: null })],
       styles: [buildStyle("shape")],
     });
-    mountSection({
+    await mountSection({
       journalDecorations: [journalMark],
       globalDecorations: [globalMark],
       contributions: [
@@ -184,15 +166,8 @@ describe("DecorationBreakdownSection", () => {
     expect(screen.queryByText(m.decoration_breakdown_overridden_heading())).toBeNull();
   });
 
-  it("keeps its accessible name intact for a journal name containing a space", () => {
-    const { container, service } = createSettingsService({ slices: [decorationsSlice] });
-    service.getSlice(decorationsSlice).state = { decorations: [] };
-    const journals = JournalsRepository.fromParts({}, createNanoEvents<JournalsEvents>());
-    const shelves = ShelvesRepository.fromParts({}, createNanoEvents<ShelvesEvents>());
-    container.register(JournalsRepository).useValue(journals);
-    container.register(ShelvesRepository).useValue(shelves);
-    container.register(DecorationsStore).useClass(DecorationsStore);
-    container.register(Calendar).useValue(testCalendar());
+  it("keeps its accessible name intact for a journal name containing a space", async () => {
+    const harness = await buildHarness();
 
     const cell: BreakdownCell = markRaw({
       kind: "interval",
@@ -202,18 +177,7 @@ describe("DecorationBreakdownSection", () => {
       styles: [],
     });
 
-    render(DecorationBreakdownSection, {
-      props: { cell, index: 0 },
-      global: {
-        plugins: [
-          {
-            install(app) {
-              provideInjectorOnApp(app, container);
-            },
-          },
-        ],
-      },
-    });
+    harness.render(DecorationBreakdownSection, { props: { cell, index: 0 } });
 
     // `aria-labelledby` tokenizes on whitespace, so an id built from the raw journal name would
     // resolve to nonexistent ids and the region would lose its accessible name entirely.

--- a/src/decorations/ui/DecorationCellModal.test.ts
+++ b/src/decorations/ui/DecorationCellModal.test.ts
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import { screen } from "@testing-library/vue";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { DayPeriod, WeekPeriod } from "@/calendar";
 import { date } from "@/calendar/testing";
@@ -40,18 +40,6 @@ interface MountOptions {
   notes?: readonly Note[];
   entry: BreakdownEntry;
   shelf?: string | null;
-}
-
-// NoteSizeService.get() schedules its own async fill on a miss (note-size-service.ts's
-// #fill), and DecorationEngine.explainRange's first read during mount already triggers that
-// fill for any note-size condition in scope, so waiting out the promise chain is enough —
-// the same pattern note-size-service.test.ts's own `settle` uses. Measured: no
-// FakeNoteSizeService or manual vault event is needed; see the report for the evidence this
-// corrects an earlier ruling that assumed the real service could not be driven deterministically.
-async function settle(): Promise<void> {
-  await Promise.resolve();
-  await Promise.resolve();
-  await Promise.resolve();
 }
 
 async function mount(options: MountOptions): Promise<{ harness: TestHarness }> {
@@ -205,8 +193,10 @@ describe("DecorationCellModal", () => {
 
     expect(screen.getByText(m.decoration_breakdown_cell_empty())).toBeTruthy();
 
-    await settle();
-
-    expect(screen.getByTestId("decoration-preview")).toBeTruthy();
+    // NoteSizeService.get() schedules its own async fill on a miss (note-size-service.ts's
+    // #fill), and DecorationEngine.explainRange's first read during mount already triggers that
+    // fill for any note-size condition in scope, so waiting the fill out is enough — no
+    // FakeNoteSizeService or manual vault event is needed.
+    await vi.waitFor(() => expect(screen.getByTestId("decoration-preview")).toBeTruthy());
   });
 });

--- a/src/decorations/ui/DecorationCellModal.test.ts
+++ b/src/decorations/ui/DecorationCellModal.test.ts
@@ -1,29 +1,23 @@
 import userEvent from "@testing-library/user-event";
-import { cleanup, render, screen } from "@testing-library/vue";
-import { createNanoEvents } from "nanoevents";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { nextTick, reactive } from "vue";
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
 
-import { Calendar, DayPeriod, WeekPeriod } from "@/calendar";
-import { date, installTestCalendar, testCalendar } from "@/calendar/testing";
-import {
-  DecorationEngine,
-  DecorationsStore,
-  decorationsSlice,
-  type CalendarDecoration,
-  type JournalDecoration,
-} from "@/decorations";
+import { DayPeriod, WeekPeriod } from "@/calendar";
+import { date } from "@/calendar/testing";
+import type { CalendarDecoration, JournalDecoration } from "@/decorations";
 import { m } from "@/i18n";
-import { provideInjectorOnApp } from "@/infrastructure/di";
-import { NoteMetadataService, NoteSizeService, type VaultPath } from "@/infrastructure/host";
-import { FakeNoteMetadataService, FakeNoteSizeService } from "@/infrastructure/host/testing";
-import { CycleService, JournalsIndex, JournalsRepository, TimelineService, type JournalsEvents } from "@/journals";
+import type { VaultPath } from "@/infrastructure/host";
+import { JournalsIndex } from "@/journals";
 import type { JournalConfig } from "@/journals/config";
+import { journalsCoreModule } from "@/journals/module";
 import { customJournal, fixedJournal } from "@/journals/testing";
-import { createSettingsService } from "@/settings/testing";
-import { ShelvesRepository, type ShelvesEvents } from "@/shelves";
 import type { ShelfConfig } from "@/shelves/config";
+import { shelvesCoreModule } from "@/shelves/module";
+import { buildShelf } from "@/shelves/testing";
+import { testContainer, type TestHarness } from "@/testing";
 
+import { decorationsModule } from "../module";
+import { decorationsSettingsCoreModule } from "../settings/module";
 import { buildCalendarDecoration, buildCondition, buildDecoration, buildStyle } from "../testing";
 
 import DecorationCellModal from "./DecorationCellModal.vue";
@@ -33,6 +27,10 @@ import type { BreakdownEntry } from "./breakdown-entry";
 interface Note {
   readonly journalName: string;
   readonly anchor: DayPeriod;
+  // Empty by default: has-note/title conditions only need the file to exist. The note-size
+  // test overrides this so the real NoteSizeService's async fill (triggered by the modal's
+  // own first read) has a size to land on.
+  readonly content?: string;
 }
 
 interface MountOptions {
@@ -44,51 +42,39 @@ interface MountOptions {
   shelf?: string | null;
 }
 
-function mount(options: MountOptions) {
-  const { container, service } = createSettingsService({ slices: [decorationsSlice] });
-  service.getSlice(decorationsSlice).state = { decorations: [...(options.globalDecorations ?? [])] };
+// NoteSizeService.get() schedules its own async fill on a miss (note-size-service.ts's
+// #fill), and DecorationEngine.explainRange's first read during mount already triggers that
+// fill for any note-size condition in scope, so waiting out the promise chain is enough —
+// the same pattern note-size-service.test.ts's own `settle` uses. Measured: no
+// FakeNoteSizeService or manual vault event is needed; see the report for the evidence this
+// corrects an earlier ruling that assumed the real service could not be driven deterministically.
+async function settle(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
 
-  const journalStorage = reactive<Record<string, JournalConfig>>({ ...options.journals });
-  const journals = JournalsRepository.fromParts(journalStorage, createNanoEvents<JournalsEvents>());
-
-  const shelfStorage = reactive<Record<string, ShelfConfig>>({ ...options.shelves });
-  const shelves = ShelvesRepository.fromParts(shelfStorage, createNanoEvents<ShelvesEvents>());
-
-  const fakeMetadata = new FakeNoteMetadataService();
-  const index = new JournalsIndex();
-  const notes = options.notes ?? [];
-  for (const note of notes) {
-    const path = `${note.journalName}/${note.anchor.anchor.toAnchor()}.md` as VaultPath;
-    index.register({ journalName: note.journalName, anchor: note.anchor.anchor.toAnchor(), path });
-    fakeMetadata.setMetadata(path, { title: note.journalName, tags: [], properties: {}, tasks: [] });
-  }
-
-  container.register(JournalsRepository).useValue(journals);
-  container.register(ShelvesRepository).useValue(shelves);
-  container.register(DecorationsStore).useClass(DecorationsStore);
-  container.register(JournalsIndex).useValue(index);
-  container.register(CycleService).useClass(CycleService);
-  container.register(TimelineService).useClass(TimelineService);
-  container.register(NoteMetadataService).useValue(fakeMetadata as unknown as NoteMetadataService);
-  const size = new FakeNoteSizeService();
-  container.register(NoteSizeService).useValue(size as unknown as NoteSizeService);
-  container.register(DecorationEngine).useClass(DecorationEngine);
-  container.register(Calendar).useValue(testCalendar());
-
-  render(DecorationCellModal, {
-    props: { entry: options.entry, shelf: options.shelf },
-    global: {
-      plugins: [
-        {
-          install(app) {
-            provideInjectorOnApp(app, container);
-          },
-        },
-      ],
+async function mount(options: MountOptions): Promise<{ harness: TestHarness }> {
+  const harness = await testContainer({
+    modules: [journalsCoreModule, shelvesCoreModule, decorationsModule, decorationsSettingsCoreModule],
+    data: {
+      journals: options.journals ?? {},
+      shelves: options.shelves ?? {},
+      decorations: { decorations: [...(options.globalDecorations ?? [])] },
     },
   });
 
-  return { size };
+  const index = harness.resolve(JournalsIndex);
+  const notes = options.notes ?? [];
+  for (const note of notes) {
+    const path = `${note.journalName}/${note.anchor.anchor.toAnchor()}.md` as VaultPath;
+    harness.host.putFile(path, note.content ?? "");
+    index.register({ journalName: note.journalName, anchor: note.anchor.anchor.toAnchor(), path });
+  }
+
+  harness.render(DecorationCellModal, { props: { entry: options.entry, shelf: options.shelf } });
+
+  return { harness };
 }
 
 const anyDayDecoration: JournalDecoration = buildDecoration({
@@ -116,18 +102,9 @@ const anyDayCalendarDecoration: CalendarDecoration = buildCalendarDecoration({
 });
 
 describe("DecorationCellModal", () => {
-  let teardown: () => void;
-  beforeEach(() => {
-    ({ teardown } = installTestCalendar());
-  });
-  afterEach(() => {
-    teardown();
-    cleanup();
-  });
-
-  it("renders only the clicked cell when the date also belongs to a decorated week cell", () => {
+  it("renders only the clicked cell when the date also belongs to a decorated week cell", async () => {
     const day = DayPeriod.containing(date("2026-05-25"));
-    mount({
+    await mount({
       journals: {
         daily: fixedJournal("daily", { type: "day" }, { decorations: [hasNoteDecoration] }),
         weekly: fixedJournal("weekly", { type: "week" }, { decorations: [anyDayDecoration] }),
@@ -140,10 +117,10 @@ describe("DecorationCellModal", () => {
     expect(screen.getAllByTestId("decoration-preview")).toHaveLength(1);
   });
 
-  it("resolves a week entry against the week cell", () => {
+  it("resolves a week entry against the week cell", async () => {
     const day = DayPeriod.containing(date("2026-05-25"));
     const week = WeekPeriod.containing(date("2026-05-25"));
-    mount({
+    await mount({
       journals: {
         daily: fixedJournal("daily", { type: "day" }, { decorations: [hasNoteDecoration] }),
         weekly: fixedJournal("weekly", { type: "week" }, { decorations: [anyDayDecoration] }),
@@ -155,9 +132,9 @@ describe("DecorationCellModal", () => {
     expect(screen.getByText(m.decoration_breakdown_owner({ kind: "journal", name: "weekly" }))).toBeTruthy();
   });
 
-  it("resolves an interval entry against the interval's own decorations", () => {
+  it("resolves an interval entry against the interval's own decorations", async () => {
     const day = DayPeriod.containing(date("2026-05-25"));
-    mount({
+    await mount({
       journals: {
         sprint: customJournal("sprint", "week", 2, "2026-05-25", { decorations: [hasNoteDecoration] }),
       },
@@ -172,9 +149,9 @@ describe("DecorationCellModal", () => {
     ).toBeTruthy();
   });
 
-  it("resolves a day entry against the day cell when that day starts an interval", () => {
+  it("resolves a day entry against the day cell when that day starts an interval", async () => {
     const day = DayPeriod.containing(date("2026-05-25"));
-    mount({
+    await mount({
       journals: {
         daily: fixedJournal("daily", { type: "day" }, { decorations: [anyDayDecoration] }),
         sprint: customJournal("sprint", "week", 2, "2026-05-25", { decorations: [hasNoteDecoration] }),
@@ -189,13 +166,10 @@ describe("DecorationCellModal", () => {
     ).toBeNull();
   });
 
-  it("resolves against the shelf it was opened under", () => {
+  it("resolves against the shelf it was opened under", async () => {
     const day = DayPeriod.containing(date("2026-05-25"));
-    mount({
-      shelves: {
-        work: { name: "work", journals: [], decorations: [] },
-        home: { name: "home", journals: [], decorations: [anyDayCalendarDecoration] },
-      },
+    await mount({
+      shelves: { work: buildShelf("work"), home: buildShelf("home", { decorations: [anyDayCalendarDecoration] }) },
       entry: { kind: "fixed", period: day },
       shelf: "work",
     });
@@ -205,11 +179,8 @@ describe("DecorationCellModal", () => {
 
   it("re-resolves when the shelf selection changes", async () => {
     const day = DayPeriod.containing(date("2026-05-25"));
-    mount({
-      shelves: {
-        work: { name: "work", journals: [], decorations: [] },
-        home: { name: "home", journals: [], decorations: [anyDayCalendarDecoration] },
-      },
+    await mount({
+      shelves: { work: buildShelf("work"), home: buildShelf("home", { decorations: [anyDayCalendarDecoration] }) },
       entry: { kind: "fixed", period: day },
       shelf: "home",
     });
@@ -223,19 +194,18 @@ describe("DecorationCellModal", () => {
 
   it("shows a note-size decoration once its size lands", async () => {
     const day = DayPeriod.containing(date("2026-05-25"));
-    const path = "daily/2026-05-25.md" as VaultPath;
-    const { size } = mount({
+    await mount({
       journals: {
         daily: fixedJournal("daily", { type: "day" }, { decorations: [noteSizeDecoration] }),
       },
-      notes: [{ journalName: "daily", anchor: day }],
+      // 400 "word"s clears the condition's gt:100 threshold once NoteSizeService reads it.
+      notes: [{ journalName: "daily", anchor: day, content: "word ".repeat(400) }],
       entry: { kind: "fixed", period: day },
     });
 
     expect(screen.getByText(m.decoration_breakdown_cell_empty())).toBeTruthy();
 
-    size.setSize(path, { words: 400, characters: 2200 });
-    await nextTick();
+    await settle();
 
     expect(screen.getByTestId("decoration-preview")).toBeTruthy();
   });

--- a/src/decorations/ui/DecorationPreview.test.ts
+++ b/src/decorations/ui/DecorationPreview.test.ts
@@ -1,11 +1,9 @@
-import { cleanup, render, screen } from "@testing-library/vue";
-import { afterEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
 
 import DecorationPreview from "./DecorationPreview.vue";
 
 import type { JournalDecorationStyle } from "../config";
-
-afterEach(() => cleanup());
 
 describe("DecorationPreview", () => {
   it("renders the slot content", () => {

--- a/src/decorations/ui/use-decoration-menu-item.test.ts
+++ b/src/decorations/ui/use-decoration-menu-item.test.ts
@@ -1,14 +1,10 @@
-import { cleanup, render } from "@testing-library/vue";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { defineComponent, h, shallowRef } from "vue";
 
 import { CalendarDate, DayPeriod } from "@/calendar";
 import type { Period } from "@/calendar";
-import { installTestCalendar } from "@/calendar/testing";
-import { Container, provideInjectorOnApp } from "@/infrastructure/di";
 import type { MenuItemSpec } from "@/infrastructure/host";
-import { ModalService } from "@/infrastructure/host/modals";
-import { FakeModalService } from "@/infrastructure/host/modals/testing";
+import { testContainer } from "@/testing";
 import { icons } from "@/ui/icons";
 
 import { cellKey } from "../engine";
@@ -30,16 +26,14 @@ function renderDiv() {
   return h("div");
 }
 
-function mountItems(
+async function mountItems(
   cells: ReadonlyMap<string, CellStyleRef> | null,
   shelf: string | null = null,
-): {
+): Promise<{
   itemsFor: (entry: BreakdownEntry) => readonly MenuItemSpec[];
-  modals: FakeModalService;
-} {
-  const modals = new FakeModalService();
-  const container = new Container();
-  container.register(ModalService).useValue(modals as unknown as ModalService);
+  modals: Awaited<ReturnType<typeof testContainer>>["modals"];
+}> {
+  const harness = await testContainer();
 
   const captured: { value: ((entry: BreakdownEntry) => readonly MenuItemSpec[]) | null } = { value: null };
   const Host = defineComponent({
@@ -48,68 +42,49 @@ function mountItems(
       return renderDiv;
     },
   });
-  render(Host, {
-    global: {
-      plugins: [
-        {
-          install(app) {
-            provideInjectorOnApp(app, container);
-          },
-        },
-      ],
-    },
-  });
+  harness.render(Host);
   if (!captured.value) throw new Error("composable did not run");
-  return { itemsFor: captured.value, modals };
+  return { itemsFor: captured.value, modals: harness.modals };
 }
 
 function cellsWith(period: Period, ref: CellStyleRef): ReadonlyMap<string, CellStyleRef> {
   return new Map([[cellKey(period.kind, period.anchor.toAnchor()), ref]]);
 }
 
-let teardown: () => void;
-beforeEach(() => {
-  ({ teardown } = installTestCalendar());
-});
-afterEach(() => {
-  teardown();
-  cleanup();
-});
-
 describe("useDecorationMenuItems", () => {
-  it("contributes no item for a cell with no decorations", () => {
+  it("contributes no item for a cell with no decorations", async () => {
     const period = DayPeriod.containing(date("2026-05-25"));
     const cells = cellsWith(period, shallowRef([]));
 
-    const { itemsFor } = mountItems(cells);
+    const { itemsFor } = await mountItems(cells);
 
     expect(itemsFor({ kind: "fixed", period })).toEqual([]);
   });
 
-  it("contributes no item when no cell map was provided", () => {
+  it("contributes no item when no cell map was provided", async () => {
     const period = DayPeriod.containing(date("2026-05-25"));
 
-    const { itemsFor } = mountItems(null);
+    const { itemsFor } = await mountItems(null);
 
     expect(itemsFor({ kind: "fixed", period })).toEqual([]);
   });
 
-  it("contributes an item for a cell carrying at least one style", () => {
+  it("contributes an item for a cell carrying at least one style", async () => {
     const period = DayPeriod.containing(date("2026-05-25"));
     const cells = cellsWith(period, shallowRef([buildStyle("background")]));
 
-    const { itemsFor } = mountItems(cells);
+    const { itemsFor } = await mountItems(cells);
     const items = itemsFor({ kind: "fixed", period });
 
     expect(items).toHaveLength(1);
     expect(items[0]).toMatchObject({ icon: icons.action.search });
   });
 
-  it("opens the cell readout for the clicked cell", () => {
+  it("opens the cell readout for the clicked cell", async () => {
     const period = DayPeriod.containing(date("2026-05-25"));
     const cells = cellsWith(period, shallowRef([buildStyle("background")]));
 
-    const { itemsFor, modals } = mountItems(cells);
+    const { itemsFor, modals } = await mountItems(cells);
     itemsFor({ kind: "fixed", period })[0].onClick();
 
     const opened = modals.lastOpen<{ entry: BreakdownEntry }, void>();
@@ -117,21 +92,21 @@ describe("useDecorationMenuItems", () => {
     expect(opened.props.entry).toEqual({ kind: "fixed", period });
   });
 
-  it("scopes the readout it opens to the surface's shelf", () => {
+  it("scopes the readout it opens to the surface's shelf", async () => {
     const period = DayPeriod.containing(date("2026-05-25"));
     const cells = cellsWith(period, shallowRef([buildStyle("background")]));
 
-    const { itemsFor, modals } = mountItems(cells, "Work");
+    const { itemsFor, modals } = await mountItems(cells, "Work");
     itemsFor({ kind: "fixed", period })[0].onClick();
 
     expect(modals.lastOpen<{ shelf: string | null }, void>().props.shelf).toBe("Work");
   });
 
-  it("forwards an interval entry unchanged", () => {
+  it("forwards an interval entry unchanged", async () => {
     const period = DayPeriod.containing(date("2026-05-25"));
     const cells = cellsWith(period, shallowRef([buildStyle("background")]));
 
-    const { itemsFor, modals } = mountItems(cells);
+    const { itemsFor, modals } = await mountItems(cells);
     itemsFor({ kind: "interval", period, journalName: "sprint" })[0].onClick();
 
     expect(modals.lastOpen<{ entry: BreakdownEntry }, void>().props.entry).toEqual({

--- a/src/decorations/use-cell-decorations.test.ts
+++ b/src/decorations/use-cell-decorations.test.ts
@@ -1,31 +1,24 @@
-import { cleanup, render } from "@testing-library/vue";
-import { createNanoEvents, type Emitter } from "nanoevents";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { defineComponent, h, inject as vInject, nextTick, reactive, ref, type Ref } from "vue";
+import { describe, expect, it, vi } from "vitest";
+import { defineComponent, h, inject as vInject, nextTick, ref, type Ref } from "vue";
 
-import { CalendarDate, DayPeriod, WeekPeriod } from "@/calendar";
+import { DayPeriod, WeekPeriod } from "@/calendar";
 import type { Period } from "@/calendar";
-import { installTestCalendar } from "@/calendar/testing";
-import { provideInjectorOnApp, type Container } from "@/infrastructure/di";
-import {
-  NoteMetadataService,
-  NoteSizeService,
-  NotesService,
-  type NotesEvents,
-  type VaultPath,
-} from "@/infrastructure/host";
-import { FakeNoteMetadataService, FakeNoteSizeService } from "@/infrastructure/host/testing";
-import { CycleService, JournalsIndex, JournalsRepository, TimelineService } from "@/journals";
+import { date } from "@/calendar/testing";
+import { NoteMetadataService, NoteSizeService, type VaultPath } from "@/infrastructure/host";
+import { FakeNoteSizeService } from "@/infrastructure/host/testing";
+import { JournalsIndex } from "@/journals";
 import type { JournalConfig } from "@/journals/config";
-import { fakeRepo, fixedJournal } from "@/journals/testing";
-import { createSettingsService } from "@/settings/testing";
-import { ShelvesRepository, type ShelvesEvents } from "@/shelves";
-import type { ShelfConfig } from "@/shelves/config";
+import { journalsCoreModule } from "@/journals/module";
+import { fixedJournal } from "@/journals/testing";
+import { shelvesCoreModule } from "@/shelves/module";
+import { buildShelf } from "@/shelves/testing";
+import { overrideWith, testContainer, type TestHarness } from "@/testing";
 
 import { DecorationsStore } from "./decorations-store";
-import { cellKey, DecorationEngine } from "./engine";
+import { cellKey } from "./engine";
+import { decorationsModule } from "./module";
 import { resolveCell } from "./resolve-cell";
-import { decorationsSlice } from "./settings/slice";
+import { decorationsSettingsCoreModule } from "./settings/module";
 import { buildCalendarDecoration, buildCondition, buildDecoration, buildStyle } from "./testing";
 import { CellDecorationMapKey, CellPaddingKey, type CellStyleRef } from "./ui/cell-decoration-map-key";
 import { useCellDecorations } from "./use-cell-decorations";
@@ -35,62 +28,36 @@ function key(period: Period): string {
   return cellKey(period.kind, period.anchor.toAnchor());
 }
 
-interface Harness {
-  c: Container;
-  notesEmitter: Emitter<NotesEvents>;
-  fakeMetadata: FakeNoteMetadataService;
+interface DecorationsHarness {
+  harness: TestHarness;
   size: FakeNoteSizeService;
   store: DecorationsStore;
 }
 
-function date(s: string): CalendarDate {
-  const r = CalendarDate.parse(s);
-  if (r.kind === "err") throw new Error(`bad date: ${s}`);
-  return r.value;
-}
-
-// Shared setup for the pieces every harness variant needs beyond the journal repository:
+// Shared setup for the pieces every harness variant needs beyond the journal configs:
 // the settings slice backing the vault-wide list, and a "work" shelf to save shelf-owned
-// decorations onto.
-function buildHarnessFrom(journals: JournalsRepository, notesEmitter: Emitter<NotesEvents>): Harness {
-  const { container: c, service } = createSettingsService({ slices: [decorationsSlice] });
-  // createSettingsService does not call initialize(), so the slice's default state is never
-  // hydrated into #root — set it explicitly or a first read is undefined.
-  service.getSlice(decorationsSlice).state = { decorations: [] };
-  c.register(JournalsRepository).useValue(journals);
-  c.register(JournalsIndex).useClass(JournalsIndex);
-  c.register(CycleService).useClass(CycleService);
-  c.register(TimelineService).useClass(TimelineService);
-  const fakeMetadata = new FakeNoteMetadataService();
-  c.register(NoteMetadataService).useValue(fakeMetadata as unknown as NoteMetadataService);
+// decorations onto — DecorationsStore.save({ kind: "shelf" }) writes through
+// ShelvesRepository.update, which is a no-op for a shelf that does not exist, so a
+// shelf-scoped test would otherwise assert an empty cell for the wrong reason.
+async function buildHarnessFrom(journals: Record<string, JournalConfig>): Promise<DecorationsHarness> {
   const size = new FakeNoteSizeService();
-  c.register(NoteSizeService).useValue(size as unknown as NoteSizeService);
-  c.register(NotesService).useValue({ events: notesEmitter } as unknown as NotesService);
-  c.register(DecorationEngine).useClass(DecorationEngine);
-  const shelfStorage = reactive<Record<string, ShelfConfig>>({
-    work: { name: "work", journals: [], decorations: [] },
+  const harness = await testContainer({
+    modules: [journalsCoreModule, shelvesCoreModule, decorationsModule, decorationsSettingsCoreModule],
+    data: { journals, shelves: { work: buildShelf("work") }, decorations: { decorations: [] } },
+    overrides: [overrideWith(NoteSizeService, size as unknown as NoteSizeService)],
   });
-  c.register(ShelvesRepository).useValue(ShelvesRepository.fromParts(shelfStorage, createNanoEvents<ShelvesEvents>()));
-  c.register(DecorationsStore).useClass(DecorationsStore);
-  const store = c.resolve(DecorationsStore);
-  return { c, notesEmitter, fakeMetadata, size, store };
+  return { harness, size, store: harness.resolve(DecorationsStore) };
 }
 
-function buildHarness(decorations: JournalConfig["decorations"] = []): Harness {
-  const notesEmitter: Emitter<NotesEvents> = createNanoEvents<NotesEvents>();
-  const journals = fakeRepo({
-    daily: fixedJournal("daily", { type: "day" }, { decorations }),
-  });
-  return buildHarnessFrom(journals, notesEmitter);
+function buildHarness(decorations: JournalConfig["decorations"] = []): Promise<DecorationsHarness> {
+  return buildHarnessFrom({ daily: fixedJournal("daily", { type: "day" }, { decorations }) });
 }
 
-function buildWeeklyHarness(weeklyDecorations: JournalConfig["decorations"]): Harness {
-  const notesEmitter: Emitter<NotesEvents> = createNanoEvents<NotesEvents>();
-  const journals = fakeRepo({
+function buildWeeklyHarness(weeklyDecorations: JournalConfig["decorations"]): Promise<DecorationsHarness> {
+  return buildHarnessFrom({
     daily: fixedJournal("daily", { type: "day" }),
     weekly: fixedJournal("weekly", { type: "week" }, { decorations: weeklyDecorations }),
   });
-  return buildHarnessFrom(journals, notesEmitter);
 }
 
 function makeChild(captured: { value: ReadonlyMap<string, CellStyleRef> | null }) {
@@ -113,7 +80,7 @@ function makeHost(Child: ReturnType<typeof makeChild>, setup: () => unknown) {
 }
 
 function mount(
-  container: Container,
+  harness: TestHarness,
   setup: () => ReadonlyMap<string, CellStyleRef>,
 ): {
   captured: { value: ReadonlyMap<string, CellStyleRef> | null };
@@ -122,27 +89,17 @@ function mount(
   const captured = { value: null as ReadonlyMap<string, CellStyleRef> | null };
   const Child = makeChild(captured);
   const Host = makeHost(Child, setup);
-  const utilities = render(Host, {
-    global: {
-      plugins: [
-        {
-          install(app) {
-            provideInjectorOnApp(app, container);
-          },
-        },
-      ],
-    },
-  });
+  const utilities = harness.render(Host);
   return { captured, unmount: () => utilities.unmount() };
 }
 
 function mountCells(
-  container: Container,
+  harness: TestHarness,
   periods: readonly Period[],
   journalNames: readonly string[],
   calendarDecorations?: { shelf: string | null },
 ): ReadonlyMap<string, CellStyleRef> {
-  const { captured } = mount(container, () =>
+  const { captured } = mount(harness, () =>
     useCellDecorations({
       periods: () => periods,
       journalNames: () => journalNames,
@@ -154,7 +111,7 @@ function mountCells(
   return cells;
 }
 
-function mountPadding(container: Container, periods: readonly Period[], journalNames: readonly string[]): Ref<string> {
+function mountPadding(harness: TestHarness, periods: readonly Period[], journalNames: readonly string[]): Ref<string> {
   const captured = { value: null as Ref<string> | null };
   const Child = defineComponent({
     template: "<div />",
@@ -169,44 +126,26 @@ function mountPadding(container: Container, periods: readonly Period[], journalN
       return renderChild;
     },
   });
-  render(Host, {
-    global: {
-      plugins: [
-        {
-          install(app) {
-            provideInjectorOnApp(app, container);
-          },
-        },
-      ],
-    },
-  });
+  harness.render(Host);
   const padding = captured.value;
   if (!padding) throw new Error("padding was not provided");
   return padding;
 }
 
-function withHasNote(): { h: Harness; period: DayPeriod; path: VaultPath } {
+async function withHasNote(): Promise<{ harness: TestHarness; period: DayPeriod; path: VaultPath }> {
   const decoration = buildDecoration({
     mode: "or",
     conditions: [buildCondition("has-note")],
     styles: [buildStyle("background")],
   });
-  const h = buildHarness([decoration]);
+  const { harness } = await buildHarness([decoration]);
   const period = DayPeriod.containing(date("2026-05-25"));
   const path = "Daily/2026-05-25.md" as VaultPath;
-  h.c.resolve(JournalsIndex).register({ journalName: "daily", anchor: period.anchor.toAnchor(), path });
-  h.fakeMetadata.setMetadata(path, { title: "2026-05-25", tags: [], properties: {}, tasks: [] });
-  return { h, period, path };
+  harness.resolve(JournalsIndex).register({ journalName: "daily", anchor: period.anchor.toAnchor(), path });
+  // has-note reads NoteMetadataService.get, which needs the file present in the vault.
+  harness.host.putFile(path);
+  return { harness, period, path };
 }
-
-let teardown: () => void;
-beforeEach(() => {
-  ({ teardown } = installTestCalendar());
-});
-afterEach(() => {
-  teardown();
-  cleanup();
-});
 
 describe("useCellDecorations", () => {
   describe("seeding", () => {
@@ -216,10 +155,10 @@ describe("useCellDecorations", () => {
         conditions: [buildCondition("weekday", { weekdays: [1] })], // Mon
         styles: [buildStyle("background")],
       });
-      const { c } = buildHarness([decoration]);
+      const { harness } = await buildHarness([decoration]);
       const period = DayPeriod.containing(date("2026-05-25"));
 
-      const { captured } = mount(c, () =>
+      const { captured } = mount(harness, () =>
         useCellDecorations({
           periods: () => [period],
           journalNames: () => ["daily"],
@@ -243,14 +182,16 @@ describe("useCellDecorations", () => {
         conditions: [buildCondition("weekday", { weekdays: [1] })],
         styles: [buildStyle("corner")],
       });
-      const { c } = buildHarness([kept, dropped]);
+      const { harness } = await buildHarness([kept, dropped]);
       const period = DayPeriod.containing(date("2026-05-25"));
 
-      const { captured } = mount(c, () =>
+      const { captured } = mount(harness, () =>
         useCellDecorations({
           periods: () => [period],
           journalNames: () => ["daily"],
-          filter: (binding) => binding.decoration === kept,
+          // A seeded journal's decorations reach the binding as re-parsed copies, so the filter
+          // names `kept` by its position in the journal's list rather than by identity.
+          filter: (binding) => binding.index === 0,
         }),
       );
       await nextTick();
@@ -265,12 +206,14 @@ describe("useCellDecorations", () => {
         conditions: [buildCondition("weekday", { weekdays: [1] })],
         styles: [buildStyle("background")],
       });
-      const { c } = buildHarness([decoration]);
+      const { harness } = await buildHarness([decoration]);
       const p1 = DayPeriod.containing(date("2026-05-25"));
       const p2 = DayPeriod.containing(date("2026-05-26"));
       const periodsRef: Ref<DayPeriod[]> = ref([p1]);
 
-      const { captured } = mount(c, () => useCellDecorations({ periods: periodsRef, journalNames: () => ["daily"] }));
+      const { captured } = mount(harness, () =>
+        useCellDecorations({ periods: periodsRef, journalNames: () => ["daily"] }),
+      );
       await nextTick();
       expect(captured.value!.has(key(p1))).toBe(true);
       expect(captured.value!.has(key(p2))).toBe(false);
@@ -284,8 +227,8 @@ describe("useCellDecorations", () => {
 
   describe("event handling", () => {
     it("updates the affected anchor when metadata-changed fires for an in-scope path", async () => {
-      const { h, period, path } = withHasNote();
-      const { captured } = mount(h.c, () =>
+      const { harness, period, path } = await withHasNote();
+      const { captured } = mount(harness, () =>
         useCellDecorations({
           periods: () => [period],
           journalNames: () => ["daily"],
@@ -295,14 +238,14 @@ describe("useCellDecorations", () => {
 
       const slot = captured.value!.get(key(period))!;
       const initial = slot.value;
-      h.notesEmitter.emit("metadata-changed", path);
+      harness.host.emitMetadata(path);
       await nextTick();
       expect(slot.value).not.toBe(initial);
     });
 
     it("does not touch the slot when metadata-changed fires for an out-of-scope path", async () => {
-      const { h, period } = withHasNote();
-      const { captured } = mount(h.c, () =>
+      const { harness, period } = await withHasNote();
+      const { captured } = mount(harness, () =>
         useCellDecorations({
           periods: () => [period],
           journalNames: () => ["daily"],
@@ -312,7 +255,11 @@ describe("useCellDecorations", () => {
 
       const slot = captured.value!.get(key(period))!;
       const initial = slot.value;
-      h.notesEmitter.emit("metadata-changed", "Other/random.md" as VaultPath);
+      // The file has to exist: metadataCache "changed" carries the TFile, and NotesService drops
+      // the event when there is none — without it the composable's handler never runs at all.
+      const outOfScope = "Other/random.md" as VaultPath;
+      harness.host.putFile(outOfScope);
+      harness.host.emitMetadata(outOfScope);
       await nextTick();
       expect(slot.value).toBe(initial);
     });
@@ -323,10 +270,10 @@ describe("useCellDecorations", () => {
         conditions: [buildCondition("has-note")],
         styles: [buildStyle("background")],
       });
-      const h = buildHarness([decoration]);
+      const { harness } = await buildHarness([decoration]);
       const period = DayPeriod.containing(date("2026-05-25"));
 
-      const { captured } = mount(h.c, () =>
+      const { captured } = mount(harness, () =>
         useCellDecorations({
           periods: () => [period],
           journalNames: () => ["daily"],
@@ -337,8 +284,8 @@ describe("useCellDecorations", () => {
       const initial = slot.value;
 
       const path = "Daily/2026-05-25.md" as VaultPath;
-      h.fakeMetadata.setMetadata(path, { title: "2026-05-25", tags: [], properties: {}, tasks: [] });
-      h.c.resolve(JournalsIndex).register({ journalName: "daily", anchor: period.anchor.toAnchor(), path });
+      harness.host.putFile(path);
+      harness.resolve(JournalsIndex).register({ journalName: "daily", anchor: period.anchor.toAnchor(), path });
       await nextTick();
 
       expect(slot.value).not.toBe(initial);
@@ -350,14 +297,14 @@ describe("useCellDecorations", () => {
         conditions: [buildCondition("has-note")],
         styles: [buildStyle("background")],
       });
-      const h = buildWeeklyHarness([decoration]);
+      const { harness } = await buildWeeklyHarness([decoration]);
       const weekPeriod = WeekPeriod.containing(date("2026-06-10"));
       const weekAnchor = weekPeriod.anchor.toAnchor();
       const dayPeriods = [...weekPeriod.days()].map((d) => DayPeriod.containing(d));
       const collidingDay = dayPeriods.find((d) => d.anchor.toAnchor() === weekAnchor);
       expect(collidingDay).toBeDefined();
 
-      const { captured } = mount(h.c, () =>
+      const { captured } = mount(harness, () =>
         useCellDecorations({
           periods: () => [weekPeriod, ...dayPeriods],
           journalNames: () => ["daily", "weekly"],
@@ -370,8 +317,8 @@ describe("useCellDecorations", () => {
       expect(daySlot.value).toHaveLength(0);
 
       const path = "Weekly/2026-W24.md" as VaultPath;
-      h.fakeMetadata.setMetadata(path, { title: "2026-W24", tags: [], properties: {}, tasks: [] });
-      h.c.resolve(JournalsIndex).register({ journalName: "weekly", anchor: weekAnchor, path });
+      harness.host.putFile(path);
+      harness.resolve(JournalsIndex).register({ journalName: "weekly", anchor: weekAnchor, path });
       await nextTick();
 
       expect(weekSlot.value).toHaveLength(1);
@@ -385,16 +332,25 @@ describe("useCellDecorations", () => {
         conditions: [buildCondition("title", { condition: "ends-with", value: "-match" })],
         styles: [buildStyle("background")],
       });
-      const h = buildHarness([decoration]);
+      const { harness } = await buildHarness([decoration]);
       const period = DayPeriod.containing(date("2026-05-25"));
       const anchor = period.anchor.toAnchor();
-      const index = h.c.resolve(JournalsIndex);
+      const index = harness.resolve(JournalsIndex);
 
       const oldPath = "Daily/plain.md" as VaultPath;
       index.register({ journalName: "daily", anchor, path: oldPath });
-      h.fakeMetadata.setMetadata(oldPath, { title: "plain", tags: [], properties: {}, tasks: [] });
+      // The title a condition reads is the file's basename, so the path carries it.
+      harness.host.putFile(oldPath);
 
-      const { captured } = mount(h.c, () =>
+      // createFakeHost has no metadataCache "resolved" emitter, so the composable's own
+      // subscription is captured here and driven by hand once the cache has caught up.
+      const resolvedBatches: (() => void)[] = [];
+      vi.spyOn(harness.resolve(NoteMetadataService), "onResolved").mockImplementation((callback) => {
+        resolvedBatches.push(callback);
+        return () => void resolvedBatches.splice(resolvedBatches.indexOf(callback), 1);
+      });
+
+      const { captured } = mount(harness, () =>
         useCellDecorations({
           periods: () => [period],
           journalNames: () => ["daily"],
@@ -412,9 +368,9 @@ describe("useCellDecorations", () => {
       expect(slot.value).toHaveLength(0);
 
       // Cache catches up, then metadataCache "resolved" lands after the rename event.
-      h.fakeMetadata.setMetadata(newPath, { title: "renamed-match", tags: [], properties: {}, tasks: [] });
-      h.notesEmitter.emit("renamed", { from: oldPath, to: newPath });
-      h.fakeMetadata.emitResolved();
+      const renamed = harness.host.putFile(newPath);
+      harness.host.emitVault("rename", renamed, oldPath);
+      for (const batch of resolvedBatches.splice(0)) batch();
       await nextTick();
 
       expect(slot.value).toHaveLength(1);
@@ -426,12 +382,12 @@ describe("useCellDecorations", () => {
         conditions: [buildCondition("note-size", { condition: "gt", value: 100 })],
         styles: [buildStyle("background")],
       });
-      const h = buildHarness([decoration]);
+      const { harness, size } = await buildHarness([decoration]);
       const period = DayPeriod.containing(date("2026-05-25"));
       const path = "Daily/2026-05-25.md" as VaultPath;
-      h.c.resolve(JournalsIndex).register({ journalName: "daily", anchor: period.anchor.toAnchor(), path });
+      harness.resolve(JournalsIndex).register({ journalName: "daily", anchor: period.anchor.toAnchor(), path });
 
-      const { captured } = mount(h.c, () =>
+      const { captured } = mount(harness, () =>
         useCellDecorations({ periods: () => [period], journalNames: () => ["daily"] }),
       );
       await nextTick();
@@ -440,7 +396,7 @@ describe("useCellDecorations", () => {
       // Absent on first paint by design: the size has not been read yet.
       expect(slot.value).toHaveLength(0);
 
-      h.size.setSize(path, { words: 400, characters: 2200 });
+      size.setSize(path, { words: 400, characters: 2200 });
       await nextTick();
 
       expect(slot.value).toHaveLength(1);
@@ -452,30 +408,30 @@ describe("useCellDecorations", () => {
         conditions: [buildCondition("note-size", { condition: "gt", value: 100 })],
         styles: [buildStyle("background")],
       });
-      const h = buildHarness([decoration]);
+      const { harness, size } = await buildHarness([decoration]);
       const period = DayPeriod.containing(date("2026-05-25"));
-      h.c.resolve(JournalsIndex).register({
+      harness.resolve(JournalsIndex).register({
         journalName: "daily",
         anchor: period.anchor.toAnchor(),
         path: "Daily/2026-05-25.md" as VaultPath,
       });
 
-      const { captured } = mount(h.c, () =>
+      const { captured } = mount(harness, () =>
         useCellDecorations({ periods: () => [period], journalNames: () => ["daily"] }),
       );
       await nextTick();
 
       const slot = captured.value!.get(key(period))!;
       const initial = slot.value;
-      h.size.setSize("Other/random.md" as VaultPath, { words: 400, characters: 2200 });
+      size.setSize("Other/random.md" as VaultPath, { words: 400, characters: 2200 });
       await nextTick();
 
       expect(slot.value).toBe(initial);
     });
 
     it("detaches subscriptions on unmount", async () => {
-      const { h, period, path } = withHasNote();
-      const { captured, unmount } = mount(h.c, () =>
+      const { harness, period, path } = await withHasNote();
+      const { captured, unmount } = mount(harness, () =>
         useCellDecorations({
           periods: () => [period],
           journalNames: () => ["daily"],
@@ -486,7 +442,7 @@ describe("useCellDecorations", () => {
       const initial = slot.value;
 
       unmount();
-      expect(() => h.notesEmitter.emit("metadata-changed", path)).not.toThrow();
+      expect(() => harness.host.emitMetadata(path)).not.toThrow();
       expect(slot.value).toBe(initial);
     });
   });
@@ -498,11 +454,11 @@ describe("useCellDecorations", () => {
         conditions: [buildCondition("weekday", { weekdays: [1] })],
         styles: [buildStyle("background")],
       });
-      const { c, store } = buildHarness();
+      const { harness, store } = await buildHarness();
       store.save({ kind: "global" }, [decoration]);
       const period = DayPeriod.containing(date("2026-05-25"));
 
-      const cells = mountCells(c, [period], [], { shelf: null });
+      const cells = mountCells(harness, [period], [], { shelf: null });
       await nextTick();
 
       expect(cells.get(key(period))?.value).toEqual(decoration.styles);
@@ -514,11 +470,11 @@ describe("useCellDecorations", () => {
         conditions: [buildCondition("weekday", { weekdays: [1] })],
         styles: [buildStyle("background")],
       });
-      const { c, store } = buildHarness();
+      const { harness, store } = await buildHarness();
       store.save({ kind: "shelf", shelfName: "work" }, [decoration]);
       const period = DayPeriod.containing(date("2026-05-25"));
 
-      const cells = mountCells(c, [period], [], { shelf: "personal" });
+      const cells = mountCells(harness, [period], [], { shelf: "personal" });
       await nextTick();
 
       expect(cells.get(key(period))?.value).toEqual([]);
@@ -532,7 +488,7 @@ describe("useCellDecorations", () => {
         conditions: [buildCondition("weekday", { weekdays: [1] })],
         styles: [journalStyle],
       });
-      const { c, store } = buildHarness([journalDecoration]);
+      const { harness, store } = await buildHarness([journalDecoration]);
       store.save({ kind: "global" }, [
         buildCalendarDecoration({
           mode: "or",
@@ -542,7 +498,7 @@ describe("useCellDecorations", () => {
       ]);
       const period = DayPeriod.containing(date("2026-05-25"));
 
-      const cells = mountCells(c, [period], ["daily"], { shelf: null });
+      const cells = mountCells(harness, [period], ["daily"], { shelf: null });
       await nextTick();
 
       const styles = cells.get(key(period))?.value ?? [];
@@ -564,7 +520,7 @@ describe("useCellDecorations", () => {
         conditions: [buildCondition("weekday", { weekdays: [1] })],
         styles: [journalBorder],
       });
-      const { c, store } = buildHarness([journalDecoration]);
+      const { harness, store } = await buildHarness([journalDecoration]);
       store.save({ kind: "global" }, [
         buildCalendarDecoration({
           mode: "or",
@@ -574,7 +530,7 @@ describe("useCellDecorations", () => {
       ]);
       const period = DayPeriod.containing(date("2026-05-25"));
 
-      const cells = mountCells(c, [period], ["daily"], { shelf: null });
+      const cells = mountCells(harness, [period], ["daily"], { shelf: null });
       await nextTick();
 
       const styles = cells.get(key(period))?.value ?? [];
@@ -590,7 +546,7 @@ describe("useCellDecorations", () => {
         conditions: [buildCondition("weekday", { weekdays: [1] })],
         styles: [journalStyle],
       });
-      const { c, store } = buildHarness([journalDecoration]);
+      const { harness, store } = await buildHarness([journalDecoration]);
       store.save({ kind: "shelf", shelfName: "work" }, [
         buildCalendarDecoration({
           mode: "or",
@@ -600,7 +556,7 @@ describe("useCellDecorations", () => {
       ]);
       const period = DayPeriod.containing(date("2026-05-25"));
 
-      const cells = mountCells(c, [period], ["daily"], { shelf: "work" });
+      const cells = mountCells(harness, [period], ["daily"], { shelf: "work" });
       await nextTick();
 
       const styles = cells.get(key(period))?.value ?? [];
@@ -614,11 +570,11 @@ describe("useCellDecorations", () => {
         conditions: [buildCondition("weekday", { weekdays: [1] })],
         styles: [buildStyle("background")],
       });
-      const { c, store } = buildHarness();
+      const { harness, store } = await buildHarness();
       store.save({ kind: "global" }, [decoration]);
       const period = DayPeriod.containing(date("2026-05-25"));
 
-      const cells = mountCells(c, [period], []); // no calendarDecorations option
+      const cells = mountCells(harness, [period], []); // no calendarDecorations option
       await nextTick();
 
       expect(cells.get(key(period))?.value).toEqual([]);
@@ -630,10 +586,10 @@ describe("useCellDecorations", () => {
         conditions: [buildCondition("weekday", { weekdays: [1] })],
         styles: [buildStyle("background")],
       });
-      const { c, store } = buildHarness();
+      const { harness, store } = await buildHarness();
       const period = DayPeriod.containing(date("2026-05-25"));
 
-      const cells = mountCells(c, [period], [], { shelf: null });
+      const cells = mountCells(harness, [period], [], { shelf: null });
       await nextTick();
       expect(cells.get(key(period))?.value).toEqual([]);
 
@@ -647,7 +603,7 @@ describe("useCellDecorations", () => {
       const shelfStyle = buildStyle("background", { color: { type: "custom", color: "#333333" } });
       const globalStyle = buildStyle("background", { color: { type: "custom", color: "#444444" } });
       const weekdayCondition = buildCondition("weekday", { weekdays: [1] });
-      const { c, store } = buildHarness();
+      const { harness, store } = await buildHarness();
       store.save({ kind: "shelf", shelfName: "work" }, [
         buildCalendarDecoration({ mode: "or", conditions: [weekdayCondition], styles: [shelfStyle] }),
       ]);
@@ -656,7 +612,7 @@ describe("useCellDecorations", () => {
       ]);
       const period = DayPeriod.containing(date("2026-05-25"));
 
-      const cells = mountCells(c, [period], [], { shelf: "work" });
+      const cells = mountCells(harness, [period], [], { shelf: "work" });
       await nextTick();
 
       expect(resolveCell(cells.get(key(period))?.value ?? []).background).toBe("#333333");
@@ -669,10 +625,10 @@ describe("useCellDecorations", () => {
         conditions: [buildCondition("weekday", { weekdays: [1] })], // Mon
         styles: [buildStyle("shape", { placement_x: "right", placement_y: "middle", size: 0.5 })],
       });
-      const { c } = buildHarness([decoration]);
+      const { harness } = await buildHarness([decoration]);
 
-      const matching = mountPadding(c, [DayPeriod.containing(date("2026-05-25"))], ["daily"]); // Mon
-      const nonMatching = mountPadding(c, [DayPeriod.containing(date("2026-05-26"))], ["daily"]); // Tue
+      const matching = mountPadding(harness, [DayPeriod.containing(date("2026-05-25"))], ["daily"]); // Mon
+      const nonMatching = mountPadding(harness, [DayPeriod.containing(date("2026-05-26"))], ["daily"]); // Tue
       await nextTick();
 
       expect(matching.value).toBe("max(0.1em, 2px) max(0.6em, 2px)");

--- a/src/notes-calendar/ui/NotesMonthView.test.ts
+++ b/src/notes-calendar/ui/NotesMonthView.test.ts
@@ -6,7 +6,7 @@ import { nextTick } from "vue";
 import { CalendarDate, MonthPeriod } from "@/calendar";
 import { anchor } from "@/calendar/testing";
 import { decorationsModule } from "@/decorations/module";
-import { decorationsSettingsModule } from "@/decorations/settings/module";
+import { decorationsSettingsCoreModule } from "@/decorations/settings/module";
 import { buildCondition, buildDecoration, buildStyle } from "@/decorations/testing";
 import { initLocale } from "@/i18n";
 import type { VaultPath } from "@/infrastructure/host";
@@ -24,7 +24,7 @@ const MODULES = [
   journalsCoreModule,
   shelvesCoreModule,
   decorationsModule,
-  decorationsSettingsModule,
+  decorationsSettingsCoreModule,
   notesCalendarModule,
 ];
 

--- a/src/notes-calendar/ui/NotesWeekView.test.ts
+++ b/src/notes-calendar/ui/NotesWeekView.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import { CalendarDate, WeekPeriod } from "@/calendar";
 import { anchor } from "@/calendar/testing";
 import { decorationsModule } from "@/decorations/module";
-import { decorationsSettingsModule } from "@/decorations/settings/module";
+import { decorationsSettingsCoreModule } from "@/decorations/settings/module";
 import { buildCondition, buildDecoration, buildStyle } from "@/decorations/testing";
 import { initLocale } from "@/i18n";
 import type { JournalConfig } from "@/journals";
@@ -22,7 +22,7 @@ const MODULES = [
   journalsCoreModule,
   shelvesCoreModule,
   decorationsModule,
-  decorationsSettingsModule,
+  decorationsSettingsCoreModule,
   notesCalendarModule,
 ];
 

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -139,6 +139,42 @@ export default defineConfig({
         // `useResolvedWeekPlacement` (calendar/week-placement.ts) run for the first time in place of
         // the mocked stand-ins: +6 statements, +2 branches, +4 functions, +4 lines — the one branch
         // rise this sweep produced, not a drop.
+        //
+        // Sweep 4 (decorations) measured its thirteen commits, plus the merge base (e6b38e6f), in a
+        // scratch worktree — base: 92.3 / 87.9 / 89.28 / 94.41 (11076/11999 statements, 4775/5432
+        // branches, 3934/4406 functions, 9684/10257 lines). e6b38e6f is the merge commit that
+        // landed sweep 3, so this is sweep 3's own end state, not an independently-measured match.
+        // Every one of the thirteen commits (417b3b82, 1a3acf43, a5dd2eb3, 8e43c34c, 9a4efd30,
+        // f03bd784, 0085d899, a0e7d475, dfb31bd4, bc76c89a, 1c927395, ff1b68ac, 9a97fb28) measured
+        // the identical numerator and denominator on all four metrics, not merely the same rounded
+        // percentage; f03bd784 and 9a97fb28 were re-measured with the vite transform cache cleared
+        // to rule out a stale-transform artifact, and the numbers held.
+        //
+        // The two moves this sweep's own plan predicted were checked, not assumed, and neither
+        // happened, for reasons found rather than guessed. `f03bd784` ("move core service tests onto
+        // testContainer") was expected to move `NoteMetadataService.get`
+        // (infrastructure/host/internal/note-metadata-service.ts) and `NoteSizeService.#fill`
+        // (infrastructure/host/internal/note-size-service.ts) from cold to warm the way sweep 2's
+        // NavigationCodeBlock step moved `NoteMetadataService.onResolved` — but per-file
+        // coverage-summary.json shows both already at 100%/97.82% lines at the merge base, before
+        // decorations' own conversion touched them: every sweep before this one (journals, calendar,
+        // shelves, commands, code-blocks, notes-calendar) had already driven testContainer through
+        // this shared infrastructure, and decorations, swept last, had nothing left to warm. The
+        // predicted fall from `JournalsRepository.fromParts` / `ShelvesRepository.fromParts` losing
+        // their last decorations callers didn't happen because they never lost their last callers,
+        // full stop: decorations' own call sites (decorations-store.test.ts,
+        // gather-bindings.test.ts, match-service.test.ts, the delete/edit-decoration flow tests,
+        // DecorationsSection.test.ts, and the three modal tests) are gone by 9a97fb28 — `git grep
+        // fromParts -- src/decorations` at the tip returns nothing — but `src/journals/testing.ts`'s
+        // `fakeRepo` and `src/shelves/testing.ts`'s `fakeShelvesRepo` both still call `fromParts`
+        // directly, and both wrappers are themselves still called from outside decorations —
+        // `fakeRepo` from `src/notes-calendar/testing.ts`,
+        // `src/views/blocks/custom-intervals/CustomIntervalsBlock.isolated.test.ts`,
+        // `CustomIntervalsBlock.fixed-scope.isolated.test.ts`, and `src/views/view-leaf.test.ts`.
+        // `JournalsRepository.fromParts`/`ShelvesRepository.fromParts` also have direct callers of
+        // their own under `src/views` — `IntervalBlockSection.test.ts`, `ButtonItemConfig.test.ts`,
+        // `ShelfSelectorItem.test.ts` — so both methods stayed warm regardless of what decorations
+        // itself still calls.
         statements: 92.3,
         branches: 87.9,
         functions: 89.28,


### PR DESCRIPTION
Phase 3 sweep 4 of the test-conversion campaign: all 48 test files in `src/decorations` move onto the
`testContainer()` harness, one module splits, and the campaign's lint selectors arm over the feature.

Follows [#293](https://github.com/srg-kostyrko/obsidian-journal/pull/293) (shelves/commands/maintenance/api),
[#294](https://github.com/srg-kostyrko/obsidian-journal/pull/294) (calendar),
[#295](https://github.com/srg-kostyrko/obsidian-journal/pull/295) (harness) and
[#296](https://github.com/srg-kostyrko/obsidian-journal/pull/296) (code-blocks/notes-calendar).

## Gates

| Gate | Result |
| --- | --- |
| 1 — test count exact | **395 files / 4200 tests** at every one of the 14 commits; `src/decorations` 48 / 456. The full `file > describe > test` string set is identical between base and tip — zero renames — and the `expect(` count is unchanged in all 48 files |
| 2 — coverage floor | **92.3 / 87.9 / 89.28 / 94.41** — exactly flat, same numerator *and* denominator on all four metrics at all 13 conversion commits. Branch coverage neither rose nor fell |
| 3 — e2e | this PR's CI (the only check on the module split) |
| 4 — regression guards | probed red-and-restored; **two of the plan's own attributions turned out to be wrong** — see below |

## Production changes

Only four non-test files:

- `src/decorations/settings/module.ts` + new `ui-module.ts` — `decorationsSettingsModule` splits into a
  core half (the two flows and the `decorationsSlice` registration) and a UI half (the journal-edit
  section, shelf-edit section and dashboard block). `decorationsSettingsModule` still composes both, so
  `main.ts` is unchanged. No eager service moves. `decorationsModule` itself is **not** split — three
  non-eager services, no UI token.
- `eslint.config.mjs` — one glob appended to `convertedTestGlobs`.
- `vitest.config.mts` — a comment block recording what the sweep measured. The thresholds are unchanged.

`src/main.ts` and `src/decorations/index.ts` are byte-identical to base.

## What this sweep found

The conversion was uneventful. The findings were not.

**Two gate-4 attributions in the plan were wrong**, and only probing found it:

- `engine.ts:239`'s `periodMatchesWrite` — the test I expected to guard it (*"keeps day and week
  decorations in separate cells when their anchors coincide"*) stays **green** when the line is deleted.
  It asserts on `result.size`, which stays 2 while both cells get contaminated with both journals'
  styles. The real falsifier is *"returns no entries when period kind mismatches journal write-type"*.
- `use-cell-decorations.ts:76`'s `periodMatchesWrite` — has **no falsifying test anywhere in the repo, at
  any commit**. Deleting it leaves all 4200 tests green at this branch's tip *and* at the merge base.

The documented custom-interval/day-cell collision trap **is** guarded — through `cellKey`, not through
either line. Both gaps are **pre-existing**, each proved so by measuring the base commit, and neither is
filled here: gate 1 forbids adding a test inside a sweep, so they are recorded for Phase 4.5.

**A controller ruling was overturned by measurement.** The plan ruled that `FakeNoteSizeService` had to be
kept because the real `NoteSizeService` could not be driven deterministically. It can:
`DecorationEngine.explainRange` reads a size on first render, which puts the path into `#pending`, so the
early return in `#refresh` never applies. The fake is gone from both modal tests. The first replacement
used a fixed count of `await Promise.resolve()` hops and measured **one hop from failing**, so it is now
`vi.waitFor`.

Other gaps recorded for Phase 4.5, all pre-existing: `engine-checks.test.ts`'s 51 tests are entirely
grid-insensitive; `ConditionItem.test.ts` asserts nothing depending on `MetadataTypeService`;
`EditDecorationModal.vue:34`'s deep strip has no falsifier; two of six custom-interval cluster tests do
not discriminate; `DecorationsSection.test.ts`'s owner-scoped seeding catches substitution but not
additive leak.

## Review

Every task had an independent reviewer with a falsification brief, plus a whole-branch review. Guards
were verified by breaking production and confirming red — including the collision guard, both flow
modal seams, all three badge-state tests, Guard 3's rename ordering in both directions, and the five
lint selectors against their legitimate near-misses.
