### PR TITLE
fix(journals): keep auto-create alive when a template blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Journals created in the same session no longer share one navigation block, interval block, and set of decorations. Editing the navigation block of one daily journal used to change every daily journal created alongside it in that session, and a journal created after such an edit was born carrying it; restarting Obsidian separated them again, so journals created in different sessions were never affected. A journal already changed this way keeps the settings it ended up with — check the navigation blocks and decorations of journals you created together, and set them back by hand where they are wrong.
 - A fresh install no longer logs a repair warning at startup for settings it has never saved. Having no stored value yet was being treated the same as a corrupted one, so a brand-new install's log read as if its settings were already damaged.
+- Auto-create no longer stops for the rest of the session when a journal template waits for input. A template that opens a prompt — Templater's `tp.system.prompt` or `tp.system.suggester`, for instance — never finishes on its own at midnight, when nobody is there to answer it, and that silently took auto-create down until Obsidian was restarted; journals listed after the waiting one never got their notes at all. The midnight check is now scheduled before the notes are written rather than after, and each journal gets a bounded wait before the rest are attended to. A prompt you answer later still writes its note.
 
 ## [3.2.0] - 2026-08-23
 

--- a/src/journals/notes/auto-create.test.ts
+++ b/src/journals/notes/auto-create.test.ts
@@ -13,6 +13,11 @@ import { fixedJournal } from "../testing";
 import { AutoCreateService } from "./auto-create";
 import { NoteCreationService } from "./note-creation";
 
+// A template that blocks on user input — a Templater `<% tp.system.prompt %>` — leaves ensureNote
+// pending forever, and at local midnight there is nobody to answer it.
+const neverSettles = (): ReturnType<NoteCreationService["ensureNote"]> =>
+  AsyncResult.fromPromise(new Promise<never>(() => undefined), () => new JournalNotFoundError("unreachable"));
+
 describe("AutoCreateService", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -75,6 +80,19 @@ describe("AutoCreateService", () => {
       await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000);
 
       expect(harness.host.files.has("2026-05-19.md")).toBe(true);
+      expect(harness.host.files.has("2026-05-20.md")).toBe(false);
+    });
+
+    it("arms no midnight timer when disposed before the index is ready", async () => {
+      // The boot tick is chained off whenReady(), so it can land after dispose — and it now arms
+      // the timer up front, where nothing would ever clear it again.
+      const service = harness.resolve(AutoCreateService);
+      await service.initialize();
+      await service[Symbol.asyncDispose]();
+
+      harness.resolve(JournalsIndex).markReady();
+      await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000);
+
       expect(harness.host.files.has("2026-05-20.md")).toBe(false);
     });
   });
