### PR TITLE
refactor(testing): delete the campaign's test-only production hatches (Phase 3 sweep 7)

### DIFF
--- a/docs/unit-testing-strategy.md
+++ b/docs/unit-testing-strategy.md
@@ -249,29 +249,29 @@ variant-named wrapper at all only where the variant genuinely changes the
 shape — `fixedJournal` versus `customJournal`.
 
 **Fixtures live in the feature's `testing.ts`**, never as a local factory in a
-test file — that is the rule. What enforces it inside `src/journals` today is
-narrower than the rule itself: eslint's `no-restricted-syntax` flags only a
+test file — that is the rule. What enforces it across `src` is narrower than
+the rule itself: eslint's `no-restricted-syntax` flags only a
 `FunctionDeclaration` (not a `const foo = (...) => ...`) whose name matches
-`^(make|build|seed|create)(Journal|Command|View|Shelf|Decoration|Config)`. It
-is a naming tripwire, not a general ban — still worth having, because it
+`^(make|build|seed|create)(Journal|Command|View|Shelf|Decoration|Config|NavSegment|ToolbarItem)`.
+It is a naming tripwire, not a general ban — still worth having, because it
 catches the common shape without anyone having to remember it — but matching
 is purely syntactic, so passing lint and violating the rule are independent
 in both directions. A factory can violate the rule and still pass lint
 permanently, by construction of the selector rather than by luck: the
 selector only matches `FunctionDeclaration`, so `const makeJournal = () =>
 buildLiteral(...)` hand-builds an entity and is invisible to it no matter
-what any future sweep fixes, and a `function` whose name lands outside the
-six-word alternation escapes the same way. The converse also holds — a name
-that happens to match the shape says nothing about whether the function
-builds anything by hand at all; some do (a hand-built entity literal
+what changes elsewhere in the codebase, and a `function` whose name lands
+outside the eight-noun alternation escapes the same way. The converse also
+holds — a name that happens to match the shape says nothing about whether the
+function builds anything by hand at all; some do (a hand-built entity literal
 restating schema defaults, say) and some are compliant one-line delegators to
 a feature fixture, or arrange/seed helpers that were never entity fixtures to
 begin with. Neither a lint pass nor a lint failure is a verdict — only
 reading the function body is. Treat the selector as a naming-convention aid,
-not a compliance check: a sweep enabling it for its own directory should
-expect both false negatives (real violations the selector's shape can't see)
-and escapees that turn out to be fine on inspection, and should judge each
-one by what it does rather than by whether lint flagged it.
+not a compliance check: expect both false negatives (real violations the
+selector's shape can't see) and escapees that turn out to be fine on
+inspection, and judge each one by what it does rather than by whether lint
+flagged it.
 
 The entity alternation
 (`Journal|Command|View|Shelf|Decoration|Config|NavSegment|ToolbarItem`) and

--- a/docs/unit-testing-strategy.md
+++ b/docs/unit-testing-strategy.md
@@ -177,11 +177,10 @@ meant. `version` is always accepted — it is honored by the harness itself.
 
 `harness.render` and `harness.renderModal` come pre-bound to the harness's
 injector, so it cannot be forgotten and no container is threaded through call
-sites. Under `src/journals` — the directory converted onto this harness —
-importing `@testing-library/vue`'s raw `render` in a file that already builds
-a harness is a lint error; the guard is scoped to that directory only, so an
-unconverted file elsewhere (`src/shelves/ui/ShelfEditSubpage.test.ts`, for
-example) can still import it directly.
+sites. A file that already builds a harness cannot also import
+`@testing-library/vue`'s raw `render` — that combination is a lint error
+across `src`, under the same rule set and the same `src/infrastructure/**`
+carve-out described in [Enforcement](#enforcement).
 
 ```ts
 harness.render(JournalEditSubpage, { props: { journalName: "work", nav: noopNav } });
@@ -474,18 +473,16 @@ uses for the `vi.mock` ban. No custom plugin.
 | -------------------------------------------------------------- | ------------------------------------------------------------------------------- |
 | No `new Container()` in a test                                 | Build it with `testContainer()` from `@/testing`                                |
 | No `.register(...).use*` inside a test body or hook            | Pass a feature CORE/UI module to `testContainer({ modules })`                   |
-| No local factory matching journals' naming tripwire            | Fixtures live in the feature's `testing.ts` — see [gaps](#fixtures-and-seeding) |
+| No local factory matching the naming tripwire                  | Fixtures live in the feature's `testing.ts` — see [gaps](#fixtures-and-seeding) |
 | No raw `render` import in a file that already builds a harness | Mount through `harness.render`, which binds the injector                        |
 | `vi.mock` only in `*.isolated.test.ts`                         | The shared module registry, see [Isolation](#isolation)                         |
 
 **The full rule set is enabled for all of `src`, minus two carve-outs.** One
 `files: ["src/**/*.test.ts"]` block in `eslint.config.mjs` carries the whole
 `no-restricted-syntax` list; the base `vi.mock` rule alone applies more
-broadly, to every `**/*.test.ts`. Enrollment used to be a hand-maintained
-glob per converted directory; it collapsed into this single block once every
-feature had converted, because a list like that has to grow a line for each
-new feature directory, and a directory nobody remembered to add reads
-identically to one that is enforced.
+broadly, to every `**/*.test.ts`. A hand-maintained glob per directory would
+be fragile: it has to grow a line for each new feature directory, and a
+forgotten line reads identically to an enforced one.
 
 **`src/infrastructure/**` is an explicit `ignores` entry on that block, and
 stays one.** Its `host`/`di`/`flows` tests are what `testContainer()` itself

--- a/docs/unit-testing-strategy.md
+++ b/docs/unit-testing-strategy.md
@@ -213,18 +213,28 @@ export function fixedJournal(name: string, write: JournalWrite, overrides: Parti
 
 (`src/journals/testing.ts`.)
 
-A feature with no defaults factory of its own parses a minimal object through
-the production schema instead, then applies overrides. No fixture like this
-exists yet for commands — this is the shape a Phase 3 sweep should write, not
-a file to go looking for:
+A feature with no defaults factory of its own delegates to its collection's
+`defaultItem` instead, then applies overrides — `buildCommand` takes this
+form, and `src/shelves/testing.ts`'s `buildShelf` is the same shape against
+`shelvesCollection`:
 
 ```ts
 export function buildCommand(overrides: Partial<CommandConfig> = {}): CommandConfig {
-  return { ...v.parse(commandConfigSchema, MINIMAL_COMMAND), ...overrides };
+  return { ...commandCollection.defaultItem(""), ...overrides };
 }
 ```
 
-The schema-parse form fails loudly when the schema changes and cannot drift.
+(`src/commands/testing.ts`.)
+
+`defineCollection` (`src/settings/schema.ts`) carries `defaultItem` on the
+collection object it returns, and it is the same function production reaches
+when it creates the entity — `EditCommandModal.vue` calls it for a fresh
+command, and the settings parse calls it to repair a corrupt one. Parsing the
+item schema directly is not an option here: `commandConfigSchema` and
+`shelfConfigSchema` are module-local and not exported, so a fixture cannot
+reach them without widening the production surface for a test's convenience.
+Delegating to `defaultItem` satisfies the no-literal rule above more directly
+than parsing a schema would have.
 
 **Naming: `build<Entity>(overrides)`.** The base form takes a single
 `Partial<Entity>` argument — the entity's name passes through `overrides` like
@@ -263,13 +273,15 @@ expect both false negatives (real violations the selector's shape can't see)
 and escapees that turn out to be fine on inspection, and should judge each
 one by what it does rather than by whether lint flagged it.
 
-The entity alternation (`Journal|Command|View|Shelf|Decoration|Config`) and
-the message ("use fixedJournal/customJournal") are both journals-specific. A
-sweep enabling this rule for its own directory must extend the alternation
-with its own entity nouns and rewrite the message for its own fixture names —
-widening only the file glob to cover, say, `src/notes-calendar` or
-`src/code-blocks` turns on a selector that matches nothing there, which looks
-identical to a working one (see [Enforcement](#enforcement)).
+The entity alternation
+(`Journal|Command|View|Shelf|Decoration|Config|NavSegment|ToolbarItem`) and
+the message ("use fixedJournal/customJournal/buildShelf") are a fixed list,
+not a general pattern. The rule is enrolled for all of `src` in one block
+(see [Enforcement](#enforcement)), but the selector still only fires for a
+fixture name built from one of those nouns: a feature whose entity noun is
+not in the alternation — or a fixture named outside the `make|build|seed|create`
+prefix — is invisible to it, and a directory with such a fixture looks
+identical to one the selector is actually covering.
 
 ### The standard for new tests
 

--- a/docs/unit-testing-strategy.md
+++ b/docs/unit-testing-strategy.md
@@ -235,6 +235,28 @@ reach them without widening the production surface for a test's convenience.
 Delegating to `defaultItem` satisfies the no-literal rule above more directly
 than parsing a schema would have.
 
+A third case: a sub-entity with no collection of its own has no `defaultItem`
+to delegate to either. `NavBlockSegment` is one — it lives as an array field
+inside `JournalConfig.navBlock`, not as an entry in a `defineCollection`
+collection — so `buildNavSegment` parses a minimal literal through the
+segment's own schema instead:
+
+```ts
+export function buildNavSegment(overrides: Partial<NavBlockSegment> = {}): NavBlockSegment {
+  return { ...v.parse(navBlockSegmentSchema, MINIMAL_SEGMENT), ...overrides };
+}
+```
+
+(`src/journals/testing.ts`.) This is available here because
+`navBlockSegmentSchema` is exported (`src/journals/config.ts`);
+`commandConfigSchema` and `shelfConfigSchema` are module-local, which is why
+`buildCommand` and `buildShelf` reach for `defaultItem` instead of parsing.
+The schema-parse form fails loudly when the schema changes and
+cannot drift, so it earns its place exactly where the other two forms have
+nothing to delegate to — reach for a defaults factory first, then a
+collection's `defaultItem`, and only parse a minimal literal through an
+exported schema when the entity has neither.
+
 **Naming: `build<Entity>(overrides)`.** The base form takes a single
 `Partial<Entity>` argument — the entity's name passes through `overrides` like
 any other field, with a default supplied the same way the rest are. Promote a
@@ -498,7 +520,12 @@ Two mechanics that have already caused a silent failure once each:
   must sit _after_ the general test-file block and **re-declare the `vi.mock`
   selector**, or the ban silently lifts for every file it covers.
 - **A selector matching nothing looks identical to one that works.** Verify a new
-  rule by writing a violation and watching it fire, then removing it.
+  rule by writing a violation and watching it fire, then removing it. Do this
+  without touching the working tree: pipe the violation through eslint's stdin
+  mode against a real, already-enrolled path —
+  `printf '<violation>' | npx eslint --stdin --stdin-filename src/<enrolled-file>.test.ts` —
+  which runs the same selectors and writes nothing to disk, so an interrupted
+  check never leaves a stray file behind for the test-count gate to trip over.
 
 Two selectors are deliberately narrowed, and the narrowing is load-bearing:
 

--- a/docs/unit-testing-strategy.md
+++ b/docs/unit-testing-strategy.md
@@ -277,27 +277,18 @@ identical to a working one (see [Enforcement](#enforcement)).
 standard, and the only seeding path a new test should use: a name-keyed
 record mirroring on-disk settings, not an array.
 
-The path it is retiring still exists. Five `static fromParts` methods —
-`src/journals/repository.ts:33`, `src/commands/repository.ts:22`,
-`src/shelves/repository.ts:24`, `src/shelves/service.ts:11`,
-`src/views/repository.ts:20` — bypass the schema entirely: each does
-`Object.create(this.prototype)` to skip the constructor, then casts through a
-local `Mutable` interface to write protected fields. At the time of writing,
-forty-four test files still reach one of these methods: 35 call `fromParts`
-directly and 14 call the `fakeRepo` fixture that wraps it (5 files do both).
-That count is a moving target, not a fixed inventory — check the call sites
-directly rather than trusting a number here, since each feature's Phase 3
-sweep rewrites its own callers onto `testContainer({ data })` as it lands. A
-directory being "converted" does not by itself mean its `fromParts` is
-unused: a leftover `fromParts`/`fakeRepo` caller can sit inside an
-otherwise-converted directory until that feature's own sweep retires the
-method, `src/journals` included — don't assume none remain just from the
-directory name. Data seeded through `fromParts`/`fakeRepo` never sees the
-parse defaults or the repair
-path, and the helpers live in production source, which the
-[file-location rules](architecture.md#testing) forbid. Deleting a feature's
-`fromParts` is the closing step of that feature's Phase 3 sweep — not a
-decision to make ahead of the sweep that owns it.
+There is no other seeding path left to reach for. Every repository once
+carried a `static fromParts` that skipped the constructor with
+`Object.create(this.prototype)` and wrote protected fields through a local
+`Mutable` cast, and every view model had a matching `fromRepository`; the
+`fakeRepo`/`fakeShelvesRepo` fixtures that wrapped two of those statics
+existed for the same purpose. All of it is gone, along with every caller. If
+a future change reaches for something shaped like it — a constructor
+bypassed through `Object.create`, a `Mutable`-style cast to reach protected
+fields — that is a regression of the same kind, worth refusing for the same
+two reasons: it bypasses the schema, so seeded data never sees the parse
+defaults or the repair path, and it lives in production source, which the
+[file-location rules](architecture.md#testing) forbid.
 
 ### Fakes do not carry error queues
 
@@ -475,23 +466,28 @@ uses for the `vi.mock` ban. No custom plugin.
 | No raw `render` import in a file that already builds a harness | Mount through `harness.render`, which binds the injector                        |
 | `vi.mock` only in `*.isolated.test.ts`                         | The shared module registry, see [Isolation](#isolation)                         |
 
-**Scope is per-directory, and rolls out as each feature converts.** Today the
-full set is enabled for `src/journals/**/*.test.ts`; the base `vi.mock` rule
-applies to every `**/*.test.ts`. A Phase 3 sweep enables the rest for its own
-directory in the same PR that converts it, by appending one glob to the
-`convertedTestGlobs` array in `eslint.config.mjs`.
+**The full rule set is enabled for all of `src`, minus two carve-outs.** One
+`files: ["src/**/*.test.ts"]` block in `eslint.config.mjs` carries the whole
+`no-restricted-syntax` list; the base `vi.mock` rule alone applies more
+broadly, to every `**/*.test.ts`. Enrollment used to be a hand-maintained
+glob per converted directory; it collapsed into this single block once every
+feature had converted, because a list like that has to grow a line for each
+new feature directory, and a directory nobody remembered to add reads
+identically to one that is enforced.
 
-**`src/infrastructure/**` is not on that list, and will not be.** Its
-`host`/`di`/`flows` tests are what `testContainer()` itself is built and
-verified against — converting them onto the harness would test the harness
-through itself. This is a permanent boundary, not a directory the campaign
-hasn't reached yet.
+**`src/infrastructure/**` is an explicit `ignores` entry on that block, and
+stays one.** Its `host`/`di`/`flows` tests are what `testContainer()` itself
+is built and verified against — converting them onto the harness would test
+the harness through itself. This is a permanent boundary, not a directory
+the campaign hasn't reached yet, and an `ignores` entry says so more clearly
+than a glob list ever could: absence from a list is silent, but an `ignores`
+entry is visible in the config and can carry a comment explaining why.
 
 Two mechanics that have already caused a silent failure once each:
 
-- **Flat-config rule options replace, they do not merge.** A per-directory block
+- **Flat-config rule options replace, they do not merge.** The full-set block
   must sit _after_ the general test-file block and **re-declare the `vi.mock`
-  selector**, or the ban silently lifts for that whole feature.
+  selector**, or the ban silently lifts for every file it covers.
 - **A selector matching nothing looks identical to one that works.** Verify a new
   rule by writing a violation and watching it fire, then removing it.
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,29 +22,6 @@ const noStrayDefineModal = {
   message: "`defineModal()` is only allowed in `<feature>/ui/modals.ts`. Move the modal definition there.",
 };
 
-// Test files whose feature has been converted onto testContainer. The Phase 3 sweeps
-// append one glob each; Phase 6 replaces the list with "**/*.test.ts".
-// `src/infrastructure/**` is deliberately absent and stays absent: its host/di/flows
-// tests are what testContainer is built from, so converting them onto the harness
-// would test the harness through itself.
-const convertedTestGlobs = [
-  "src/journals/**/*.test.ts",
-  "src/shelves/**/*.test.ts",
-  "src/commands/**/*.test.ts",
-  "src/maintenance/**/*.test.ts",
-  "src/api/**/*.test.ts",
-  "src/calendar/**/*.test.ts",
-  "src/code-blocks/**/*.test.ts",
-  "src/notes-calendar/**/*.test.ts",
-  "src/decorations/**/*.test.ts",
-  "src/views/**/*.test.ts",
-  "src/settings/**/*.test.ts",
-  "src/templates/**/*.test.ts",
-  "src/ui/**/*.test.ts",
-  "src/logging/**/*.test.ts",
-  "src/i18n/**/*.test.ts",
-];
-
 // `no-restricted-syntax` options replace rather than merge, so this array must carry
 // the vi.mock selector too — a block that omits it lifts the isolation ban for every
 // glob it covers, and a selector matching nothing looks exactly like one that works.
@@ -414,8 +391,15 @@ export default [
   },
   {
     // Must sit after the two test blocks above: rule options replace rather than merge.
-    files: convertedTestGlobs,
-    ignores: ["**/*.isolated.test.ts"],
+    // Phase 3 finished converting every feature directory, so enrollment is now "all of src"
+    // minus the two permanent carve-outs, rather than a hand-maintained glob list. A list would
+    // have to grow a line for each new feature directory, and a directory nobody remembered to
+    // add is indistinguishable from one that is enforced.
+    // `src/infrastructure/**` is deliberately exempt and stays exempt: its host/di/flows
+    // tests are what testContainer is built from, so converting them onto the harness
+    // would test the harness through itself.
+    files: ["src/**/*.test.ts"],
+    ignores: ["**/*.isolated.test.ts", "src/infrastructure/**"],
     rules: {
       "no-restricted-syntax": ["error", ...campaignTestSelectors],
     },

--- a/src/commands/command-registry.test.ts
+++ b/src/commands/command-registry.test.ts
@@ -5,7 +5,6 @@ import { anchor } from "@/calendar/testing";
 import { m } from "@/i18n";
 import { Flows } from "@/infrastructure/flows";
 import type { VaultPath } from "@/infrastructure/host";
-import type { FakeHost } from "@/infrastructure/host/internal/testing";
 import { AsyncResult } from "@/infrastructure/result";
 import { JournalsIndex, JournalsRepository, OpenDateFlow } from "@/journals";
 import type { JournalConfig } from "@/journals";
@@ -16,7 +15,7 @@ import { ShelvesRepository } from "@/shelves";
 import type { ShelfConfig } from "@/shelves";
 import { shelvesCoreModule } from "@/shelves/module";
 import { buildShelf } from "@/shelves/testing";
-import { testContainer } from "@/testing";
+import { testContainer, type FakeHost } from "@/testing";
 
 import { DynamicCommandRegistry } from "./command-registry";
 import { commandCollection } from "./config";

--- a/src/commands/repository.ts
+++ b/src/commands/repository.ts
@@ -7,8 +7,6 @@ import { commandCollection, type CommandConfig } from "./config";
 import { CommandIdTakenError, InvalidCommandUpdateError, UnknownCommandError } from "./errors";
 import { CommandsEventsToken } from "./tokens";
 
-import type { Emitter } from "nanoevents";
-
 export type CommandsEvents = RepositoryEvents<string, CommandConfig>;
 
 export class CommandsRepository extends BaseRepository<
@@ -19,28 +17,6 @@ export class CommandsRepository extends BaseRepository<
   RepositoryQuery<string, CommandConfig>,
   CommandsEvents
 > {
-  static fromParts(storage: Record<string, CommandConfig>, events: Emitter<CommandsEvents>): CommandsRepository {
-    const repo = Object.create(this.prototype) as CommandsRepository;
-    interface Mutable {
-      idKey: keyof CommandConfig | undefined;
-      nameKey: keyof CommandConfig;
-      QueryConstructor: typeof RepositoryQuery;
-      storage: Record<string, CommandConfig>;
-      events: Emitter<CommandsEvents>;
-      unknownEntityError: (id: string) => UnknownCommandError;
-      invalidUpdateError: (id: string) => InvalidCommandUpdateError;
-    }
-    const w = repo as unknown as Mutable;
-    w.idKey = undefined;
-    w.nameKey = "name";
-    w.QueryConstructor = RepositoryQuery;
-    w.storage = storage;
-    w.events = events;
-    w.unknownEntityError = (id) => new UnknownCommandError(id);
-    w.invalidUpdateError = (id) => new InvalidCommandUpdateError(id);
-    return repo;
-  }
-
   protected idKey: keyof CommandConfig | undefined = undefined;
   protected nameKey: keyof CommandConfig = "name";
   protected QueryConstructor = RepositoryQuery;

--- a/src/commands/view-model.ts
+++ b/src/commands/view-model.ts
@@ -8,10 +8,6 @@ import { CommandsRepository } from "./repository";
 import type { CommandConfig } from "./config";
 
 export class CommandsViewModel {
-  static fromRepository(repository: CommandsRepository): CommandsViewModel {
-    return new CommandsViewModel(repository);
-  }
-
   readonly #repository: CommandsRepository;
 
   readonly commands: ComputedRef<CommandConfig[]>;

--- a/src/decorations/settings/ui/ConditionProperty.test.ts
+++ b/src/decorations/settings/ui/ConditionProperty.test.ts
@@ -9,8 +9,7 @@ import { defineComponent, h, nextTick } from "vue";
 import { decorationConditionSchema, type JournalDecorationCondition } from "@/decorations";
 import { m } from "@/i18n";
 import type { VaultProperty } from "@/infrastructure/host";
-import type { FakeHost } from "@/infrastructure/host/internal/testing";
-import { testContainer } from "@/testing";
+import { testContainer, type FakeHost } from "@/testing";
 
 import ConditionProperty from "./ConditionProperty.vue";
 

--- a/src/journals/index.ts
+++ b/src/journals/index.ts
@@ -13,8 +13,7 @@ export { JournalsIndex } from "./journals-index";
 
 export { useIndexVersion } from "./use-index-version";
 
-export { journalsModule, journalsCoreModule, journalsStartupModule } from "./module";
-export { journalsUiModule } from "./ui-module";
+export { journalsModule } from "./module";
 
 export {
   JournalEditSectionToken,

--- a/src/journals/repository.ts
+++ b/src/journals/repository.ts
@@ -15,8 +15,6 @@ import {
 } from "./errors";
 import { JournalsEventsToken } from "./tokens";
 
-import type { Emitter } from "nanoevents";
-
 export interface JournalsEvents extends RepositoryEvents<string, JournalConfig> {
   renamed: (oldName: string, newName: string) => void;
   cloned: (sourceName: string, newName: string) => void;
@@ -30,28 +28,6 @@ export class JournalsRepository extends BaseRepository<
   RepositoryQuery<string, JournalConfig>,
   JournalsEvents
 > {
-  static fromParts(storage: Record<string, JournalConfig>, events: Emitter<JournalsEvents>): JournalsRepository {
-    const repo = Object.create(this.prototype) as JournalsRepository;
-    interface Mutable {
-      idKey: keyof JournalConfig;
-      nameKey: keyof JournalConfig;
-      QueryConstructor: typeof RepositoryQuery;
-      storage: Record<string, JournalConfig>;
-      events: Emitter<JournalsEvents>;
-      unknownEntityError: (name: string) => UnknownJournalError;
-      invalidUpdateError: (name: string) => InvalidJournalUpdateError;
-    }
-    const w = repo as unknown as Mutable;
-    w.idKey = "name";
-    w.nameKey = "name";
-    w.QueryConstructor = RepositoryQuery;
-    w.storage = storage;
-    w.events = events;
-    w.unknownEntityError = (name) => new UnknownJournalError(name);
-    w.invalidUpdateError = (name) => new InvalidJournalUpdateError(name);
-    return repo;
-  }
-
   protected idKey: keyof JournalConfig = "name";
   protected nameKey: keyof JournalConfig = "name";
   protected QueryConstructor = RepositoryQuery;

--- a/src/journals/testing.ts
+++ b/src/journals/testing.ts
@@ -1,21 +1,15 @@
-import { createNanoEvents } from "nanoevents";
 import * as v from "valibot";
 import { assert } from "vitest";
 
 import type { Option } from "@/infrastructure/result";
 
 import { journalDefaultsFor, navBlockSegmentSchema } from "./config";
-import { JournalsRepository } from "./repository";
 
 import type { JournalConfig, JournalWrite, NavBlockSegment } from "./config";
 
 export function unwrap<T>(opt: Option<T>): T {
   assert(opt.isSome(), "expected Some");
   return opt.value;
-}
-
-export function fakeRepo(journals: Record<string, JournalConfig>): JournalsRepository {
-  return JournalsRepository.fromParts(journals, createNanoEvents());
 }
 
 export function fixedJournal(name: string, write: JournalWrite, overrides: Partial<JournalConfig> = {}): JournalConfig {

--- a/src/journals/vault-subscription.test.ts
+++ b/src/journals/vault-subscription.test.ts
@@ -4,9 +4,8 @@ import { assert, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AnchorString } from "@/calendar";
 import { NoteMetadataService } from "@/infrastructure/host";
 import type { VaultPath } from "@/infrastructure/host";
-import type { FakeHost } from "@/infrastructure/host/internal/testing";
 import { SettingsEventsToken } from "@/settings";
-import { testContainer, type TestHarness } from "@/testing";
+import { testContainer, type FakeHost, type TestHarness } from "@/testing";
 
 import { CycleService } from "./cycle";
 import { JournalsIndex } from "./journals-index";

--- a/src/journals/view-model.ts
+++ b/src/journals/view-model.ts
@@ -8,10 +8,6 @@ import { JournalsRepository } from "./repository";
 import type { JournalConfig } from "./config";
 
 export class JournalsViewModel {
-  static fromRepository(repository: JournalsRepository): JournalsViewModel {
-    return new JournalsViewModel(repository);
-  }
-
   readonly #repository: JournalsRepository;
 
   readonly journals: ComputedRef<JournalConfig[]>;

--- a/src/maintenance/repair-service.test.ts
+++ b/src/maintenance/repair-service.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from "vitest";
 
 import { anchor } from "@/calendar/testing";
 import type { VaultPath } from "@/infrastructure/host";
-import type { FakeHost } from "@/infrastructure/host/internal/testing";
 import { AsyncResult } from "@/infrastructure/result";
 import { expectOk } from "@/infrastructure/result/testing";
 import { FRONTMATTER_NAME_KEY, type JournalConfig } from "@/journals/config";
@@ -11,7 +10,7 @@ import { JournalsIndex } from "@/journals/journals-index";
 import { journalsCoreModule } from "@/journals/module";
 import { NoteConnectionService } from "@/journals/notes/note-connection";
 import { fixedJournal } from "@/journals/testing";
-import { testContainer } from "@/testing";
+import { testContainer, type FakeHost } from "@/testing";
 
 import { maintenanceCoreModule } from "./module";
 import { RepairService } from "./repair-service";

--- a/src/maintenance/scan-service.test.ts
+++ b/src/maintenance/scan-service.test.ts
@@ -2,14 +2,13 @@ import { describe, expect, it, vi } from "vitest";
 
 import { anchor } from "@/calendar/testing";
 import type { VaultPath } from "@/infrastructure/host";
-import type { FakeHost } from "@/infrastructure/host/internal/testing";
 import type { JournalConfig } from "@/journals/config";
 import { JournalsIndex } from "@/journals/journals-index";
 import { journalsCoreModule } from "@/journals/module";
 import { JournalsRepository } from "@/journals/repository";
 import { customJournal, fixedJournal } from "@/journals/testing";
 import { legacyMigrationsModule, pendingNoteMigrationSlice } from "@/settings/legacy";
-import { testContainer } from "@/testing";
+import { testContainer, type FakeHost } from "@/testing";
 
 import { maintenanceCoreModule } from "./module";
 import { gateCollisions, orphanFindings, pendingOldIdsOf, ScanService } from "./scan-service";

--- a/src/maintenance/scanned-note.test.ts
+++ b/src/maintenance/scanned-note.test.ts
@@ -3,12 +3,11 @@ import { describe, expect, it, vi } from "vitest";
 import { anchor } from "@/calendar/testing";
 import { NoteMetadataService } from "@/infrastructure/host";
 import type { VaultPath } from "@/infrastructure/host";
-import type { FakeHost } from "@/infrastructure/host/internal/testing";
 import type { JournalConfig } from "@/journals/config";
 import { journalsCoreModule } from "@/journals/module";
 import { NotePathService } from "@/journals/notes/note-path";
 import { customJournal, fixedJournal } from "@/journals/testing";
-import { testContainer } from "@/testing";
+import { testContainer, type FakeHost } from "@/testing";
 
 import { maintenanceCoreModule } from "./module";
 import { ScannedNoteResolver } from "./scanned-note";

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -16,7 +16,7 @@ export {
   UnregisteredSliceError,
   UnregisteredSubpageError,
 } from "./errors";
-export { settingsCoreModule, settingsModule } from "./module";
+export { settingsModule } from "./module";
 export { ReloadHintService } from "./reload-hint";
 export { SettingsService } from "./settings-service";
 export {

--- a/src/shelves/repository.ts
+++ b/src/shelves/repository.ts
@@ -7,8 +7,6 @@ import { shelvesCollection, type ShelfConfig } from "./config";
 import { InvalidShelfNameError, InvalidShelfUpdateError, ShelfNameTakenError, UnknownShelfError } from "./errors";
 import { ShelvesEventsToken } from "./tokens";
 
-import type { Emitter } from "nanoevents";
-
 export interface ShelvesEvents extends RepositoryEvents<string, ShelfConfig> {
   renamed: (oldName: string, newName: string) => void;
 }
@@ -21,28 +19,6 @@ export class ShelvesRepository extends BaseRepository<
   RepositoryQuery<string, ShelfConfig>,
   ShelvesEvents
 > {
-  static fromParts(storage: Record<string, ShelfConfig>, events: Emitter<ShelvesEvents>): ShelvesRepository {
-    const repo = Object.create(this.prototype) as ShelvesRepository;
-    interface Mutable {
-      idKey: keyof ShelfConfig;
-      nameKey: keyof ShelfConfig;
-      QueryConstructor: typeof RepositoryQuery;
-      storage: Record<string, ShelfConfig>;
-      events: Emitter<ShelvesEvents>;
-      unknownEntityError: (name: string) => UnknownShelfError;
-      invalidUpdateError: (name: string) => InvalidShelfUpdateError;
-    }
-    const w = repo as unknown as Mutable;
-    w.idKey = "name";
-    w.nameKey = "name";
-    w.QueryConstructor = RepositoryQuery;
-    w.storage = storage;
-    w.events = events;
-    w.unknownEntityError = (name) => new UnknownShelfError(name);
-    w.invalidUpdateError = (name) => new InvalidShelfUpdateError(name);
-    return repo;
-  }
-
   protected idKey: keyof ShelfConfig = "name";
   protected nameKey: keyof ShelfConfig = "name";
   protected QueryConstructor = RepositoryQuery;

--- a/src/shelves/service.ts
+++ b/src/shelves/service.ts
@@ -8,14 +8,6 @@ import { ShelvesRepository } from "./repository";
 import type { Emitter } from "nanoevents";
 
 export class ShelvesService {
-  static fromParts(
-    shelves: ShelvesRepository,
-    journals: JournalsRepository,
-    journalEvents: Emitter<JournalsEvents>,
-  ): ShelvesService {
-    return new ShelvesService(shelves, journals, journalEvents);
-  }
-
   readonly #shelves: ShelvesRepository;
   readonly #journals: JournalsRepository;
 

--- a/src/shelves/testing.ts
+++ b/src/shelves/testing.ts
@@ -1,14 +1,7 @@
-import { createNanoEvents } from "nanoevents";
-
 import { shelvesCollection } from "./config";
-import { ShelvesRepository } from "./repository";
 
 import type { ShelfConfig } from "./config";
 
 export function buildShelf(name: string, overrides: Partial<ShelfConfig> = {}): ShelfConfig {
   return { ...shelvesCollection.defaultItem(name), ...overrides };
-}
-
-export function fakeShelvesRepo(shelves: Record<string, ShelfConfig> = {}): ShelvesRepository {
-  return ShelvesRepository.fromParts(shelves, createNanoEvents());
 }

--- a/src/shelves/ui/DeleteShelfModal.test.ts
+++ b/src/shelves/ui/DeleteShelfModal.test.ts
@@ -3,10 +3,7 @@ import { screen } from "@testing-library/vue";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { m } from "@/i18n";
-import { journalsCoreModule } from "@/journals/module";
 import { testContainer, type TestHarness } from "@/testing";
-
-import { shelvesCoreModule } from "../module";
 
 import DeleteShelfModal from "./DeleteShelfModal.vue";
 
@@ -14,7 +11,7 @@ describe("DeleteShelfModal", () => {
   let harness: TestHarness;
 
   beforeEach(async () => {
-    harness = await testContainer({ modules: [journalsCoreModule, shelvesCoreModule] });
+    harness = await testContainer();
   });
 
   it("lists the other shelves as destinations", () => {

--- a/src/shelves/ui/PlaceJournalModal.test.ts
+++ b/src/shelves/ui/PlaceJournalModal.test.ts
@@ -3,10 +3,7 @@ import { screen } from "@testing-library/vue";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { m } from "@/i18n";
-import { journalsCoreModule } from "@/journals/module";
 import { testContainer, type TestHarness } from "@/testing";
-
-import { shelvesCoreModule } from "../module";
 
 import PlaceJournalModal from "./PlaceJournalModal.vue";
 
@@ -14,7 +11,7 @@ describe("PlaceJournalModal", () => {
   let harness: TestHarness;
 
   beforeEach(async () => {
-    harness = await testContainer({ modules: [journalsCoreModule, shelvesCoreModule] });
+    harness = await testContainer();
   });
 
   it("offers every shelf plus the not-on-a-shelf option", () => {

--- a/src/shelves/ui/ShelfNameModal.test.ts
+++ b/src/shelves/ui/ShelfNameModal.test.ts
@@ -3,10 +3,7 @@ import { screen, waitFor } from "@testing-library/vue";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { m } from "@/i18n";
-import { journalsCoreModule } from "@/journals/module";
 import { testContainer, type TestHarness } from "@/testing";
-
-import { shelvesCoreModule } from "../module";
 
 import { shelfNameModal } from "./modals";
 import ShelfNameModal from "./ShelfNameModal.vue";
@@ -25,7 +22,7 @@ describe("ShelfNameModal", () => {
   let harness: TestHarness;
 
   beforeEach(async () => {
-    harness = await testContainer({ modules: [journalsCoreModule, shelvesCoreModule] });
+    harness = await testContainer();
   });
 
   it("submits the entered name", async () => {

--- a/src/shelves/view-model.test.ts
+++ b/src/shelves/view-model.test.ts
@@ -10,7 +10,7 @@ import { ShelvesViewModel } from "./view-model";
 
 import type { ShelfConfig } from "./config";
 
-async function buildVM(initial: Record<string, ShelfConfig> = {}) {
+async function resolveViewModel(initial: Record<string, ShelfConfig> = {}) {
   const harness = await testContainer({
     modules: [journalsCoreModule, shelvesCoreModule],
     data: { shelves: initial },
@@ -21,13 +21,13 @@ async function buildVM(initial: Record<string, ShelfConfig> = {}) {
 describe("ShelvesViewModel", () => {
   describe("shelves", () => {
     it("yields the current shelves", async () => {
-      const { vm } = await buildVM({ Personal: buildShelf("Personal") });
+      const { vm } = await resolveViewModel({ Personal: buildShelf("Personal") });
 
       expect(vm.shelves.value.map((s) => s.name)).toEqual(["Personal"]);
     });
 
     it("reflects mutations after create", async () => {
-      const { vm, repo } = await buildVM();
+      const { vm, repo } = await resolveViewModel();
 
       repo.create("Personal");
 
@@ -37,7 +37,7 @@ describe("ShelvesViewModel", () => {
 
   describe("shelfOptions", () => {
     it("labels options by the shelf name", async () => {
-      const { vm } = await buildVM({ Personal: buildShelf("Personal"), Home: buildShelf("Home") });
+      const { vm } = await resolveViewModel({ Personal: buildShelf("Personal"), Home: buildShelf("Home") });
 
       expect(vm.shelfOptions.value).toEqual([
         { value: "Personal", label: "Personal" },
@@ -48,7 +48,7 @@ describe("ShelvesViewModel", () => {
 
   describe("shelfCount", () => {
     it("returns the count", async () => {
-      const { vm } = await buildVM({ Personal: buildShelf("Personal") });
+      const { vm } = await resolveViewModel({ Personal: buildShelf("Personal") });
 
       expect(vm.shelfCount.value).toBe(1);
     });
@@ -56,13 +56,13 @@ describe("ShelvesViewModel", () => {
 
   describe("getShelf", () => {
     it("returns Some for a known name", async () => {
-      const { vm } = await buildVM({ Personal: buildShelf("Personal") });
+      const { vm } = await resolveViewModel({ Personal: buildShelf("Personal") });
 
       expect(vm.getShelf("Personal").isSome()).toBe(true);
     });
 
     it("returns None for an unknown name", async () => {
-      const { vm } = await buildVM();
+      const { vm } = await resolveViewModel();
 
       expect(vm.getShelf("nope").isNone()).toBe(true);
     });
@@ -70,19 +70,19 @@ describe("ShelvesViewModel", () => {
 
   describe("isShelfNameAvailable", () => {
     it("is false when the name is in use", async () => {
-      const { vm } = await buildVM({ Personal: buildShelf("Personal") });
+      const { vm } = await resolveViewModel({ Personal: buildShelf("Personal") });
 
       expect(vm.isShelfNameAvailable("Personal")).toBe(false);
     });
 
     it("is true when the name is free", async () => {
-      const { vm } = await buildVM({ Personal: buildShelf("Personal") });
+      const { vm } = await resolveViewModel({ Personal: buildShelf("Personal") });
 
       expect(vm.isShelfNameAvailable("Other")).toBe(true);
     });
 
     it("treats excludeCurrent as available", async () => {
-      const { vm } = await buildVM({ Personal: buildShelf("Personal") });
+      const { vm } = await resolveViewModel({ Personal: buildShelf("Personal") });
 
       expect(vm.isShelfNameAvailable("Personal", "Personal")).toBe(true);
     });

--- a/src/shelves/view-model.ts
+++ b/src/shelves/view-model.ts
@@ -8,10 +8,6 @@ import { ShelvesRepository } from "./repository";
 import type { ShelfConfig } from "./config";
 
 export class ShelvesViewModel {
-  static fromRepository(repository: ShelvesRepository): ShelvesViewModel {
-    return new ShelvesViewModel(repository);
-  }
-
   readonly #repository: ShelvesRepository;
 
   readonly shelves: ComputedRef<ShelfConfig[]>;

--- a/src/testing.test.ts
+++ b/src/testing.test.ts
@@ -15,14 +15,8 @@ import { ContainerDisposedError, useService } from "@/infrastructure/di";
 import { NoticeService } from "@/infrastructure/host";
 import { useModal } from "@/infrastructure/host/modals";
 import { FakeNoticeService, FakePluginData } from "@/infrastructure/host/testing";
-import {
-  CycleService,
-  JournalsIndex,
-  JournalsViewModel,
-  VaultSubscriptionService,
-  journalsCoreModule,
-  journalsModule,
-} from "@/journals";
+import { CycleService, JournalsIndex, JournalsViewModel, VaultSubscriptionService, journalsModule } from "@/journals";
+import { journalsCoreModule } from "@/journals/module";
 import { JournalsRepository } from "@/journals/repository";
 import { fixedJournal } from "@/journals/testing";
 import { CURRENT_VERSION, SettingsService } from "@/settings";

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -34,6 +34,8 @@ import { templatesModule } from "@/templates";
 
 import type { App } from "vue";
 
+export type { FakeHost } from "@/infrastructure/host/internal/testing";
+
 // Copied string literals: these are the warnings SettingsService logs when a parse repairs
 // rather than rejects. A message reworded there without this list is a guard that stops firing.
 const REPAIR_WARNINGS = new Set([

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -28,13 +28,8 @@ import { FakeModalService, provideModalApiOnApp } from "@/infrastructure/host/mo
 import { FakeSuggestService } from "@/infrastructure/host/suggests/testing";
 import { FakeNoticeService, FakePluginData, FakeTemplaterService } from "@/infrastructure/host/testing";
 import { createLoggerTestingModule, type MemorySink } from "@/infrastructure/logger/testing";
-import {
-  CURRENT_VERSION,
-  CollectionDefinitionToken,
-  SettingsService,
-  SliceDefinitionToken,
-  settingsCoreModule,
-} from "@/settings";
+import { CURRENT_VERSION, CollectionDefinitionToken, SettingsService, SliceDefinitionToken } from "@/settings";
+import { settingsCoreModule } from "@/settings/module";
 import { templatesModule } from "@/templates";
 
 import type { App } from "vue";

--- a/src/ui/UiPropertySuggest.test.ts
+++ b/src/ui/UiPropertySuggest.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { VaultProperty } from "@/infrastructure/host";
-import type { FakeHost } from "@/infrastructure/host/internal/testing";
-import { testContainer } from "@/testing";
+import { testContainer, type FakeHost } from "@/testing";
 
 import { icons } from "./icons";
 import UiPropertySuggest from "./UiPropertySuggest.vue";

--- a/src/views/flows/reposition-view.flow.test.ts
+++ b/src/views/flows/reposition-view.flow.test.ts
@@ -2,10 +2,9 @@ import { describe, expect, it } from "vitest";
 
 import { m } from "@/i18n";
 import { Flows, UserAborted } from "@/infrastructure/flows";
-import type { FakeHost } from "@/infrastructure/host/internal/testing";
 import { journalsCoreModule } from "@/journals/module";
 import { shelvesCoreModule } from "@/shelves/module";
-import { testContainer } from "@/testing";
+import { testContainer, type FakeHost } from "@/testing";
 
 import { viewsCoreModule } from "../module";
 import { viewsStartupModule } from "../startup-module";

--- a/src/views/repository.ts
+++ b/src/views/repository.ts
@@ -7,8 +7,6 @@ import { viewsCollection, type View, type ViewId } from "./config";
 import { InvalidViewNameError, InvalidViewUpdateError, UnknownViewError, type ViewsLifecycleError } from "./errors";
 import { ViewsEventsToken, type ViewsEvents } from "./tokens";
 
-import type { Emitter } from "nanoevents";
-
 export class ViewsRepository extends BaseRepository<
   ViewId,
   View,
@@ -17,28 +15,6 @@ export class ViewsRepository extends BaseRepository<
   RepositoryQuery<ViewId, View>,
   ViewsEvents
 > {
-  static fromParts(storage: Record<string, View>, events: Emitter<ViewsEvents>): ViewsRepository {
-    const repo = Object.create(this.prototype) as ViewsRepository;
-    interface Mutable {
-      idKey: keyof View;
-      nameKey: keyof View;
-      QueryConstructor: typeof RepositoryQuery;
-      storage: Record<ViewId, View>;
-      events: Emitter<ViewsEvents>;
-      unknownEntityError: (id: ViewId) => UnknownViewError;
-      invalidUpdateError: (id: ViewId) => InvalidViewUpdateError;
-    }
-    const w = repo as unknown as Mutable;
-    w.idKey = "id";
-    w.nameKey = "name";
-    w.QueryConstructor = RepositoryQuery;
-    w.storage = storage;
-    w.events = events;
-    w.unknownEntityError = (id) => new UnknownViewError(id);
-    w.invalidUpdateError = (id) => new InvalidViewUpdateError(id);
-    return repo;
-  }
-
   protected idKey: keyof View = "id";
   protected nameKey: keyof View = "name";
   protected QueryConstructor = RepositoryQuery<ViewId, View>;

--- a/src/views/view-host.test.ts
+++ b/src/views/view-host.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import { m } from "@/i18n";
-import type { FakeHost } from "@/infrastructure/host/internal/testing";
 import { journalsCoreModule } from "@/journals/module";
 import type { ShelfConfig } from "@/shelves";
 import { shelvesCoreModule } from "@/shelves/module";
 import { buildShelf } from "@/shelves/testing";
-import { testContainer } from "@/testing";
+import { testContainer, type FakeHost } from "@/testing";
 
 import { FALLBACK_VIEW_ICON, viewsCollection, type View, type ViewId } from "./config";
 import { DEFAULT_CALENDAR_VIEW_ID } from "./default-view";

--- a/src/views/view-model.ts
+++ b/src/views/view-model.ts
@@ -8,10 +8,6 @@ import { ViewsRepository } from "./repository";
 import type { View, ViewId } from "./config";
 
 export class ViewsViewModel {
-  static fromRepository(repository: ViewsRepository): ViewsViewModel {
-    return new ViewsViewModel(repository);
-  }
-
   readonly #repository: ViewsRepository;
 
   readonly views: ComputedRef<View[]>;

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -33,8 +33,13 @@ export default defineConfig({
         // `module.ts` is assumed to hold wiring only — `src/settings/legacy/module.ts` already
         // breaks that assumption (its `legacyMigrations` array is real behavior with its own
         // test), so a file matching this glob still needs checking for non-wiring exports.
+        // `src/**/startup-module.ts` joins them for the same reason — a startup module is that
+        // same wiring — and carries the same caveat. Unlike the other two it is not avoiding a
+        // fresh-0% drag: the one such file today, `src/views/startup-module.ts`, is at 100%, so
+        // excluding it removes covered code and nudges the floor down rather than up.
         "src/**/module.ts",
         "src/**/ui-module.ts",
+        "src/**/startup-module.ts",
       ],
       // A floor to catch silent deletion during the test-conversion campaign, not a target to
       // chase. Set at the measured value: a PR that lowers coverage edits these numbers in the
@@ -399,10 +404,47 @@ export default defineConfig({
         // unregistered, which this file no longer does anywhere. Net: +1 statement, -1 branch.
         //
         // New tip -> 92.25 / 87.9 / 89.72 / 94.26 (11095/12026, 4782/5440, 3965/4419, 9690/10279).
-        statements: 92.25,
+        //
+        // Closing PR (merge base 8a63de66, which reproduced the line above exactly) -> 92.66 / 87.9 / 89.86 /
+        // 94.68 (11093/11971, 4782/5440, 3955/4401, 9688/10232). Measured at the tip and diffed per file
+        // against the base; ten files differ and no other file moved by so much as one count.
+        //
+        // Two of the branch's commits move the numbers, and this commit's new exclude removes a tenth file.
+        // `0cfc834f` deleted the five `fromParts` constructors (the four repositories, -12 statements / -10
+        // lines / -3 functions each, and `shelves/service.ts`, -1 / -1 / -1); `c8585787` deleted the four
+        // `fromRepository` view model constructors (-1 / -1 / -1 each). All nine had been dead at the merge
+        // base already, which the counts show directly: covered statements and covered lines are unchanged in
+        // every one of the nine, so nothing that used to run stopped running. Only totals shrink, so all four
+        // percentages rise. `b442f965` and `cbd5a217` touched only `testing.ts` and `*.test.ts` files plus two
+        // barrels, and the per-file diff confirms them neutral.
+        //
+        // Covered functions do fall, by one per file, but that is an artifact of the v8 provider rather than a
+        // weaker test: it had counted each dead static's function entry as covered while marking every
+        // statement inside that static uncovered. Deleting the static takes the phantom covered entry with it,
+        // which is why 18 functions leave the total while only 10 leave the covered count (nine phantoms plus
+        // the startup module's genuine one), and the percentage still goes up. No surviving function changed
+        // verdict — the unchanged covered statement and line counts prove that file by file.
+        //
+        // Branches were expected flat and were measured flat per file, not in aggregate: not one of
+        // the ten files carries a branch delta in either direction, so no pair of opposite movements
+        // is hiding behind the unchanged 4782/5440. Every deleted body was straight-line code.
+        //
+        // `src/views/startup-module.ts` leaves the set through the new `src/**/startup-module.ts`
+        // exclude above. It stood at 100% (2/2 statements, 1/1 functions, 2/2 lines, no branches),
+        // so that exclusion removes covered code and costs a sliver of each percentage instead of
+        // saving one; it is there to match the `module.ts` and `ui-module.ts` excludes, not to head
+        // off a fresh 0% file.
+        //
+        // Left uncovered on purpose, recorded for Phase 4.5 rather than filled (gate 1): the
+        // `invalidUpdateError` arrow bodies in `src/commands/repository.ts:26` and
+        // `src/views/repository.ts:24`, which no test on either repository reaches, since neither
+        // suite pushes an update through the rejecting path. `src/views/repository.ts` also keeps
+        // the pre-existing uncovered `InvalidViewNameError` return at `:31`; this branch did not
+        // touch it.
+        statements: 92.66,
         branches: 87.9,
-        functions: 89.72,
-        lines: 94.26,
+        functions: 89.86,
+        lines: 94.68,
       },
     },
     projects: [

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -423,7 +423,8 @@ export default defineConfig({
         // statement inside that static uncovered. Deleting the static takes the phantom covered entry with it,
         // which is why 18 functions leave the total while only 10 leave the covered count (nine phantoms plus
         // the startup module's genuine one), and the percentage still goes up. No surviving function changed
-        // verdict — the unchanged covered statement and line counts prove that file by file.
+        // verdict: the ten-function fall is fully accounted for by the nine phantoms and the
+        // startup module's own one, leaving no residue for any surviving function.
         //
         // Branches were expected flat and were measured flat per file, not in aggregate: not one of
         // the ten files carries a branch delta in either direction, so no pair of opposite movements


### PR DESCRIPTION
Closes Phase 3 of the testing-strategy campaign. Every sweep is now merged; this is the
closing PR the charter reserved for the production deletions the conversions made possible.

## Production deletions

Nine test-only escape hatches, each with zero callers before this branch opened. The grep
proving that ran inside the commit that deleted each group.

- `JournalsRepository.fromParts`, `CommandsRepository.fromParts`, `ShelvesRepository.fromParts`,
  `ViewsRepository.fromParts`, `ShelvesService.fromParts`
- `JournalsViewModel.fromRepository`, `CommandsViewModel.fromRepository`,
  `ShelvesViewModel.fromRepository`, `ViewsViewModel.fromRepository`

Each `fromParts` was a hand-rolled `Object.create(this.prototype)` that skipped the
constructor and cast through a local `Mutable` interface to write protected fields — data
seeded that way never met the parse defaults or the repair path, and the helper shipped in
the production bundle, which `docs/architecture.md`'s file-location rules forbid. The
`fromRepository` statics were the same defect in one line.

`fakeRepo` and `fakeShelvesRepo`, the last two callers, go first so the deletion greps are
unambiguous. `createSettingsService` was already retired in the previous sweep.

## Barrel trims

`@/journals` and `@/settings` stop exporting their core, UI and startup modules — the
charter's ruling 5: a barrel exports `<feature>Module` only, and tests deep-import the rest.
`src/testing.ts` and `src/testing.test.ts` were the only consumers and now deep-import.
`journalsModule` stays on the journals barrel; `src/testing.test.ts` consumes it there.

## Test-side cleanups the charter deferred to this PR

- `buildVM` → `resolveViewModel` in `src/shelves/view-model.test.ts`. The old name dodged the
  fixture-factory lint selector by abbreviating the entity out of it.
- Three shelves modal tests stop wiring `[journalsCoreModule, shelvesCoreModule]`. All three
  components — and their four `Ui*` children — resolve nothing from the container, so the
  wiring was inert. Verified by probe rather than by inspection: with a `useService` added to
  the component the tests pass wired and fail unwired with `TokenNotRegisteredError`, so the
  drop makes the files stricter, not weaker.
- `type FakeHost` is re-exported from `@/testing`; nine tests stop deep-importing it from
  `src/infrastructure/host/internal/testing`.

## Lint enrollment

`convertedTestGlobs` grew one glob per sweep and has nothing left to append. It collapses to
a single `files: ["src/**/*.test.ts"]` block with `ignores` for `**/*.isolated.test.ts` and
`src/infrastructure/**`. The delta is exactly one file in (`src/testing.test.ts`, which
clears all five selectors) and zero out, and a new feature directory is now enrolled by
default rather than when someone remembers to add it. All five selectors were confirmed
firing against a directory the old list never covered.

`src/infrastructure/**` moves from *absent from a list* to an explicit, commented `ignores`
entry — absence is silent; an entry is visible.

## Coverage

`92.25 / 87.86 → 92.66 / 87.90 / 89.86 / 94.68`, attributed per file in the config comment.
The deletions removed only uncovered code, so statements, functions and lines rise and
branches do not move — verified per file, not in aggregate.

`src/**/startup-module.ts` joins the `exclude` globs beside `module.ts` and `ui-module.ts`.
The comment is explicit that this one *costs* a sliver rather than saving one: the only such
file today is at 100%, so the rationale is consistency — a startup module is the same DI
wiring `docs/unit-testing-strategy.md` forbids testing — and not the fresh-0% drag the
sibling globs head off.

Two lines stay uncovered and are recorded rather than filled: the `invalidUpdateError` arrow
bodies in the commands and views repositories, which no test triggers while the journals and
shelves equivalents are covered.

## Documentation

`docs/unit-testing-strategy.md` described the deleted methods and the deleted glob array as
live, with a caller count of forty-four. Repairing that surfaced three further false claims
in the same document, all now fixed: a fixture the doc said did not exist (it does, in a
shape the charter deliberately chose over the one the doc printed), a stale selector
alternation, and a Mounting section scoping a lint rule to `src/journals` and citing an
example file that had since been converted.

The verification instruction now points at a non-mutating form — `eslint --stdin` — instead
of writing a throwaway violation into the source tree.

## Gates

- **Test count:** 395 files / 4219 tests, unchanged. No test added, deleted, renamed or
  merged — no test-declaring line is touched anywhere in the diff.
- **Coverage:** exits 0 at the committed thresholds.
- **`check:types`, `check:i18n`, `check:lint`:** clean, lint run after the final commit.
- **e2e:** the only real check on the production deletions.

No `CHANGELOG.md` entry — nothing here is visible to a plugin user.