@@ -178,6 +196,63 @@ describe("AutoCreateService", () => {
     const bExists = harness.host.files.has("B/2026-05-19.md");
     expect(aExists || bExists).toBe(true);
     expect(aExists && bExists).toBe(false);
+  });
+
+  describe("a journal whose creation never settles", () => {
+    it("keeps the midnight timer running, so auto-create survives the session", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }, { autoCreate: true }) } },
+      });
+      vi.spyOn(harness.resolve(NoteCreationService), "ensureNote").mockImplementationOnce(neverSettles);
+      harness.resolve(JournalsIndex).markReady();
+
+      await harness.resolve(AutoCreateService).initialize();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(harness.host.files.has("2026-05-19.md")).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(15 * 60 * 60 * 1000);
+
+      expect(harness.host.files.has("2026-05-20.md")).toBe(true);
+    });
+
+    it("arms the midnight timer before waiting, so a prompt opened near midnight cannot skip a day", async () => {
+      // The budget alone would reschedule once it expires — but a block that starts less than a
+      // budget before midnight would then arm the timer past midnight and lose the day entirely.
+      vi.setSystemTime(new Date(2026, 4, 19, 23, 59, 50));
+      const harness = await testContainer({
+        modules: [journalsCoreModule],
+        data: { journals: { daily: fixedJournal("daily", { type: "day" }, { autoCreate: true }) } },
+      });
+      vi.spyOn(harness.resolve(NoteCreationService), "ensureNote").mockImplementationOnce(neverSettles);
+      harness.resolve(JournalsIndex).markReady();
+
+      await harness.resolve(AutoCreateService).initialize();
+      await vi.advanceTimersByTimeAsync(10 * 1000);
+
+      expect(harness.host.files.has("2026-05-20.md")).toBe(true);
+    });
+
+    it("does not starve the journals after it in the same tick", async () => {
+      const harness = await testContainer({
+        modules: [journalsCoreModule],
+        data: {
+          journals: {
+            a: fixedJournal("a", { type: "day" }, { autoCreate: true, folder: "A" }),
+            b: fixedJournal("b", { type: "day" }, { autoCreate: true, folder: "B" }),
+          },
+        },
+      });
+      vi.spyOn(harness.resolve(NoteCreationService), "ensureNote").mockImplementationOnce(neverSettles);
+      harness.resolve(JournalsIndex).markReady();
+
+      await harness.resolve(AutoCreateService).initialize();
+      // Past the per-journal budget, which is well under a minute.
+      await vi.advanceTimersByTimeAsync(60 * 1000);
+
+      expect(harness.host.files.has("B/2026-05-19.md")).toBe(true);
+      expect(harness.host.files.has("A/2026-05-19.md")).toBe(false);
+    });
   });
 
   it("creates the note without opening the confirm modal even when confirmCreation is true", async () => {

--- a/src/journals/notes/auto-create.ts
+++ b/src/journals/notes/auto-create.ts
@@ -11,6 +11,8 @@ import { TimelineService } from "../timeline";
 
 import { NoteCreationService } from "./note-creation";
 
+const CREATE_BUDGET_MS = 30_000;
+
 export class AutoCreateService {
   readonly #creation = inject(NoteCreationService);
   readonly #frontmatter = inject(FrontmatterService);
@@ -24,14 +26,35 @@ export class AutoCreateService {
   #disposed = false;
 
   async #tick(): Promise<void> {
+    // Armed before the loop, not after it: a createCurrent that never settles would otherwise
+    // leave the timer unset and auto-create dead for the rest of the session. A `finally` is no
+    // help — a never-settling await never reaches one.
+    this.#schedule();
     for (const [name, config] of this.#journals.find().entries()) {
       if (!config.autoCreate) continue;
-      await this.createCurrent(name);
+      await this.#createWithinBudget(name);
     }
+  }
+
+  #schedule(): void {
     if (this.#disposed) return;
     this.#timer = window.setTimeout(() => {
       void this.#tick();
     }, Clock.msUntilNextLocalMidnight());
+  }
+
+  // A journal template that blocks on user input (Templater's tp.system.prompt/suggester) leaves
+  // ensureNote pending until somebody answers, and at local midnight nobody does. The wait is
+  // bounded so the journals after it still get their notes; the call is abandoned, not cancelled,
+  // so a merely slow template still writes its note once it finishes.
+  async #createWithinBudget(name: string): Promise<void> {
+    const budget = Promise.withResolvers<"timed-out">();
+    const budgetTimer = window.setTimeout(() => budget.resolve("timed-out"), CREATE_BUDGET_MS);
+    const outcome = await Promise.race([this.createCurrent(name).then(() => "settled" as const), budget.promise]);
+    window.clearTimeout(budgetTimer);
+    if (outcome === "timed-out") {
+      this.#logger.warn("auto-create: gave up waiting for note creation", { name, budgetMs: CREATE_BUDGET_MS });
+    }
   }
 
   initialize(): AsyncResult<void, never> {


### PR DESCRIPTION
Fixes #283.

The trace in the issue is correct. Confirmed against source, reproduced at unit level.

## What was wrong

`AutoCreateService.#tick` rescheduled its midnight timer only **after** its loop over journals had finished. A `createCurrent` that never settles — a template opening a Templater `tp.system.prompt`/`suggester` at midnight, with nobody there to answer — left the timer unset and auto-create dead for the rest of the session, with nothing logged.

Worth stating because it was one of the directions floated in the issue: **scheduling in a `finally` does not fix this.** A never-settling `await` inside the `try` never reaches the `finally` either. The clock has to be armed before the loop.

## The fix

Two mechanisms, each with its own falsifying test:

1. **`#schedule()` runs at the top of `#tick`, not the bottom.** The clock no longer depends on the work.
2. **Each journal gets a bounded wait** (`CREATE_BUDGET_MS`, 30s) before the loop moves on, so the journals after a stuck one still get their notes — otherwise they would starve at *every* midnight, re-stalling at the same journal.

The blocked call is **abandoned, not cancelled**: a merely slow template still writes its note once it finishes, so the budget costs a log line rather than a note. `Promise.race` keeps a handler on the abandoned promise, so a late rejection cannot surface as unhandled.

Direction 3 from the issue — suppressing Templater for unattended creation — was not taken: it would break every user whose auto-created notes legitimately use `<% tp.date.now() %>`, and sidesteps the block rather than resolving it.

## Verification of each production line

Each change was reverted individually to confirm exactly which test falsifies it:

| Reverted | Test that goes red |
| --- | --- |
| `#schedule()` moved back below the loop | *arms the midnight timer before waiting, so a prompt opened near midnight cannot skip a day* |
| budget removed (`await this.createCurrent(name)`) | *does not starve the journals after it in the same tick* |
| `if (this.#disposed) return` in `#schedule` | *arms no midnight timer when disposed before the index is ready* |

The headline regression test — *keeps the midnight timer running, so auto-create survives the session* — is satisfied by either mechanism alone and fails only with both reverted; it pins the reported symptom rather than a line.

The near-midnight test is not contrived: with the budget alone, a block starting less than one budget before midnight arms the timer *past* midnight and loses the day outright.

## Observation, not changed here

`#tick`'s loop still runs to completion after `[Symbol.asyncDispose]` — `initialize` chains off `whenReady()`, so a boot tick landing after dispose still writes today's notes. That is pre-existing and unreported; the new test pins only that it arms no timer. Say the word if it should be guarded too.

## Verification

- 4 new tests, red before the fix, green after
- `npm test` — 4204 passed (395 files)
- `check:types`, `check:lint` (0 errors), `check:i18n` pass; `coverage` back at the 87.9% branch floor