### PR TITLE
test: close the Phase 4.5 coverage and vacuous-guard backlog

### DIFF
--- a/__mocks__/obsidian.ts
+++ b/__mocks__/obsidian.ts
@@ -38,14 +38,21 @@ export function setTooltip(el: HTMLElement, tooltip: string): void {
   el.dataset.tooltip = tooltip;
 }
 
+// Real Obsidian returns null for a name outside its icon registry, and UiIcon's false arm is
+// only reachable through that. The seeded set is a test-controlled registry, not a copy of
+// Obsidian's — a test that needs a name present seeds it.
+const DEFAULT_ICON_IDS = ["calendar", "calendar-days", "book-open", "file-text", "terminal"];
+let iconIds = new Set(DEFAULT_ICON_IDS);
+
 export function getIcon(name: string): SVGSVGElement | null {
+  if (!iconIds.has(name)) return null;
   const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
   svg.setAttribute("data-icon", name);
   return svg;
 }
 
 export function getIconIds(): string[] {
-  return ["calendar", "calendar-days", "book-open", "file-text", "terminal"];
+  return [...iconIds];
 }
 
 interface TagSourceCache {
@@ -417,5 +424,11 @@ export const __testing = {
     attachedInputSuggests.length = 0;
     for (const m of [...openMenus]) m.hide();
     openMenus.length = 0;
+  },
+  seedIcons(names: readonly string[]): void {
+    for (const name of names) iconIds.add(name);
+  },
+  resetIcons(): void {
+    iconIds = new Set(DEFAULT_ICON_IDS);
   },
 };

--- a/__mocks__/obsidian.ts
+++ b/__mocks__/obsidian.ts
@@ -82,6 +82,55 @@ export function normalizePath(path: string): string {
 
 export type App = unknown;
 
+export function getLanguage(): string {
+  return "en";
+}
+
+export class Plugin {
+  readonly app: App;
+  readonly manifest: { id: string; version: string; dir?: string };
+  readonly settingTabs: PluginSettingTab[] = [];
+  readonly protocolHandlers = new Map<string, (parameters: Record<string, string>) => unknown>();
+
+  constructor(app: App, manifest: { id: string; version: string; dir?: string }) {
+    this.app = app;
+    this.manifest = manifest;
+  }
+
+  register(_callback: () => void): void {}
+
+  registerEvent(_eventRef: unknown): void {}
+
+  registerMarkdownCodeBlockProcessor(
+    _language: string,
+    _handler: (source: string, element: HTMLElement, context: MarkdownPostProcessorContext) => unknown,
+  ): void {}
+
+  addCommand<T>(command: T): T {
+    return command;
+  }
+
+  removeCommand(_id: string): void {}
+
+  registerView(_viewType: string, _viewCreator: (leaf: WorkspaceLeaf) => ItemView): void {}
+
+  addSettingTab(tab: PluginSettingTab): void {
+    this.settingTabs.push(tab);
+  }
+
+  registerObsidianProtocolHandler(action: string, handler: (parameters: Record<string, string>) => unknown): void {
+    this.protocolHandlers.set(action, handler);
+  }
+
+  loadData(): Promise<unknown> {
+    return Promise.resolve(undefined);
+  }
+
+  saveData(_data: unknown): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
 export class PluginSettingTab {
   readonly app: App;
   readonly containerEl: HTMLElement;

--- a/docs/i18n-glossary.md
+++ b/docs/i18n-glossary.md
@@ -252,12 +252,18 @@ classes still in the corpus, all from the same context-free-MT root cause:
 
 ## Coverage
 
-All eleven locales are complete at **711/711**. Every locale has had a line-by-line pass
+All eleven locales are complete at **765/765**. Every locale has had a line-by-line pass
 over every key against `en.json`, and the `decoration_breakdown_*`, `decoration_badge_*`
 and week-reanchor keys are translated everywhere.
 
 Be precise about what that pass was, because "reviewed" overstates it for nine of them:
 
+- `command_view_shelf_needs_open_view` was translated by an agent working from this file,
+  modelled on `command_open_needs_active_note` — the same speech act, so each locale reuses
+  its own rendering of "open X first" and appends the canonical shelf term. Not
+  native-verified. Worth a native eye: whether the purpose clause reads naturally after an
+  imperative in de, it and ko, and whether ko's `을(를)` particle form is acceptable in UI
+  copy where the preceding token is a variable.
 - **uk** was reviewed by a native speaker. It is the only locale where the output was
   verified by someone who reads the language.
 - The 23 `journal_sequence_*` and numbering-warning keys were translated by an agent

--- a/docs/unit-testing-strategy.md
+++ b/docs/unit-testing-strategy.md
@@ -473,12 +473,19 @@ suite fast: the import graph is paid once per worker instead of once per file.
 
 The cost is that a file can reach the next one through anything
 process-global. A test that does belongs in `*.isolated.test.ts`, which runs
-in its own registry. Two kinds are known:
+in its own registry. The list is open, not closed — isolate on the
+**mechanism**, not on whether the test also cleans up after itself.
+`calendar.isolated.test.ts` restores moment's locale in an `afterEach` and is
+still isolated. Known kinds:
 
 - `vi.mock`, whose factory replaces the module for every later file in the
   worker. This one is eslint-enforced.
 - Rewriting moment's **global** locale, which leaves the next file on a
   different week grid.
+- Switching the paraglide locale with `setLocale`, which writes a module-scope
+  variable **and** a `document.cookie` that happy-dom keeps.
+- Listening on a process global such as `process.on("unhandledRejection")`,
+  which a floating rejection from any other file in the worker can trip.
 
 The resulting flake surfaces as a nondeterministic count in a _different_ file
 than the polluting one, which is why the rule is worth following before you
@@ -489,6 +496,35 @@ happy-dom, such as `@vueuse/integrations/useSortable` and `obsidian`. Not the
 project's own modules, and never a child component: mocking a child asserts
 which component the parent renders rather than what the user sees. Reach for
 a container override instead.
+
+## Harness behavior that will mislead you
+
+Four properties of this project's test stack that are invisible in the code
+depending on them, and each of which has produced a test that could not fail.
+
+**Vue's `v-bind()` in `<style scoped>` never reaches the DOM.** The resolved
+`@vue/runtime-dom` is the CJS build, whose `useCssVars` is a hardcoded no-op —
+the real implementation ships only in the ESM bundler build. Nothing appears as
+an inline style, a custom property, or a computed value, so no assertion on a
+bound CSS value can distinguish a correct component from a broken one. Assert
+on `data-*` attributes, classes, or text instead. This is a resolve-config
+limitation rather than a fact about Vue.
+
+**`@vue/test-utils` deep-wraps every object prop in a reactive proxy.** `mount`
+copies each prop into a `reactive({})`, so a plain object literal arrives at the
+component as a `Proxy` regardless of what the caller passed. A test reasoning "I
+passed a plain object, so this path is not reactive" is wrong.
+
+**`vi.spyOn(...).mockRejectedValue(...)` is pre-handled by vitest.** The
+mock-result tracking attaches its own handler, so `unhandledRejection` never
+fires and a test asserting that a rejection is _swallowed_ passes whether or not
+the production code swallows it. Patch the prototype by hand and restore in a
+`finally` when you need a genuinely floating rejection.
+
+**`SettingsService`'s root is deeply reactive.** A plain object nested under it
+is re-wrapped on every read, so a value read back through the store is a proxy
+no matter what was written. To observe what was actually persisted, `toRaw` the
+top-level entity from the repository and navigate the raw graph from there.
 
 ## Enforcement
 

--- a/docs/unit-testing-strategy.md
+++ b/docs/unit-testing-strategy.md
@@ -170,8 +170,12 @@ a **mis-keyed** seed silent too: `calender` for `calendar` would let the test
 assert against the slice's defaults and pass with the seed ignored. The other
 cause is a correctly spelled key whose module was left out of `modules`, which
 is the same "your seed is not reaching the parse" mistake wearing a different
-hat. There is no `allow` for it: a key nothing registers is never what the test
-meant. `version` is always accepted — it is honored by the harness itself.
+hat. `allow: { legacySeedKeys: [...] }` is the one exception: `data` is consumed
+before migrations run, while the guard validates against post-migration slice
+and collection registrations, so a legacy blob's pre-migration-only keys
+(`calendar_view`, `useShelves`, …) would otherwise always throw. A key left out
+of that list still throws — naming one is not a way to disarm the guard
+wholesale. `version` is always accepted — it is honored by the harness itself.
 
 ## Mounting
 

--- a/env.d.ts
+++ b/env.d.ts
@@ -10,7 +10,7 @@ declare module "@vue/reactivity" {
 
 // Augment the obsidian module to expose the __testing registry used in unit tests.
 // The actual implementation lives in __mocks__/obsidian.ts (aliased by vitest).
-import type { AbstractInputSuggest, IconName, Modal, SuggestModal } from "obsidian";
+import type { AbstractInputSuggest, IconName, Modal, PluginSettingTab, SuggestModal } from "obsidian";
 
 declare module "obsidian" {
   // `Plugin.addRibbonIcon` has no counterpart for mid-lifetime removal, so the
@@ -24,6 +24,11 @@ declare module "obsidian" {
     readonly items: { title: string; icon: string; section: string; warning: boolean }[];
     showAtMouseEventCalls: MouseEvent[];
     pick(index: number): Promise<void>;
+  }
+
+  interface Plugin {
+    readonly settingTabs: PluginSettingTab[];
+    readonly protocolHandlers: Map<string, (parameters: Record<string, string>) => unknown>;
   }
 
   export const __testing: {

--- a/env.d.ts
+++ b/env.d.ts
@@ -36,5 +36,7 @@ declare module "obsidian" {
     readonly openMenus: readonly Menu[];
     lastOpenMenu(): Menu;
     reset(): void;
+    seedIcons(names: readonly string[]): void;
+    resetIcons(): void;
   };
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -414,6 +414,17 @@ export default [
     },
   },
   {
+    // getSettingDefinitions() needs Obsidian 1.13.0 and the manifest floor is 1.8.7, so
+    // display()/hide() stay production's only rendering path and this test exercises exactly
+    // what Obsidian invokes. Inline eslint-disable comments are banned repo-wide
+    // (eslint-comments/no-use), so the carve-out lives here instead, the same shape as the
+    // Promise.withResolvers / no-invalid-void-type carve-out.
+    files: ["src/settings/ui/plugin-setting-tab.test.ts"],
+    rules: {
+      "@typescript-eslint/no-deprecated": "off",
+    },
+  },
+  {
     files: ["src/infrastructure/logger/console-sink.ts"],
     rules: {
       // ConsoleSink is the single, intentional bridge from LogSink to the

--- a/messages/de.json
+++ b/messages/de.json
@@ -382,6 +382,7 @@
 	"command_open_previous": "Vorherige Notiz öffnen",
 	"command_open_view": "{name} öffnen",
 	"command_view_change_shelf": "Regal in {name} wechseln",
+	"command_view_shelf_needs_open_view": "Öffne zuerst {name}, um das Regal zu wählen.",
 	"shelf_picker_placeholder": "Regale durchsuchen",
 	"command_palette_journal_name": "{journal}: {name}",
 	"command_palette_shelf_name": "Regal: {shelf}: {name}",

--- a/messages/en.json
+++ b/messages/en.json
@@ -240,6 +240,7 @@
   "command_open_previous": "Open previous note",
   "command_open_view": "Open {name}",
   "command_view_change_shelf": "Change shelf in {name}",
+  "command_view_shelf_needs_open_view": "Open {name} first to choose its shelf.",
   "shelf_picker_placeholder": "Search shelves",
   "command_palette_journal_name": "{journal}: {name}",
   "command_palette_shelf_name": "Shelf: {shelf}: {name}",

--- a/messages/es.json
+++ b/messages/es.json
@@ -382,6 +382,7 @@
 	"command_open_previous": "Abrir la nota anterior",
 	"command_open_view": "Abrir {name}",
 	"command_view_change_shelf": "Cambiar estante en {name}",
+	"command_view_shelf_needs_open_view": "Abre primero {name} para elegir su estante.",
 	"shelf_picker_placeholder": "Buscar estantes",
 	"command_palette_journal_name": "{journal}: {name}",
 	"command_palette_shelf_name": "Estante: {shelf}: {name}",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -384,6 +384,7 @@
 	"command_open_previous": "Ouvrir la note précédente",
 	"command_open_view": "Ouvrir {name}",
 	"command_view_change_shelf": "Changer d’étagère dans {name}",
+	"command_view_shelf_needs_open_view": "Ouvrez d’abord {name} pour choisir son étagère.",
 	"shelf_picker_placeholder": "Rechercher une étagère",
 	"command_palette_journal_name": "{journal} : {name}",
 	"command_palette_shelf_name": "Étagère : {shelf} : {name}",

--- a/messages/it.json
+++ b/messages/it.json
@@ -382,6 +382,7 @@
 	"command_open_previous": "Apri la nota precedente",
 	"command_open_view": "Apri {name}",
 	"command_view_change_shelf": "Cambia scaffale in {name}",
+	"command_view_shelf_needs_open_view": "Apri prima {name} per scegliere il suo scaffale.",
 	"shelf_picker_placeholder": "Cerca scaffali",
 	"command_palette_journal_name": "{journal}: {name}",
 	"command_palette_shelf_name": "Scaffale: {shelf}: {name}",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -367,6 +367,7 @@
 	"command_open_previous": "前のノートを開く",
 	"command_open_view": "{name} を開く",
 	"command_view_change_shelf": "{name} の棚を変更",
+	"command_view_shelf_needs_open_view": "先に {name} を開いて、その棚を選んでください。",
 	"shelf_picker_placeholder": "棚を検索",
 	"command_palette_journal_name": "{journal}: {name}",
 	"command_palette_shelf_name": "棚: {shelf}: {name}",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -382,6 +382,7 @@
 	"command_open_previous": "이전 노트 열기",
 	"command_open_view": "{name} 열기",
 	"command_view_change_shelf": "{name}의 선반 변경",
+	"command_view_shelf_needs_open_view": "선반을 선택하려면 먼저 {name}을(를) 여세요.",
 	"shelf_picker_placeholder": "선반 검색",
 	"command_palette_journal_name": "{journal}: {name}",
 	"command_palette_shelf_name": "선반: {shelf}: {name}",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -382,6 +382,7 @@
 	"command_open_previous": "Abrir a nota anterior",
 	"command_open_view": "Abrir {name}",
 	"command_view_change_shelf": "Alterar prateleira em {name}",
+	"command_view_shelf_needs_open_view": "Abra primeiro {name} para escolher a sua prateleira.",
 	"shelf_picker_placeholder": "Pesquisar prateleiras",
 	"command_palette_journal_name": "{journal}: {name}",
 	"command_palette_shelf_name": "Prateleira: {shelf}: {name}",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -386,6 +386,7 @@
 	"command_open_previous": "Открыть предыдущую заметку",
 	"command_open_view": "Открыть {name}",
 	"command_view_change_shelf": "Изменить полку в {name}",
+	"command_view_shelf_needs_open_view": "Сначала откройте {name}, чтобы выбрать полку.",
 	"shelf_picker_placeholder": "Поиск полок",
 	"command_palette_journal_name": "{journal}: {name}",
 	"command_palette_shelf_name": "Полка: {shelf}: {name}",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -367,6 +367,7 @@
 	"command_open_previous": "Відкрити попередню нотатку",
 	"command_open_view": "Відкрити {name}",
 	"command_view_change_shelf": "Змінити полицю в {name}",
+	"command_view_shelf_needs_open_view": "Спочатку відкрийте {name}, щоб вибрати полицю.",
 	"shelf_picker_placeholder": "Пошук полиць",
 	"command_palette_journal_name": "{journal}: {name}",
 	"command_palette_shelf_name": "Полиця: {shelf}: {name}",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -367,6 +367,7 @@
 	"command_open_previous": "打开上一条笔记",
 	"command_open_view": "打开 {name}",
 	"command_view_change_shelf": "切换 {name} 中的书架",
+	"command_view_shelf_needs_open_view": "请先打开 {name} 以选择其书架。",
 	"shelf_picker_placeholder": "搜索书架",
 	"command_palette_journal_name": "{journal}：{name}",
 	"command_palette_shelf_name": "书架：{shelf}：{name}",

--- a/scripts/check-i18n-glossary.mjs
+++ b/scripts/check-i18n-glossary.mjs
@@ -302,6 +302,12 @@ function messages(locale) {
   return out;
 }
 
+/** Every message key in a messages file, ignoring the schema pointer. */
+function keys(locale) {
+  const json = JSON.parse(readFileSync(`messages/${locale}.json`, "utf8"));
+  return new Set(Object.keys(json).filter((key) => key !== "$schema"));
+}
+
 /**
  * Paraglide splits composite match keys on `,` without trimming, so a stray space
  * ("side=start, day=1") leaks into the generated input names and breaks the types.
@@ -367,13 +373,41 @@ for (const locale of locales) {
   }
 }
 
+// A key present only in `en` still compiles: paraglide silently re-exports it from
+// en.js, so the locale ships English with no warning, no type error and no failing test.
+// Every other gate passed on exactly that shape once. The corpus has always been at
+// full parity, so any divergence is a missing translation rather than a deliberate one;
+// if a key ever should stay untranslated, allowlist it here rather than dropping this.
+const BASE_LOCALE = "en";
+const baseKeys = keys(BASE_LOCALE);
+for (const locale of locales) {
+  if (locale === BASE_LOCALE) continue;
+  const localeKeys = keys(locale);
+  for (const key of baseKeys)
+    if (!localeKeys.has(key))
+      violations.push({
+        locale,
+        label: key,
+        text: "(absent)",
+        reason: `missing from ${locale}.json — paraglide would fall back to ${BASE_LOCALE} and ship English`,
+      });
+  for (const key of localeKeys)
+    if (!baseKeys.has(key))
+      violations.push({
+        locale,
+        label: key,
+        text: "(extra)",
+        reason: `not in ${BASE_LOCALE}.json — a key removed from the base leaves dead translations behind`,
+      });
+}
+
 for (const { locale, label, text, reason } of violations) console.error(`${locale} ${label}\n  ${reason}\n  ${text}`);
 
 if (violations.length > 0) {
   const byLocale = {};
   for (const { locale } of violations) byLocale[locale] = (byLocale[locale] ?? 0) + 1;
   console.error(
-    `\n${violations.length} glossary violation(s): ${Object.entries(byLocale)
+    `\n${violations.length} i18n violation(s): ${Object.entries(byLocale)
       .map(([l, n]) => `${l}=${n}`)
       .join(" ")}\nSee docs/i18n-glossary.md.`,
   );

--- a/src/api/journals-api.test.ts
+++ b/src/api/journals-api.test.ts
@@ -2,8 +2,12 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { AnchorString } from "@/calendar";
 import { Flows } from "@/infrastructure/flows";
+import { WorkspaceOpenError, WorkspaceService } from "@/infrastructure/host";
 import type { VaultPath } from "@/infrastructure/host";
+import { NoteFileService } from "@/infrastructure/host/internal/note-file-service";
+import { AsyncResult, Option } from "@/infrastructure/result";
 import type { JournalConfig } from "@/journals/config";
+import { CycleService } from "@/journals/cycle";
 import { EnsureJournalEntryFlow, OpenJournalEntryFlow } from "@/journals/flows";
 import { JournalsIndex } from "@/journals/journals-index";
 import { journalsCoreModule } from "@/journals/module";
@@ -256,6 +260,34 @@ describe("JournalsApiService writes", () => {
     await expect(api.ensureNote("past", "2026-08-18")).rejects.toMatchObject({ code: "outside-timeline" });
   });
 
+  it("maps a cycle miss to the unmappable-date code", async () => {
+    // Every name reaching this point already came from #select(), which only returns
+    // journals JournalsRepository confirms exist — and CycleService.anchorOf returns None
+    // only for a journal that does not exist, so a real config can never produce this state.
+    // The spy forces it anyway: the code string is the one thing a consumer can discriminate
+    // on across the published boundary, and the open `(string & {})` union means a misspelled
+    // literal here still type-checks. This test exists purely to catch that typo, not to
+    // exercise a reachable user path.
+    const { api, harness } = await buildApi({
+      past: fixedJournal(
+        "past",
+        { type: "day" },
+        {
+          timeline: {
+            start: "2020-01-01" as AnchorString,
+            end: { kind: "date", date: "2020-12-31" as AnchorString },
+          },
+        },
+      ),
+    });
+    // Must persist (not *Once*): #resolveOne calls anchorOf twice for this selector — once in
+    // #eligible, once in the mappable fallback — and a one-shot mock would let the second call
+    // fall through to the real implementation, flipping the verdict to outside-timeline.
+    vi.spyOn(harness.resolve(CycleService), "anchorOf").mockReturnValue(Option.none());
+
+    await expect(api.ensureNote("past", "2026-08-18")).rejects.toMatchObject({ code: "unmappable-date" });
+  });
+
   it("still reaches a note that exists outside the timeline", async () => {
     const { api, index, harness } = await buildApi({
       past: fixedJournal(
@@ -280,6 +312,31 @@ describe("JournalsApiService writes", () => {
 
     expect(result.note.path).toBe("Past/2026-08-18.md");
     expect(result.created).toBe(false);
+  });
+
+  it("reports open-failed when the workspace refuses to open the note", async () => {
+    const { api, harness } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    vi.spyOn(harness.resolve(WorkspaceService), "openNote").mockReturnValueOnce(
+      AsyncResult.err(new WorkspaceOpenError("2026-08-18.md" as VaultPath, new Error("no such view"))),
+    );
+
+    await expect(api.openNote("daily", "2026-08-18")).rejects.toMatchObject({ code: "open-failed" });
+  });
+
+  it("reports creation-failed when the written note cannot be read back", async () => {
+    const { api, harness } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    vi.spyOn(harness.resolve(NoteFileService), "resolve").mockReturnValueOnce(null);
+
+    await expect(api.ensureNote("daily", "2026-08-18")).rejects.toMatchObject({ code: "creation-failed" });
+  });
+
+  it("falls back to creation-failed for a flow failure that is neither aborted nor open-failed", async () => {
+    const { api, flows } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    // #toApiError has a second, independent site producing this same code string — its
+    // catch-all for a cause that is neither UserAborted nor WorkspaceOpenError.
+    flows.mockReturnValueOnce(AsyncResult.err(new Error("boom")));
+
+    await expect(api.ensureNote("daily", "2026-08-18")).rejects.toMatchObject({ code: "creation-failed" });
   });
 
   it("shows the picker when several journals match, and uses the choice", async () => {

--- a/src/code-blocks/nav/settings/ui/EditNavBlockSegmentModal.test.ts
+++ b/src/code-blocks/nav/settings/ui/EditNavBlockSegmentModal.test.ts
@@ -2,6 +2,7 @@ import userEvent from "@testing-library/user-event";
 import { screen, waitFor } from "@testing-library/vue";
 import { describe, expect, it } from "vitest";
 
+import type { AnchorString } from "@/calendar";
 import { m } from "@/i18n";
 import type { JournalConfig, NavBlockSegment } from "@/journals";
 import { journalsCoreModule } from "@/journals/module";
@@ -25,9 +26,11 @@ async function mountModal(options: {
       ...(options.shelves && { shelves: options.shelves }),
     },
   });
-  return harness.renderModal<typeof EditNavBlockSegmentModal, { segment: NavBlockSegment }>(EditNavBlockSegmentModal, {
-    props: { journalName: "daily", segment: options.segment },
-  });
+  const rendered = harness.renderModal<typeof EditNavBlockSegmentModal, { segment: NavBlockSegment }>(
+    EditNavBlockSegmentModal,
+    { props: { journalName: "daily", segment: options.segment } },
+  );
+  return { harness, ...rendered };
 }
 
 describe("EditNavBlockSegmentModal", () => {
@@ -164,5 +167,34 @@ describe("EditNavBlockSegmentModal", () => {
       expect(submit).toHaveBeenCalledTimes(1);
     });
     expect(submit.mock.calls[0]?.[0]).toMatchObject({ segment: { linkDate: "+1q" } });
+  });
+});
+
+describe("EditNavBlockSegmentModal numbering variables", () => {
+  it("passes the journal's numbering variable names to the variable reference modal", async () => {
+    const { harness } = await mountModal({
+      journals: {
+        daily: fixedJournal(
+          "daily",
+          { type: "day" },
+          {
+            numbering: {
+              enabled: true,
+              anchorDate: "2024-01-01" as AnchorString,
+              allowBefore: false,
+              sources: [
+                { variable: "index", frontmatterKey: "journal-index", anchorValue: 1, reset: { kind: "never" } },
+              ],
+            },
+          },
+        ),
+      },
+    });
+
+    await userEvent.click(screen.getByText(m.journal_edit_variable_reference_link()));
+
+    expect(
+      harness.modals.lastOpen<{ numberingVariableNames: readonly string[] }>().props.numberingVariableNames,
+    ).toEqual(["index"]);
   });
 });

--- a/src/code-blocks/nav/settings/ui/use-shelf-mate-journals.test.ts
+++ b/src/code-blocks/nav/settings/ui/use-shelf-mate-journals.test.ts
@@ -56,4 +56,12 @@ describe("useShelfMateJournals", () => {
     const get = await mount("daily");
     expect(get()).toEqual([]);
   });
+
+  it("returns only the first shelf's mates when the journal belongs to two shelves", async () => {
+    const get = await mount("daily", {
+      home: buildShelf("home", { journals: ["daily", "weekly"] }),
+      work: buildShelf("work", { journals: ["daily", "other"] }),
+    });
+    expect(get()).toEqual(["weekly"]);
+  });
 });

--- a/src/code-blocks/nav/ui/NavigationCodeBlock.test.ts
+++ b/src/code-blocks/nav/ui/NavigationCodeBlock.test.ts
@@ -193,6 +193,22 @@ describe("NavigationCodeBlock columns", () => {
   });
 });
 
+describe("NavigationCodeBlock adjacent periods in 'existing' mode", () => {
+  it("shows the previous period once the index registers its entry after mount", async () => {
+    const { index } = await renderNav("Daily/2026-05-27.md", {
+      journals: { daily: dailyWithNavBlock({ type: "existing" }) },
+      shelves: { main: buildShelf("main", { journals: ["daily"] }) },
+      entries: [journalEntry("daily", "2026-05-27", "Daily/2026-05-27.md")],
+    });
+    expect(screen.queryByText("26")).toBeNull();
+
+    index.register(journalEntry("daily", "2026-05-26", "Daily/2026-05-26.md"));
+    await nextTick();
+
+    expect(screen.getByText("26")).toBeTruthy();
+  });
+});
+
 describe("NavigationCodeBlock segment templates", () => {
   it("renders note_name as the connected note's own name, and as the prospective name where no note exists", async () => {
     await renderNav("Daily/Renamed day.md", {

--- a/src/code-blocks/timeline/ui/TimelineCodeBlock.test.ts
+++ b/src/code-blocks/timeline/ui/TimelineCodeBlock.test.ts
@@ -2,7 +2,7 @@ import { fireEvent } from "@testing-library/vue";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { nextTick } from "vue";
 
-import { CalendarDate, type AnchorString } from "@/calendar";
+import { CalendarDate, type AnchorString, type WeekPlacement } from "@/calendar";
 import { calendarSettingsCoreModule } from "@/calendar/settings/module";
 import { anchor } from "@/calendar/testing";
 import { decorationsModule } from "@/decorations/module";
@@ -38,6 +38,7 @@ interface TimelineScenario {
   readonly shelves?: Record<string, ShelfConfig>;
   readonly entries?: readonly JournalEntry[];
   readonly timelineNavigation?: boolean;
+  readonly weekPlacement?: WeekPlacement;
 }
 
 function journalEntry(journalName: string, anchorDate: string): JournalEntry {
@@ -50,7 +51,10 @@ async function renderTimeline(config: TimelineBlockConfig, scenario: TimelineSce
     data: {
       journals: scenario.journals,
       shelves: scenario.shelves ?? {},
-      calendarDisplay: { timelineNavigation: scenario.timelineNavigation ?? false },
+      calendarDisplay: {
+        timelineNavigation: scenario.timelineNavigation ?? false,
+        ...(scenario.weekPlacement !== undefined && { weekPlacement: scenario.weekPlacement }),
+      },
     },
   });
   const index = harness.resolve(JournalsIndex);
@@ -240,6 +244,15 @@ describe("TimelineCodeBlock", () => {
 
     it("positions the week-view week column right when config.weeks is right", async () => {
       const { container } = await renderDaily({ mode: "week", weeks: "right" });
+
+      const row = container.querySelector<HTMLElement>(".notes-week-view__row");
+      expect(row?.dataset.weeks).toBe("right");
+    });
+  });
+
+  describe("global week placement", () => {
+    it("uses the calendar display setting's placement when config.weeks is unset", async () => {
+      const { container } = await renderDaily({ mode: "week" }, { weekPlacement: "right" });
 
       const row = container.querySelector<HTMLElement>(".notes-week-view__row");
       expect(row?.dataset.weeks).toBe("right");

--- a/src/commands/repository.ts
+++ b/src/commands/repository.ts
@@ -17,12 +17,15 @@ export class CommandsRepository extends BaseRepository<
   RepositoryQuery<string, CommandConfig>,
   CommandsEvents
 > {
+  // A command is keyed by an id the config itself does not carry.
   protected idKey: keyof CommandConfig | undefined = undefined;
   protected nameKey: keyof CommandConfig = "name";
   protected QueryConstructor = RepositoryQuery;
   protected storage = inject(SettingsService).recordOf(commandCollection);
   protected events = inject(CommandsEventsToken);
   protected unknownEntityError = (id: string) => new UnknownCommandError(id);
+  // Unreachable: with no idKey, BaseRepository's id-change guard short-circuits and never
+  // calls this. It stays because BaseRepository declares it abstract.
   protected invalidUpdateError = (id: string) => new InvalidCommandUpdateError(id);
 
   create(id: string, init: CommandConfig): Result<CommandConfig, CommandIdTakenError> {

--- a/src/decorations/match-service.test.ts
+++ b/src/decorations/match-service.test.ts
@@ -206,10 +206,11 @@ describe("DecorationMatchService", () => {
     });
 
     it("reports silent rather than no notes for a date-only decoration over a note-free window", async () => {
-      // The one test that pins needsNotes into the service: a decoration that never needs a
-      // note must report "silent" over a note-free window, not "no-notes". An implementation
-      // that reports "no-notes" for any note-free window regardless of the decoration would
-      // pass every other evidence test but fail this one.
+      // The counterpart to the has-note tests above and the note-size tests below, which pin needsNotes
+      // returning true: a decoration that never needs a note must report "silent" over a
+      // note-free window, not "no-notes". An implementation that reports "no-notes" for any
+      // note-free window regardless of the decoration would pass every other evidence test but
+      // fail this one.
       const decoration = neverMatches();
       const harness = await buildHarness({
         daily: fixedJournal("daily", { type: "day" }, { decorations: [decoration] }),

--- a/src/decorations/settings/ui/ConditionItem.test.ts
+++ b/src/decorations/settings/ui/ConditionItem.test.ts
@@ -1,3 +1,4 @@
+import userEvent from "@testing-library/user-event";
 import { screen } from "@testing-library/vue";
 import { toTypedSchema } from "@vee-validate/valibot";
 import * as v from "valibot";
@@ -7,12 +8,12 @@ import { defineComponent, h } from "vue";
 
 import { decorationConditionSchema, type JournalDecorationCondition } from "@/decorations";
 import { m } from "@/i18n";
-import { testContainer } from "@/testing";
+import { testContainer, type TestHarness } from "@/testing";
 
 import ConditionItem from "./ConditionItem.vue";
 
-async function mount(initial: JournalDecorationCondition) {
-  const harness = await testContainer();
+async function mount(initial: JournalDecorationCondition, harness?: TestHarness) {
+  const resolvedHarness = harness ?? (await testContainer());
   const renderHost = () => h(ConditionItem, { name: "c", condition: initial });
   const Host = defineComponent({
     setup() {
@@ -23,7 +24,7 @@ async function mount(initial: JournalDecorationCondition) {
       return renderHost;
     },
   });
-  harness.render(Host);
+  resolvedHarness.render(Host);
 }
 
 describe("ConditionItem", () => {
@@ -75,5 +76,16 @@ describe("ConditionItem", () => {
   it("renders ConditionTypeOnly for all-tasks-completed", async () => {
     await mount({ type: "all-tasks-completed" });
     expect(screen.getByText(m.decoration_condition_all_tasks_completed_describe())).toBeTruthy();
+  });
+
+  it("derives a property condition's number value type from the vault's registered type", async () => {
+    const harness = await testContainer();
+    harness.host.setPropertyType("rating", "number");
+    await mount({ type: "property", name: "", valueType: "text", condition: "exists", value: "" }, harness);
+
+    await userEvent.type(screen.getAllByRole("textbox")[0], "rating");
+    await userEvent.selectOptions(screen.getByRole("combobox"), m.decoration_string_op_label({ op: "eq" }));
+
+    expect(screen.getByRole("spinbutton")).toBeTruthy();
   });
 });

--- a/src/decorations/settings/ui/DecorationsSection.test.ts
+++ b/src/decorations/settings/ui/DecorationsSection.test.ts
@@ -94,6 +94,25 @@ describe("DecorationsSection", () => {
     expect(screen.getByText(m.decoration_condition_has_note_describe())).toBeTruthy();
   });
 
+  it("lists only the journal's own decorations when a shelf the journal is not on also has some", async () => {
+    // mount() above seeds one owner's bucket at a time, which cannot tell a scoped lookup from
+    // an additive one when the other buckets are empty. Populating both is what a substitution
+    // (reading the wrong bucket) and a leak (reading every bucket) would actually diverge on.
+    const harness = await testContainer({
+      modules: [journalsCoreModule, shelvesCoreModule, decorationsModule, decorationsSettingsCoreModule],
+      data: {
+        journals: { daily: fixedJournal("daily", { type: "day" }, { decorations: [sampleDecoration] }) },
+        shelves: { work: buildShelf("work", { decorations: [sampleCalendarDecoration] }) },
+        decorations: { decorations: [] },
+      },
+    });
+    vi.spyOn(harness.resolve(Flows), "invoke").mockReturnValue(AsyncResult.ok(undefined));
+    harness.render(DecorationsSection, { props: { owner: { kind: "journal", journalName: "daily" } } });
+    await userEvent.click(screen.getByText(m.decoration_section_title_journal()));
+
+    expect(screen.getAllByLabelText(m.decoration_edit())).toHaveLength(1);
+  });
+
   it("renders a preview swatch for each decoration", async () => {
     await mount({ kind: "journal", journalName: "daily" }, [sampleDecoration]);
     await userEvent.click(screen.getByText(m.decoration_section_title_journal()));

--- a/src/decorations/ui/CellDecoration.test.ts
+++ b/src/decorations/ui/CellDecoration.test.ts
@@ -1,6 +1,6 @@
 import { render } from "@testing-library/vue";
 import { describe, expect, it } from "vitest";
-import { defineComponent, h, provide, shallowRef } from "vue";
+import { defineComponent, h, provide, reactive, shallowRef } from "vue";
 
 import { DayPeriod } from "@/calendar";
 import { date } from "@/calendar/testing";
@@ -52,5 +52,13 @@ describe("CellDecoration", () => {
     const { container } = render(makeHost(period, cells));
     expect(container.querySelector(".decoration-corner")).toBeNull();
     expect(container.querySelector(".shape-decoration")).toBeNull();
+  });
+
+  it("renders when the period prop arrives as a reactive proxy", () => {
+    // A caller that stores its periods in a reactive array (rather than a shallowRef) hands
+    // this component a reactive-wrapped Period. cells is null here (no provide), so `cells?.get(...)`
+    // never evaluates its argument — the only reason a reactive CalendarDate never reaches `.toAnchor()`.
+    const period = reactive(DayPeriod.containing(date("2026-05-25")));
+    expect(() => render(CellDecoration, { props: { period } })).not.toThrow();
   });
 });

--- a/src/decorations/use-cell-decorations.test.ts
+++ b/src/decorations/use-cell-decorations.test.ts
@@ -326,6 +326,44 @@ describe("useCellDecorations", () => {
       expect(daySlot.value).toHaveLength(0);
     });
 
+    it("routes a metadata-changed repaint on the weekly note to the week cell despite the anchor collision", async () => {
+      const decoration = buildDecoration({
+        mode: "or",
+        conditions: [buildCondition("has-note")],
+        styles: [buildStyle("background")],
+      });
+      const { harness } = await buildWeeklyHarness([decoration]);
+      const weekPeriod = WeekPeriod.containing(date("2026-06-10"));
+      const weekAnchor = weekPeriod.anchor.toAnchor();
+      const dayPeriods = [...weekPeriod.days()].map((d) => DayPeriod.containing(d));
+      const collidingDay = dayPeriods.find((d) => d.anchor.toAnchor() === weekAnchor);
+      expect(collidingDay).toBeDefined();
+
+      const weeklyPath = "Weekly/2026-W24.md" as VaultPath;
+      // Registered before mount, so the initial scope build (not the entryChanged handler) is
+      // what maps this path back to a cell key.
+      harness.resolve(JournalsIndex).register({ journalName: "weekly", anchor: weekAnchor, path: weeklyPath });
+
+      const { captured } = mount(harness, () =>
+        useCellDecorations({
+          periods: () => [weekPeriod, ...dayPeriods],
+          journalNames: () => ["daily", "weekly"],
+        }),
+      );
+      await nextTick();
+      const weekSlot = captured.value!.get(cellKey("week", weekAnchor))!;
+      const daySlot = captured.value!.get(key(collidingDay!))!;
+      expect(weekSlot.value).toHaveLength(0);
+      expect(daySlot.value).toHaveLength(0);
+
+      harness.host.putFile(weeklyPath);
+      harness.host.emitMetadata(weeklyPath);
+      await nextTick();
+
+      expect(weekSlot.value).toHaveLength(1);
+      expect(daySlot.value).toHaveLength(0);
+    });
+
     it("recomputes a renamed cell on the next resolved when the rename re-keyed it before the cache caught up", async () => {
       const decoration = buildDecoration({
         mode: "or",

--- a/src/i18n/format-list.isolated.test.ts
+++ b/src/i18n/format-list.isolated.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { formatConjunction } from "./format-list";
+import { baseLocale, setLocale } from "./paraglide/runtime.js";
+
+afterEach(() => {
+  void setLocale(baseLocale, { reload: false });
+});
+
+describe("formatConjunction", () => {
+  it("returns the single item unchanged", () => {
+    expect(formatConjunction(["Daily"])).toBe("Daily");
+  });
+
+  it("joins two items without a serial separator comma", () => {
+    expect(formatConjunction(["Daily", "Weekly"])).toBe("Daily and Weekly");
+  });
+
+  it("joins three items with a serial separator", () => {
+    expect(formatConjunction(["Daily", "Weekly", "Monthly"])).toBe("Daily, Weekly, and Monthly");
+  });
+
+  it("returns an empty string for an empty list", () => {
+    expect(formatConjunction([])).toBe("");
+  });
+
+  it("changes the separator when the active locale changes", () => {
+    void setLocale("de", { reload: false });
+
+    expect(formatConjunction(["Daily", "Weekly"])).toBe("Daily und Weekly");
+  });
+});

--- a/src/infrastructure/flows/flows.test.ts
+++ b/src/infrastructure/flows/flows.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { Container } from "@/infrastructure/di";
 import { NoticeService } from "@/infrastructure/host";
 import { FakeNoticeService } from "@/infrastructure/host/testing";
+import { LogLevelGate, LogLevelGateToken } from "@/infrastructure/logger/log-level-gate";
 import { createLoggerTestingModule, type MemorySink } from "@/infrastructure/logger/testing";
 import { AsyncResult } from "@/infrastructure/result";
 import { expectErr, expectOk } from "@/infrastructure/result/testing";
@@ -73,6 +74,9 @@ function buildContainer(): { c: Container; sink: MemorySink; notices: FakeNotice
   const notices = new FakeNoticeService();
   const c = new Container();
   c.addModule(module);
+  // This suite asserts the level Flows logs at, including "info", which the testing module's
+  // production-matching "warn" default would filter before it reaches the sink.
+  c.override(LogLevelGateToken).useValue(new LogLevelGate("debug"));
   c.register(NoticeService).useValue(notices);
   c.register(Flows).useClass(Flows);
   return { c, sink, notices };

--- a/src/infrastructure/logger/testing.test.ts
+++ b/src/infrastructure/logger/testing.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { Container } from "@/infrastructure/di";
+
+import { LoggerFactoryToken } from "./factory";
+import { LogLevelGate, LogLevelGateToken } from "./log-level-gate";
+import { createLoggerTestingModule } from "./testing";
+
+describe("createLoggerTestingModule", () => {
+  it("defaults the gate to production's warn threshold", () => {
+    const { module, sink } = createLoggerTestingModule();
+    const c = new Container();
+    c.addModule(module);
+    const logger = c.resolve(LoggerFactoryToken).named("svc");
+
+    logger.debug("debug message");
+    logger.info("info message");
+    logger.warn("warn message");
+
+    expect(sink.records.map((record) => record.level)).toEqual(["warn"]);
+  });
+
+  it("filters a record below a seeded narrower level", () => {
+    const { module, sink } = createLoggerTestingModule();
+    const c = new Container();
+    c.addModule(module);
+    c.override(LogLevelGateToken).useValue(new LogLevelGate("error"));
+    const logger = c.resolve(LoggerFactoryToken).named("svc");
+
+    logger.warn("warn message");
+    logger.error("error message");
+
+    expect(sink.records.map((record) => record.level)).toEqual(["error"]);
+  });
+});

--- a/src/infrastructure/logger/testing.ts
+++ b/src/infrastructure/logger/testing.ts
@@ -1,5 +1,6 @@
 import type { Module } from "@/infrastructure/di";
 
+import { BufferSink, BufferSinkToken } from "./buffer-sink";
 import { LoggerFactory, LoggerFactoryToken } from "./factory";
 import { LogLevelGate, LogLevelGateToken } from "./log-level-gate";
 import { LogSinkMultiToken, type LogRecord, type LogSink } from "./types";
@@ -18,6 +19,7 @@ export function createLoggerTestingModule(): { module: Module; sink: MemorySink 
     register(c) {
       c.register(LogSinkMultiToken).useValue(sink);
       c.register(LogLevelGateToken).useValue(new LogLevelGate("debug"));
+      c.register(BufferSinkToken).useClass(BufferSink);
       c.register(LoggerFactoryToken).useClass(LoggerFactory);
     },
   };

--- a/src/infrastructure/logger/testing.ts
+++ b/src/infrastructure/logger/testing.ts
@@ -18,7 +18,7 @@ export function createLoggerTestingModule(): { module: Module; sink: MemorySink 
   const module: Module = {
     register(c) {
       c.register(LogSinkMultiToken).useValue(sink);
-      c.register(LogLevelGateToken).useValue(new LogLevelGate("debug"));
+      c.register(LogLevelGateToken).useClass(LogLevelGate);
       c.register(BufferSinkToken).useClass(BufferSink);
       c.register(LoggerFactoryToken).useClass(LoggerFactory);
     },

--- a/src/journals/notes/ui/ConfirmCreationModal.test.ts
+++ b/src/journals/notes/ui/ConfirmCreationModal.test.ts
@@ -1,0 +1,36 @@
+import userEvent from "@testing-library/user-event";
+import { screen } from "@testing-library/vue";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { m } from "@/i18n";
+import { testContainer, type TestHarness } from "@/testing";
+
+import ConfirmCreationModal from "./ConfirmCreationModal.vue";
+
+describe("ConfirmCreationModal", () => {
+  let harness: TestHarness;
+
+  beforeEach(async () => {
+    harness = await testContainer();
+  });
+
+  it("submits true when the user confirms", async () => {
+    const { submit } = harness.renderModal(ConfirmCreationModal, {
+      props: { journalName: "daily", noteName: "2026-08-27" },
+    });
+
+    await userEvent.click(screen.getByText(m.confirm_note_creation_confirm()));
+
+    expect(submit).toHaveBeenCalledWith(true);
+  });
+
+  it("cancels when the user clicks Cancel", async () => {
+    const { cancel } = harness.renderModal(ConfirmCreationModal, {
+      props: { journalName: "daily", noteName: "2026-08-27" },
+    });
+
+    await userEvent.click(screen.getByText(m.common_action_cancel()));
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/logging/flows/dump-logs.flow.test.ts
+++ b/src/logging/flows/dump-logs.flow.test.ts
@@ -1,10 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { m } from "@/i18n";
-import type { Module } from "@/infrastructure/di";
 import { NoteCreateError, NotesService } from "@/infrastructure/host";
 import type { VaultPath } from "@/infrastructure/host";
-import { BufferSink, BufferSinkToken } from "@/infrastructure/logger";
+import { BufferSinkToken } from "@/infrastructure/logger";
 import type { LogRecord } from "@/infrastructure/logger";
 import { AsyncResult } from "@/infrastructure/result";
 import { expectErr, expectOk } from "@/infrastructure/result/testing";
@@ -18,16 +17,8 @@ const record: LogRecord = { timestamp: Date.parse("2026-06-04T12:30:00Z"), level
 
 const NAME = /^journal-log-\d{8}-\d{6}\.md$/;
 
-function bufferSinkModule(): Module {
-  return {
-    register(c) {
-      c.register(BufferSinkToken).useClass(BufferSink);
-    },
-  };
-}
-
 async function build(records: readonly LogRecord[]): Promise<TestHarness> {
-  const harness = await testContainer({ modules: [loggingCoreModule, bufferSinkModule()] });
+  const harness = await testContainer({ modules: [loggingCoreModule] });
   const buffer = harness.resolve(BufferSinkToken);
   for (const r of records) buffer.write(r);
   return harness;
@@ -70,6 +61,13 @@ describe("DumpLogsFlow", () => {
       const harness = await build([]);
       await harness.resolve(DumpLogsFlow).execute();
       expect(harness.notices.messages).toContain(m.logging_dump_empty());
+    });
+  });
+
+  describe("resolution", () => {
+    it("resolves through the logger testing module alone, with no hand-supplied BufferSinkToken", async () => {
+      const harness = await testContainer({ modules: [loggingCoreModule] });
+      expect(() => harness.resolve(DumpLogsFlow)).not.toThrow();
     });
   });
 

--- a/src/main.isolated.test.ts
+++ b/src/main.isolated.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { Container } from "@/infrastructure/di";
+import { createFakeHost } from "@/infrastructure/host/internal/testing";
+
+import JournalPlugin from "./main";
+
+import type { PluginManifest } from "obsidian";
+
+// tsconfig.app.json has no "node" types; the test process itself always has this.
+declare const process: {
+  on(event: "unhandledRejection", handler: (reason: unknown) => void): void;
+  off(event: "unhandledRejection", handler: (reason: unknown) => void): void;
+};
+
+const MANIFEST = { id: "journal", name: "Journal", author: "test", version: "3.0.0" } as unknown as PluginManifest;
+
+function buildPlugin(): JournalPlugin {
+  return new JournalPlugin(createFakeHost().app, MANIFEST);
+}
+
+describe("JournalPlugin", () => {
+  it("swallows a disposal failure on unload rather than letting it escape as an unhandled rejection", async () => {
+    const plugin = buildPlugin();
+    await plugin.onload();
+    // A manual prototype patch, not `vi.spyOn` — vitest's own mock wrapper attaches its own
+    // then/catch to any promise a mock returns (to populate `mock.results`), which marks the
+    // promise as handled before production code ever gets a chance to. That makes a spied
+    // `dispose()` unable to prove anything about `main.ts`'s own `.catch()`: both its presence
+    // and its absence read as "no unhandled rejection" once vitest's tracking is in the chain.
+    const originalDispose = Container.prototype.dispose;
+    Container.prototype.dispose = () => Promise.reject(new Error("dispose boom"));
+    const rejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown): void => {
+      rejections.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandledRejection);
+
+    try {
+      plugin.onunload();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(rejections).toEqual([]);
+    } finally {
+      Container.prototype.dispose = originalDispose;
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+  });
+});

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,0 +1,110 @@
+import * as obsidian from "obsidian";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { JournalsApi } from "@/api";
+import { m } from "@/i18n";
+import { Container, createToken, type Module } from "@/infrastructure/di";
+import { createFakeHost } from "@/infrastructure/host/internal/testing";
+import { VaultSubscriptionService } from "@/journals/vault-subscription";
+
+import JournalPlugin from "./main";
+
+import type { PluginManifest } from "obsidian";
+
+const MANIFEST = { id: "journal", name: "Journal", author: "test", version: "3.0.0" } as unknown as PluginManifest;
+
+function buildPlugin(): JournalPlugin {
+  return new JournalPlugin(createFakeHost().app, MANIFEST);
+}
+
+const apiOrderingProbeToken = createToken<void>("main.test.api-ordering-probe");
+
+// A module registered into main.ts's own container, not into a testContainer harness — main.ts
+// builds its container internally with no seam to hand one in, so the only way to observe
+// something happening *during* its `autoLoad()` is to splice a module in from outside at the
+// moment `autoLoad()` runs, via the one call main.ts makes on the shared `Container` class.
+function apiOrderingProbeModule(plugin: JournalPlugin, seen: (JournalsApi | undefined)[]): Module {
+  return {
+    register(c) {
+      c.register(apiOrderingProbeToken)
+        .useFactory(() => {
+          seen.push(plugin.api);
+        })
+        .eager();
+    },
+  };
+}
+
+describe("JournalPlugin", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("exposes the api before autoLoad runs, so an early consumer reads 'not ready' not 'not installed'", async () => {
+    const plugin = buildPlugin();
+    const seen: (JournalsApi | undefined)[] = [];
+    const originalAutoLoad = Container.prototype.autoLoad;
+    vi.spyOn(Container.prototype, "autoLoad").mockImplementation(function (this: Container) {
+      this.addModule(apiOrderingProbeModule(plugin, seen));
+      return originalAutoLoad.call(this);
+    });
+
+    await plugin.onload();
+
+    expect(seen.at(0)).toBeDefined();
+  });
+
+  it("notices and disposes without initializing anything else when settings fail to load", async () => {
+    const plugin = buildPlugin();
+    vi.spyOn(plugin, "loadData").mockRejectedValue(new Error("data.json is not valid JSON"));
+    const noticeSpy = vi.spyOn(obsidian, "Notice");
+    const disposeSpy = vi.spyOn(Container.prototype, "dispose");
+    const initializeSpy = vi.spyOn(VaultSubscriptionService.prototype, "initialize");
+
+    await plugin.onload();
+
+    expect(noticeSpy).toHaveBeenCalledWith(m.settings_load_failed({ error: "Failed to load plugin settings" }));
+    expect(disposeSpy).toHaveBeenCalledOnce();
+    expect(initializeSpy).not.toHaveBeenCalled();
+    expect(plugin.api).toBeUndefined();
+  });
+
+  describe("onExternalSettingsChange", () => {
+    it("returns early when the container is unset", () => {
+      const plugin = buildPlugin();
+      const noticeSpy = vi.spyOn(obsidian, "Notice");
+
+      expect(() => plugin.onExternalSettingsChange()).not.toThrow();
+      expect(noticeSpy).not.toHaveBeenCalled();
+    });
+
+    it("notices when a reload triggered after boot fails", async () => {
+      const plugin = buildPlugin();
+      await plugin.onload();
+      vi.spyOn(plugin, "loadData").mockRejectedValueOnce(new Error("data.json vanished"));
+      const noticeSpy = vi.spyOn(obsidian, "Notice");
+
+      plugin.onExternalSettingsChange();
+
+      await vi.waitFor(() => {
+        expect(noticeSpy).toHaveBeenCalledWith(m.settings_reload_failed({ error: "Failed to load plugin settings" }));
+      });
+    });
+  });
+
+  it("clears the api and disposes the container on unload", async () => {
+    const plugin = buildPlugin();
+    await plugin.onload();
+    expect(plugin.api).toBeDefined();
+    const disposeSpy = vi.spyOn(Container.prototype, "dispose");
+
+    plugin.onunload();
+
+    expect(plugin.api).toBeUndefined();
+    expect(disposeSpy).toHaveBeenCalledOnce();
+  });
+
+  // The disposal-failure-swallow test lives in main.isolated.test.ts: it listens on the
+  // process-global "unhandledRejection" event, which the shared, isolate:false unit-suite
+  // project would let a floating rejection from another file in the same worker reach.
+});

--- a/src/maintenance/checks/rejected-anchor.test.ts
+++ b/src/maintenance/checks/rejected-anchor.test.ts
@@ -1,43 +1,29 @@
 import { describe, expect, it } from "vitest";
 
 import { anchor } from "@/calendar/testing";
-import type { VaultPath } from "@/infrastructure/host";
+
+import { buildScannedNote } from "../testing";
 
 import { checkRejectedAnchor } from "./rejected-anchor";
-
-import type { ScannedNote } from "../scanned-note";
-
-function note(overrides: Partial<ScannedNote>): ScannedNote {
-  return {
-    path: "W03.md" as VaultPath,
-    claimedJournal: "weekly",
-    journalExists: true,
-    isDayJournal: false,
-    size: 0,
-    mtime: 0,
-    rawDate: "2026-01-14",
-    ...overrides,
-  };
-}
 
 describe("checkRejectedAnchor", () => {
   it("passes a note whose stored date is already the period's anchor", () => {
     const result = checkRejectedAnchor(
-      note({ storedAnchor: anchor("2026-01-12"), canonicalAnchor: anchor("2026-01-12") }),
+      buildScannedNote({ storedAnchor: anchor("2026-01-12"), canonicalAnchor: anchor("2026-01-12") }),
     );
 
     expect(result).toBeUndefined();
   });
 
   it("passes a note claiming a journal that no longer exists", () => {
-    const result = checkRejectedAnchor(note({ journalExists: false, rawDate: undefined }));
+    const result = checkRejectedAnchor(buildScannedNote({ journalExists: false, rawDate: undefined }));
 
     expect(result).toBeUndefined();
   });
 
   it("repairs to the path's anchor when path and date agree", () => {
     const result = checkRejectedAnchor(
-      note({
+      buildScannedNote({
         storedAnchor: anchor("2026-01-14"),
         canonicalAnchor: anchor("2026-01-12"),
         pathAnchor: anchor("2026-01-12"),
@@ -50,7 +36,7 @@ describe("checkRejectedAnchor", () => {
 
   it("repairs to the date's own period when the path does not invert", () => {
     const result = checkRejectedAnchor(
-      note({ storedAnchor: anchor("2026-01-14"), canonicalAnchor: anchor("2026-01-12") }),
+      buildScannedNote({ storedAnchor: anchor("2026-01-14"), canonicalAnchor: anchor("2026-01-12") }),
     );
 
     expect(result?.repair).toEqual({ kind: "rewrite", anchor: anchor("2026-01-12") });
@@ -59,7 +45,7 @@ describe("checkRejectedAnchor", () => {
 
   it("refuses to repair when the path and the date name different periods", () => {
     const result = checkRejectedAnchor(
-      note({
+      buildScannedNote({
         storedAnchor: anchor("2026-01-21"),
         canonicalAnchor: anchor("2026-01-19"),
         pathAnchor: anchor("2026-01-12"),
@@ -75,14 +61,23 @@ describe("checkRejectedAnchor", () => {
   });
 
   it("repairs from the path when the date field holds nothing readable", () => {
-    const result = checkRejectedAnchor(note({ rawDate: "[[2026-01-12]]", pathAnchor: anchor("2026-01-12") }));
+    const result = checkRejectedAnchor(
+      buildScannedNote({
+        storedAnchor: undefined,
+        canonicalAnchor: undefined,
+        rawDate: "[[2026-01-12]]",
+        pathAnchor: anchor("2026-01-12"),
+      }),
+    );
 
     expect(result?.repair).toEqual({ kind: "rewrite", anchor: anchor("2026-01-12") });
     expect(result?.detail).toEqual({ kind: "no-usable-date", raw: "[[2026-01-12]]", to: anchor("2026-01-12") });
   });
 
   it("gives up when neither the path nor the date yields an anchor", () => {
-    const result = checkRejectedAnchor(note({ rawDate: undefined }));
+    const result = checkRejectedAnchor(
+      buildScannedNote({ storedAnchor: undefined, canonicalAnchor: undefined, rawDate: undefined }),
+    );
 
     expect(result?.repair).toEqual({ kind: "undecidable", reason: "path-not-invertible" });
     expect(result?.detail).toEqual({ kind: "unreadable", raw: undefined });

--- a/src/maintenance/checks/stale-range.test.ts
+++ b/src/maintenance/checks/stale-range.test.ts
@@ -1,50 +1,33 @@
 import { describe, expect, it } from "vitest";
 
 import { anchor } from "@/calendar/testing";
-import type { VaultPath } from "@/infrastructure/host";
+
+import { buildScannedNote } from "../testing";
 
 import { checkStaleRange } from "./stale-range";
 
-import type { ScannedNote } from "../scanned-note";
-
-function note(overrides: Partial<ScannedNote>): ScannedNote {
-  return {
-    path: "W03.md" as VaultPath,
-    claimedJournal: "weekly",
-    journalExists: true,
-    isDayJournal: false,
-    size: 0,
-    mtime: 0,
-    rawDate: "2026-01-12",
-    storedAnchor: anchor("2026-01-12"),
-    canonicalAnchor: anchor("2026-01-12"),
-    expectedStart: anchor("2026-01-12"),
-    ...overrides,
-  };
-}
-
 describe("checkStaleRange", () => {
   it("passes a note whose range matches its period", () => {
-    expect(checkStaleRange(note({ storedStart: "2026-01-12", storedEnd: "2026-01-18" }))).toBeUndefined();
+    expect(checkStaleRange(buildScannedNote({ storedStart: "2026-01-12", storedEnd: "2026-01-18" }))).toBeUndefined();
   });
 
   it("flags a period that ends on the day it starts", () => {
-    const result = checkStaleRange(note({ storedEnd: "2026-01-12" }));
+    const result = checkStaleRange(buildScannedNote({ storedEnd: "2026-01-12" }));
 
     expect(result?.repair).toEqual({ kind: "rewrite", anchor: anchor("2026-01-12") });
     expect(result?.detail).toEqual({ kind: "zero-length-range", anchor: anchor("2026-01-12") });
   });
 
   it("leaves a one-day period alone on a day journal", () => {
-    expect(checkStaleRange(note({ isDayJournal: true, storedEnd: "2026-01-12" }))).toBeUndefined();
+    expect(checkStaleRange(buildScannedNote({ isDayJournal: true, storedEnd: "2026-01-12" }))).toBeUndefined();
   });
 
   it("leaves a deliberately extended period alone", () => {
-    expect(checkStaleRange(note({ storedEnd: "2026-02-28" }))).toBeUndefined();
+    expect(checkStaleRange(buildScannedNote({ storedEnd: "2026-02-28" }))).toBeUndefined();
   });
 
   it("flags a start date that is not the period's start", () => {
-    const result = checkStaleRange(note({ storedStart: "2026-01-14" }));
+    const result = checkStaleRange(buildScannedNote({ storedStart: "2026-01-14" }));
 
     expect(result?.detail).toEqual({
       kind: "start-mismatch",
@@ -57,7 +40,11 @@ describe("checkStaleRange", () => {
 
   it("ignores a note that is already reported as rejected", () => {
     const result = checkStaleRange(
-      note({ storedAnchor: anchor("2026-01-14"), canonicalAnchor: anchor("2026-01-12"), storedEnd: "2026-01-14" }),
+      buildScannedNote({
+        storedAnchor: anchor("2026-01-14"),
+        canonicalAnchor: anchor("2026-01-12"),
+        storedEnd: "2026-01-14",
+      }),
     );
 
     expect(result).toBeUndefined();

--- a/src/maintenance/scan-service.test.ts
+++ b/src/maintenance/scan-service.test.ts
@@ -13,24 +13,9 @@ import { testContainer, type FakeHost } from "@/testing";
 import { maintenanceCoreModule } from "./module";
 import { gateCollisions, orphanFindings, pendingOldIdsOf, ScanService } from "./scan-service";
 import { ScannedNoteResolver } from "./scanned-note";
+import { buildScannedNote } from "./testing";
 
 import type { Finding } from "./findings";
-import type { ScannedNote } from "./scanned-note";
-
-function note(path: string, overrides: Partial<ScannedNote> = {}): ScannedNote {
-  return {
-    path: path as VaultPath,
-    claimedJournal: "weekly",
-    journalExists: true,
-    isDayJournal: false,
-    size: 10,
-    mtime: 1,
-    rawDate: "2026-01-12",
-    storedAnchor: anchor("2026-01-12"),
-    canonicalAnchor: anchor("2026-01-12"),
-    ...overrides,
-  };
-}
 
 function rewrite(path: string, to: string): Finding {
   return {
@@ -44,7 +29,13 @@ function rewrite(path: string, to: string): Finding {
 
 describe("gateCollisions", () => {
   it("leaves an uncontested repair alone", () => {
-    const notes = [note("a.md", { storedAnchor: anchor("2026-01-14"), canonicalAnchor: anchor("2026-01-12") })];
+    const notes = [
+      buildScannedNote({
+        path: "a.md" as VaultPath,
+        storedAnchor: anchor("2026-01-14"),
+        canonicalAnchor: anchor("2026-01-12"),
+      }),
+    ];
     const result = gateCollisions(notes, [rewrite("a.md", "2026-01-12")]);
 
     expect(result).toHaveLength(1);
@@ -52,7 +43,7 @@ describe("gateCollisions", () => {
   });
 
   it("does not treat a repair that keeps its own anchor as a collision", () => {
-    const notes = [note("a.md")];
+    const notes = [buildScannedNote({ path: "a.md" as VaultPath })];
     const result = gateCollisions(notes, [rewrite("a.md", "2026-01-12")]);
 
     expect(result.every((f) => f.check !== "duplicate-anchor")).toBe(true);
@@ -60,8 +51,16 @@ describe("gateCollisions", () => {
 
   it("withdraws both repairs when two stranded notes project onto one anchor", () => {
     const notes = [
-      note("a.md", { storedAnchor: anchor("2026-01-14"), canonicalAnchor: anchor("2026-01-12") }),
-      note("b.md", { storedAnchor: anchor("2026-01-15"), canonicalAnchor: anchor("2026-01-12") }),
+      buildScannedNote({
+        path: "a.md" as VaultPath,
+        storedAnchor: anchor("2026-01-14"),
+        canonicalAnchor: anchor("2026-01-12"),
+      }),
+      buildScannedNote({
+        path: "b.md" as VaultPath,
+        storedAnchor: anchor("2026-01-15"),
+        canonicalAnchor: anchor("2026-01-12"),
+      }),
     ];
     const result = gateCollisions(notes, [rewrite("a.md", "2026-01-12"), rewrite("b.md", "2026-01-12")]);
 
@@ -74,8 +73,12 @@ describe("gateCollisions", () => {
 
   it("withdraws a repair that would land on a healthy note's anchor", () => {
     const notes = [
-      note("healthy.md"),
-      note("stranded.md", { storedAnchor: anchor("2026-01-14"), canonicalAnchor: anchor("2026-01-12") }),
+      buildScannedNote({ path: "healthy.md" as VaultPath }),
+      buildScannedNote({
+        path: "stranded.md" as VaultPath,
+        storedAnchor: anchor("2026-01-14"),
+        canonicalAnchor: anchor("2026-01-12"),
+      }),
     ];
     const result = gateCollisions(notes, [rewrite("stranded.md", "2026-01-12")]);
 
@@ -89,22 +92,32 @@ describe("gateCollisions", () => {
   });
 
   it("reports a pre-existing duplicate between two healthy notes", () => {
-    const result = gateCollisions([note("a.md"), note("b.md")], []);
+    const result = gateCollisions(
+      [buildScannedNote({ path: "a.md" as VaultPath }), buildScannedNote({ path: "b.md" as VaultPath })],
+      [],
+    );
 
     expect(result.filter((f) => f.check === "duplicate-anchor")).toHaveLength(2);
     expect(result.at(0)?.detail).toEqual({ kind: "duplicate", anchor: anchor("2026-01-12"), size: 10, mtime: 1 });
   });
 
   it("keeps journals apart", () => {
-    const notes = [note("a.md"), note("b.md", { claimedJournal: "other" })];
+    const notes = [
+      buildScannedNote({ path: "a.md" as VaultPath }),
+      buildScannedNote({ path: "b.md" as VaultPath, claimedJournal: "other" }),
+    ];
 
     expect(gateCollisions(notes, []).filter((f) => f.check === "duplicate-anchor")).toHaveLength(0);
   });
 
   it("contributes nothing for an unhealthy note whose only finding is undecidable", () => {
     const notes = [
-      note("target.md"),
-      note("unplaced.md", { storedAnchor: anchor("2026-01-12"), canonicalAnchor: anchor("2026-01-20") }),
+      buildScannedNote({ path: "target.md" as VaultPath }),
+      buildScannedNote({
+        path: "unplaced.md" as VaultPath,
+        storedAnchor: anchor("2026-01-12"),
+        canonicalAnchor: anchor("2026-01-20"),
+      }),
     ];
     const undecidable: Finding = {
       check: "rejected-anchor",
@@ -130,7 +143,7 @@ describe("gateCollisions", () => {
 
 describe("orphanFindings", () => {
   it("reports a note whose journal no longer exists", () => {
-    const notes = [note("old.md", { journalExists: false, claimedJournal: "gone" })];
+    const notes = [buildScannedNote({ path: "old.md" as VaultPath, journalExists: false, claimedJournal: "gone" })];
 
     const result = orphanFindings(notes, new Set());
 
@@ -141,13 +154,15 @@ describe("orphanFindings", () => {
   });
 
   it("never reports a note still waiting on the legacy note migration", () => {
-    const notes = [note("legacy.md", { journalExists: false, claimedJournal: "legacy-id-7" })];
+    const notes = [
+      buildScannedNote({ path: "legacy.md" as VaultPath, journalExists: false, claimedJournal: "legacy-id-7" }),
+    ];
 
     expect(orphanFindings(notes, new Set(["legacy-id-7"]))).toHaveLength(0);
   });
 
   it("ignores notes whose journal exists", () => {
-    expect(orphanFindings([note("fine.md")], new Set())).toHaveLength(0);
+    expect(orphanFindings([buildScannedNote({ path: "fine.md" as VaultPath })], new Set())).toHaveLength(0);
   });
 });
 

--- a/src/maintenance/testing.ts
+++ b/src/maintenance/testing.ts
@@ -1,0 +1,20 @@
+import { anchor } from "@/calendar/testing";
+import type { VaultPath } from "@/infrastructure/host";
+
+import type { ScannedNote } from "./scanned-note";
+
+export function buildScannedNote(overrides: Partial<ScannedNote> = {}): ScannedNote {
+  return {
+    path: "W03.md" as VaultPath,
+    claimedJournal: "weekly",
+    journalExists: true,
+    isDayJournal: false,
+    size: 10,
+    mtime: 1,
+    rawDate: "2026-01-12",
+    storedAnchor: anchor("2026-01-12"),
+    canonicalAnchor: anchor("2026-01-12"),
+    expectedStart: anchor("2026-01-12"),
+    ...overrides,
+  };
+}

--- a/src/maintenance/ui/MaintenanceBlock.test.ts
+++ b/src/maintenance/ui/MaintenanceBlock.test.ts
@@ -1,0 +1,25 @@
+import userEvent from "@testing-library/user-event";
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import { m } from "@/i18n";
+import { SettingsUiService } from "@/settings";
+import { testContainer } from "@/testing";
+
+import { maintenanceUiModule } from "../ui-module";
+
+import MaintenanceBlock from "./MaintenanceBlock.vue";
+
+describe("MaintenanceBlock", () => {
+  it("opens the maintenance subpage when the user clicks the open button", async () => {
+    const harness = await testContainer({
+      modules: [maintenanceUiModule],
+    });
+    const ui = harness.resolve(SettingsUiService);
+    harness.render(MaintenanceBlock);
+
+    await userEvent.click(screen.getByText(m.maintenance_open()));
+
+    expect(ui.current.value?.subpage.key).toBe("maintenance");
+  });
+});

--- a/src/notes-calendar/ui/NotesWeekView.test.ts
+++ b/src/notes-calendar/ui/NotesWeekView.test.ts
@@ -1,6 +1,7 @@
 import { fireEvent, screen } from "@testing-library/vue";
 import { __testing } from "obsidian";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
 
 import { CalendarDate, WeekPeriod } from "@/calendar";
 import { anchor } from "@/calendar/testing";
@@ -8,9 +9,11 @@ import { decorationsModule } from "@/decorations/module";
 import { decorationsSettingsCoreModule } from "@/decorations/settings/module";
 import { buildCondition, buildDecoration, buildStyle } from "@/decorations/testing";
 import { initLocale } from "@/i18n";
+import type { VaultPath } from "@/infrastructure/host";
 import type { JournalConfig } from "@/journals";
+import { JournalsIndex } from "@/journals";
 import { journalsCoreModule } from "@/journals/module";
-import { fixedJournal } from "@/journals/testing";
+import { customJournal, fixedJournal } from "@/journals/testing";
 import { shelvesCoreModule } from "@/shelves/module";
 import { testContainer, type TestHarness } from "@/testing";
 
@@ -161,6 +164,69 @@ describe("NotesWeekView", () => {
       const harness = await bootHarness({ daily: fixedJournal("daily", { type: "day" }) });
       const { container } = harness.render(NotesWeekView, { props: { shelf: null, week } });
       expect(container.querySelector('[data-testid="header-quarter"]')).toBeNull();
+    });
+  });
+
+  describe("custom interval decorations", () => {
+    // A custom interval is anchored to its start date, which coincides with one day cell's
+    // anchor. The week grid renders fixed-period journals only; a custom interval's
+    // decoration belongs in the interval list, never on the day cell sharing its anchor.
+    it("does not decorate the day cell sharing a custom interval's start anchor", async () => {
+      const decoration = buildDecoration({
+        mode: "or",
+        conditions: [buildCondition("has-note")],
+        styles: [buildStyle("corner")],
+      });
+      const harness = await bootHarness({
+        sprint: customJournal("sprint", "week", 2, "2026-05-26", { decorations: [decoration] }),
+      });
+      const path = "sprint/2026-05-26.md" as VaultPath;
+      harness.resolve(JournalsIndex).register({ journalName: "sprint", anchor: anchor("2026-05-26"), path });
+      harness.host.putFile(path);
+
+      const { container } = harness.render(NotesWeekView, { props: { shelf: null, week } });
+      await nextTick();
+
+      const cell = container.querySelector('[data-anchor="2026-05-26"]');
+      expect(cell?.querySelector(".decoration-corner")).toBeNull();
+    });
+
+    // The week grid is otherwise fixed-only, but a custom journal's offset-condition
+    // decorations mark specific days inside an interval, so they belong on the day
+    // cells even though the journal itself renders as intervals.
+    it("paints a custom journal's offset decoration on the matching day cell", async () => {
+      const decoration = buildDecoration({
+        mode: "or",
+        conditions: [buildCondition("offset", { offset: 3 })],
+        styles: [buildStyle("corner")],
+      });
+      const harness = await bootHarness({
+        sprint: customJournal("sprint", "week", 2, "2026-05-26", { decorations: [decoration] }),
+      });
+
+      const { container } = harness.render(NotesWeekView, { props: { shelf: null, week } });
+      await nextTick();
+
+      // Day 3 of the interval starting 2026-05-26 is 2026-05-28.
+      const cell = container.querySelector('[data-anchor="2026-05-28"]');
+      expect(cell?.querySelector(".decoration-corner")).not.toBeNull();
+    });
+
+    it("does not paint a custom journal's non-offset decoration on other day cells", async () => {
+      const decoration = buildDecoration({
+        mode: "or",
+        conditions: [buildCondition("weekday", { weekdays: [1, 2, 3, 4, 5, 6, 0] })],
+        styles: [buildStyle("corner")],
+      });
+      const harness = await bootHarness({
+        sprint: customJournal("sprint", "week", 2, "2026-05-26", { decorations: [decoration] }),
+      });
+
+      const { container } = harness.render(NotesWeekView, { props: { shelf: null, week } });
+      await nextTick();
+
+      const cell = container.querySelector('[data-anchor="2026-05-28"]');
+      expect(cell?.querySelector(".decoration-corner")).toBeNull();
     });
   });
 

--- a/src/notes-calendar/use-notes-cell.test.ts
+++ b/src/notes-calendar/use-notes-cell.test.ts
@@ -193,6 +193,21 @@ describe("useNotesCell", () => {
       expect(menuItemTitles()).toEqual([dailyPath, secondPath]);
     });
 
+    // A single resolved path opens that file's own menu directly rather than the
+    // multi-path chooser above — a distinct route in WorkspaceService.openPathsMenu.
+    it("opens the file's own menu directly when exactly one path resolves", async () => {
+      const { harness } = await bootHarness();
+      const index = harness.resolve(JournalsIndex);
+      index.register({ journalName: "daily", anchor: may25.anchor.toAnchor(), path: dailyPath });
+      harness.host.putFile(dailyPath);
+      const api = resolveApi(harness, () => ["daily"]);
+
+      api.openContextMenu(may25, new MouseEvent("contextmenu"));
+
+      expect(harness.host.workspace.triggerCalls).toHaveLength(1);
+      expect(harness.host.workspace.triggerCalls[0]?.event).toBe("file-menu");
+    });
+
     it("contributes the explain item to the context menu of a decorated cell", async () => {
       const { harness } = await bootHarness();
       const decorations: ReadonlyMap<string, CellStyleRef> = new Map([

--- a/src/settings/legacy/data-migration-service.test.ts
+++ b/src/settings/legacy/data-migration-service.test.ts
@@ -217,6 +217,35 @@ describe("DataMigrationService", () => {
     expect(harness.host.files.get("orphan.md")?.frontmatter).toEqual({ title: "kept" });
   });
 
+  it("skips a v2 marker naming a journal that is no longer registered", async () => {
+    const marker: PendingNoteMigration = {
+      oldJournalId: "cal",
+      kind: "calendar",
+      sectionToName: { month: "Deleted Journal" },
+    };
+    const metadata = new FakeNoteMetadataService();
+    const harness = await testContainer({
+      modules: [journalsCoreModule, legacyMigrationsModule],
+      // "Deleted Journal" is deliberately absent from the journals collection — the marker
+      // still names it, the way a v2 marker survives after its target journal is removed.
+      data: { pendingNoteMigration: [marker] },
+      overrides: [overrideWith(NoteMetadataService, metadata as unknown as NoteMetadataService)],
+    });
+    const properties = {
+      journal: "cal",
+      "journal-start-date": "2022-01-01",
+      "journal-end-date": "2022-01-31",
+      "journal-section": "month",
+      "journal-date": "2022-01-01",
+      title: "kept",
+    };
+    harness.host.putFile("orphan.md", "", properties);
+
+    await migrate(harness, metadata, { "orphan.md": properties });
+
+    expect(harness.host.files.get("orphan.md")?.frontmatter).toEqual({ title: "kept" });
+  });
+
   it("clears the marker slice after running", async () => {
     const marker: PendingNoteMigration = { oldJournalId: "int", kind: "interval", name: "Sprints" };
     const metadata = new FakeNoteMetadataService();

--- a/src/settings/legacy/journal-conversion.test.ts
+++ b/src/settings/legacy/journal-conversion.test.ts
@@ -115,6 +115,24 @@ describe("prepareIntervalJournalSettings", () => {
     expect(s.index).toMatchObject({ type: "reset_after", resetAfter: 26 });
   });
 
+  it("computes the year-reset divisor for months", () => {
+    const old = intervalFixture();
+    old.numeration_type = "year";
+    old.granularity = "month";
+    old.duration = 5;
+    const s = prepareIntervalJournalSettings(old, false);
+    expect(s.index).toMatchObject({ type: "reset_after", resetAfter: 2 });
+  });
+
+  it("computes the year-reset divisor for days", () => {
+    const old = intervalFixture();
+    old.numeration_type = "year";
+    old.granularity = "day";
+    old.duration = 10;
+    const s = prepareIntervalJournalSettings(old, false);
+    expect(s.index).toMatchObject({ type: "reset_after", resetAfter: 36 });
+  });
+
   it("converts a date timeline end", () => {
     const settings = prepareIntervalJournalSettings(
       { ...intervalFixture(), end_type: "date", end_date: "2023-06-30" },

--- a/src/settings/legacy/journal-conversion.test.ts
+++ b/src/settings/legacy/journal-conversion.test.ts
@@ -110,9 +110,9 @@ describe("prepareIntervalJournalSettings", () => {
     const old = intervalFixture();
     old.numeration_type = "year";
     old.granularity = "week";
-    old.duration = 2;
+    old.duration = 5;
     const s = prepareIntervalJournalSettings(old, false);
-    expect(s.index).toMatchObject({ type: "reset_after", resetAfter: 26 });
+    expect(s.index).toMatchObject({ type: "reset_after", resetAfter: 10 });
   });
 
   it("computes the year-reset divisor for months", () => {

--- a/src/settings/legacy/journal-conversion.test.ts
+++ b/src/settings/legacy/journal-conversion.test.ts
@@ -114,6 +114,30 @@ describe("prepareIntervalJournalSettings", () => {
     const s = prepareIntervalJournalSettings(old, false);
     expect(s.index).toMatchObject({ type: "reset_after", resetAfter: 26 });
   });
+
+  it("converts a date timeline end", () => {
+    const settings = prepareIntervalJournalSettings(
+      { ...intervalFixture(), end_type: "date", end_date: "2023-06-30" },
+      false,
+    );
+
+    expect(settings.end).toEqual({ type: "date", date: "2023-06-30" });
+  });
+
+  it("converts a repeat-count timeline end", () => {
+    const settings = prepareIntervalJournalSettings({ ...intervalFixture(), end_type: "repeats", repeats: 12 }, false);
+
+    expect(settings.end).toEqual({ type: "repeats", repeats: 12 });
+  });
+
+  it("carries the configured template across", () => {
+    const settings = prepareIntervalJournalSettings(
+      { ...intervalFixture(), template: "99 - Meta/Templates/Sprint.md" },
+      false,
+    );
+
+    expect(settings.templates).toEqual(["99 - Meta/Templates/Sprint.md"]);
+  });
 });
 
 describe("allocateName", () => {

--- a/src/settings/legacy/journal-conversion.test.ts
+++ b/src/settings/legacy/journal-conversion.test.ts
@@ -98,6 +98,28 @@ describe("prepareCalendarJournalSettings", () => {
     expect(s.frontmatter.addStartDate).toBe(true);
     expect(s.frontmatter.addEndDate).toBe(true);
   });
+
+  it("converts a v1 calendar section ribbon into a today command with the configured icon and tooltip", () => {
+    const config = calendarFixture();
+    config.month.ribbon = { show: true, icon: "rocket", tooltip: "Open the sprint" };
+
+    const settings = prepareCalendarJournalSettings(config, "month", names, false, false);
+
+    expect(settings.commands.at(0)).toMatchObject({ icon: "rocket", name: "Open the sprint", showInRibbon: true });
+  });
+
+  it("falls back to the calendar icon and default tooltip when the section ribbon has none configured", () => {
+    const config = calendarFixture();
+    config.month.ribbon = { show: true, icon: "", tooltip: "" };
+
+    const settings = prepareCalendarJournalSettings(config, "month", names, false, false);
+
+    expect(settings.commands.at(0)).toMatchObject({
+      icon: "calendar-days",
+      name: "Open this month's note",
+      showInRibbon: true,
+    });
+  });
 });
 
 describe("prepareIntervalJournalSettings", () => {
@@ -207,6 +229,42 @@ describe("prepareIntervalJournalSettings", () => {
     );
 
     expect(settings.navBlock.rows.at(0)?.template).toBe("{{journal_name}} {{index}}");
+  });
+
+  it("enables start and end date frontmatter on an interval when requested", () => {
+    const settings = prepareIntervalJournalSettings(intervalFixture(), true);
+
+    expect(settings.frontmatter).toMatchObject({ addStartDate: true, addEndDate: true });
+  });
+
+  it("converts a v1 interval ribbon into a today command with the configured icon and tooltip", () => {
+    const settings = prepareIntervalJournalSettings(
+      { ...intervalFixture(), ribbon: { show: true, icon: "rocket", tooltip: "Open the sprint" } },
+      false,
+    );
+
+    expect(settings.commands).toEqual([
+      {
+        icon: "rocket",
+        name: "Open the sprint",
+        type: "same",
+        context: "today",
+        showInRibbon: true,
+        openMode: "active",
+      },
+    ]);
+  });
+
+  it("names an interval ribbon command after the journal when no tooltip was set", () => {
+    const settings = prepareIntervalJournalSettings(
+      { ...intervalFixture(), ribbon: { show: true, icon: "", tooltip: "" } },
+      false,
+    );
+
+    expect(settings.commands.at(0)).toMatchObject({
+      icon: "calendar-range",
+      name: "Open current Test Interval note",
+    });
   });
 });
 

--- a/src/settings/legacy/journal-conversion.test.ts
+++ b/src/settings/legacy/journal-conversion.test.ts
@@ -156,6 +156,58 @@ describe("prepareIntervalJournalSettings", () => {
 
     expect(settings.templates).toEqual(["99 - Meta/Templates/Sprint.md"]);
   });
+
+  // The guard never runs for this input, and its own empty-input fallback was authored to
+  // reproduce this default byte-for-byte, so forcing the guard to always execute leaves this
+  // green. Only mutating defaultNavBlocks.custom reddens it: this pins that default, not the guard.
+  it("keeps the custom journal's built-in nav-block default when neither nav template is set", () => {
+    const settings = prepareIntervalJournalSettings(intervalFixture(), false);
+
+    expect(settings.navBlock.rows.map((row) => row.template)).toEqual([
+      "{{journal_name}} {{index}}",
+      "{{start_date}}",
+      "to",
+      "{{end_date}}",
+    ]);
+  });
+
+  it("splits the dates template into one row per segment", () => {
+    const settings = prepareIntervalJournalSettings(
+      { ...intervalFixture(), navNameTemplate: "Sprint {{index}}", navDatesTemplate: "{{start_date}}|–|{{end_date}}" },
+      false,
+    );
+
+    expect(settings.navBlock.rows.map((row) => row.template)).toEqual([
+      "Sprint {{index}}",
+      "{{start_date}}",
+      "–",
+      "{{end_date}}",
+    ]);
+    expect(settings.navBlock.rows.at(0)).toMatchObject({ link: "self", fontSize: 3, bold: true, addDecorations: true });
+  });
+
+  it("falls back to a three-row date range when only the name template is set", () => {
+    const settings = prepareIntervalJournalSettings(
+      { ...intervalFixture(), navNameTemplate: "Sprint {{index}}" },
+      false,
+    );
+
+    expect(settings.navBlock.rows.map((row) => row.template)).toEqual([
+      "Sprint {{index}}",
+      "{{start_date}}",
+      "to",
+      "{{end_date}}",
+    ]);
+  });
+
+  it("titles the nav block from the journal name when only the dates template is set", () => {
+    const settings = prepareIntervalJournalSettings(
+      { ...intervalFixture(), navDatesTemplate: "{{start_date}}" },
+      false,
+    );
+
+    expect(settings.navBlock.rows.at(0)?.template).toBe("{{journal_name}} {{index}}");
+  });
 });
 
 describe("allocateName", () => {

--- a/src/settings/legacy/module.test.ts
+++ b/src/settings/legacy/module.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import { calendarSettingsCoreModule } from "@/calendar/settings/module";
+import { commandCollection } from "@/commands/config";
+import { commandsCoreModule } from "@/commands/module";
 import { FakePluginData } from "@/infrastructure/host/testing";
 import { journalConfigCollection } from "@/journals/config";
 import { journalsCoreModule } from "@/journals/module";
@@ -79,5 +81,36 @@ describe("legacy migrations integration", () => {
         allow: { legacySeedKeys: ["calendar_view"] },
       }),
     ).rejects.toThrow(TestContainerUnknownSeedKeyError);
+  });
+
+  it("carries an interval ribbon and its dates template through the full migration chain", async () => {
+    const raw = v1Raw();
+    raw.journals.int.navDatesTemplate = "{{start_date}}|through|{{end_date}}";
+    raw.journals.int.ribbon = { show: true, icon: "rocket", tooltip: "Open the sprint" };
+
+    const harness = await testContainer({
+      modules: [journalsCoreModule, commandsCoreModule, legacyMigrationsModule, calendarSettingsCoreModule],
+      data: { version: 0, ...raw },
+      allow: { legacySeedKeys: ["calendar_view"] },
+    });
+
+    const journals = harness.settings.recordOf(journalConfigCollection);
+    const sprints = Object.values(journals).find((journal) => journal.name === "Sprints");
+    expect(sprints).toBeDefined();
+    expect(sprints?.navBlock.lines.map((line) => line.map((segment) => segment.template))).toEqual([
+      ["{{journal_name}} {{index}}"],
+      ["{{start_date}}"],
+      ["through"],
+      ["{{end_date}}"],
+    ]);
+
+    const commands = harness.settings.recordOf(commandCollection);
+    const ribbonCommand = Object.values(commands).find((command) => command.name === "Open the sprint");
+    expect(ribbonCommand).toMatchObject({
+      icon: "rocket",
+      showInRibbon: true,
+      context: "today",
+      target: { kind: "journal", journalName: "Sprints" },
+    });
   });
 });

--- a/src/settings/legacy/module.test.ts
+++ b/src/settings/legacy/module.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
 
+import { calendarSettingsCoreModule } from "@/calendar/settings/module";
 import { FakePluginData } from "@/infrastructure/host/testing";
 import { journalConfigCollection } from "@/journals/config";
 import { journalsCoreModule } from "@/journals/module";
-import { testContainer } from "@/testing";
+import { TestContainerUnknownSeedKeyError, testContainer } from "@/testing";
 
 import { legacyMigrationsModule } from "./module";
 
@@ -57,5 +58,26 @@ describe("legacy migrations integration", () => {
     // duration/every surviving too rules out the vacuity trap: a journal resolved from some other
     // "custom" default would not carry the source interval's own values.
     expect(sprints?.write).toMatchObject({ every: "week", duration: 2 });
+  });
+
+  it("accepts a pre-migration key named in allow.legacySeedKeys", async () => {
+    const harness = await testContainer({
+      modules: [journalsCoreModule, legacyMigrationsModule, calendarSettingsCoreModule],
+      data: { version: 0, ...v1Raw() },
+      allow: { legacySeedKeys: ["calendar_view"] },
+    });
+
+    const journals = harness.settings.recordOf(journalConfigCollection);
+    expect(Object.values(journals).find((journal) => journal.name === "Sprints")).toBeDefined();
+  });
+
+  it("still throws for a pre-migration key that is not named in allow.legacySeedKeys", async () => {
+    await expect(
+      testContainer({
+        modules: [journalsCoreModule, legacyMigrationsModule, calendarSettingsCoreModule],
+        data: { version: 0, ...v1Raw(), calender_view: { leaf: "left", weeks: "left" } },
+        allow: { legacySeedKeys: ["calendar_view"] },
+      }),
+    ).rejects.toThrow(TestContainerUnknownSeedKeyError);
   });
 });

--- a/src/settings/migrations.test.ts
+++ b/src/settings/migrations.test.ts
@@ -5,11 +5,11 @@ import { runMigrations } from "./migrations";
 
 import type { Migration } from "./schema";
 
-function bumpVersion(toVersion: number): Migration {
+function bumpVersion(toVersion: number, calls?: string[]): Migration {
   return {
     fromVersion: toVersion - 1,
     toVersion,
-    migrate: (raw) => ({ ...raw, [`mark${toVersion}`]: true }),
+    migrate: (raw) => (calls?.push(`mark${toVersion}`), { ...raw, [`mark${toVersion}`]: true }),
   };
 }
 
@@ -39,8 +39,16 @@ describe("runMigrations", () => {
 
   describe("ordering and discovery", () => {
     it("orders migrations by fromVersion regardless of binding order", () => {
-      const result = runMigrations({ version: 0 }, [bumpVersion(3), bumpVersion(1), bumpVersion(2)], 3);
+      const calls: string[] = [];
+      const result = runMigrations(
+        { version: 0 },
+        [bumpVersion(3, calls), bumpVersion(1, calls), bumpVersion(2, calls)],
+        3,
+      );
       expect(result.kind).toBe("ok");
+      if (result.kind !== "ok") return;
+      expect(result.value).toEqual({ version: 3, mark1: true, mark2: true, mark3: true });
+      expect(calls).toEqual(["mark1", "mark2", "mark3"]);
     });
 
     it("runs every migration with the same fromVersion before advancing", () => {

--- a/src/settings/settings-service.test.ts
+++ b/src/settings/settings-service.test.ts
@@ -171,7 +171,9 @@ describe("SettingsService", () => {
       });
     });
 
-    it("derives the repaired value from the entry's own stored fields", async () => {
+    // "keeps the fields that validate..." above tells the whole-reset and field-substitution paths
+    // apart; sound derives only from kind, so this pins just that the stored kind reaches defaultItem.
+    it("passes the stored kind through to the collection's defaultItem", async () => {
       const harness = await testContainer({
         modules: [testSettingsModule({ collections: [petCollection] })],
         data: { pets: { Rex: { name: "Rex", kind: "dog", sound: "" } } },

--- a/src/settings/settings-service.test.ts
+++ b/src/settings/settings-service.test.ts
@@ -236,7 +236,10 @@ describe("SettingsService", () => {
       templates: ["99 - Meta/Templates/Weekly Note Template.md"],
     };
 
-    it("stays a weekly journal", async () => {
+    // Two independent mechanisms produce this: repairCollectionEntry substitutes only the failing
+    // dateFormat, and journalConfigCollection's defaultItem re-derives the write type from the raw
+    // entry. Neither alone reddens this test — it pins the user-visible outcome, not a mechanism.
+    it("loads a weekly journal whose date format was cleared as weekly, not daily", async () => {
       const harness = await testContainer({
         modules: [testSettingsModule({ collections: [journalConfigCollection] })],
         data: { journals: { "Journal weekly": weekly } },

--- a/src/settings/ui/plugin-setting-tab.test.ts
+++ b/src/settings/ui/plugin-setting-tab.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import { defineComponent, h } from "vue";
+
+import type { Module } from "@/infrastructure/di";
+import { testContainer } from "@/testing";
+
+import { SubpageToken } from "../tokens";
+
+import { PluginSettingTabAdapter } from "./plugin-setting-tab";
+import { defineSubpage } from "./schema";
+import { SettingsUiService } from "./settings-ui-service";
+
+const testSubpage = defineSubpage({ key: "test-subpage", component: defineComponent({ render: () => h("div") }) });
+
+// settingsCoreModule is already part of testContainer's default wiring, so this registers only
+// what settingsModule adds beyond it — registering settingsModule here would double-bind
+// settingsCoreModule's single tokens.
+function pluginSettingTabModule(): Module {
+  return {
+    register(c) {
+      c.register(PluginSettingTabAdapter).useClass(PluginSettingTabAdapter).eager();
+    },
+  };
+}
+
+function testSubpageModule(): Module {
+  return {
+    register(c) {
+      c.register(SubpageToken).useValue(testSubpage);
+    },
+  };
+}
+
+describe("PluginSettingTabAdapter", () => {
+  it("mounts the settings dashboard into containerEl on display", async () => {
+    const harness = await testContainer({ modules: [pluginSettingTabModule()], allow: { hostState: true } });
+    const tab = harness.resolve(PluginSettingTabAdapter);
+
+    tab.display();
+
+    expect(tab.containerEl.childElementCount).toBeGreaterThan(0);
+  });
+
+  it("tears down the mounted app and resets settings navigation on hide", async () => {
+    const harness = await testContainer({
+      modules: [pluginSettingTabModule(), testSubpageModule()],
+      allow: { hostState: true },
+    });
+    const tab = harness.resolve(PluginSettingTabAdapter);
+    const ui = harness.resolve(SettingsUiService);
+    tab.display();
+    ui.push(testSubpage, undefined);
+    // Vue records the mounted app on its root element (used by devtools), which lets this spy
+    // on the real instance rather than on containerEl.empty() — a DOM clear that would happen
+    // either way and so cannot tell "the app was unmounted" from "the container was cleared".
+    const vueApp = (tab.containerEl as unknown as { __vue_app__: { unmount: () => void } }).__vue_app__;
+    const unmountSpy = vi.spyOn(vueApp, "unmount");
+
+    tab.hide();
+
+    expect(unmountSpy).toHaveBeenCalledTimes(1);
+    expect(tab.containerEl.childElementCount).toBe(0);
+    expect(ui.current.value).toBeNull();
+  });
+});

--- a/src/templates/engine.ts
+++ b/src/templates/engine.ts
@@ -316,11 +316,11 @@ export class TemplateEngine {
     if (!matched) {
       return new Err(new TemplateParseError({ kind: "no-match", input }));
     }
-    // A stream with no variable tokens compiles to a regex with no named groups at
-    // all, so `.groups` is `undefined` even on a successful match (JS regex semantics
-    // key `.groups` off the pattern, not the match) — fall back to {} rather than
-    // treating a matching pure-literal template as a parse failure.
-    const groups = matched.groups ?? {};
+    // A stream with no variable tokens compiles to a regex with no named groups, so `.groups` is
+    // undefined even on a successful match (JS regex semantics key `.groups` off the pattern, not
+    // the match). That is exactly the case where captureTokens is empty, so the loop below never
+    // runs and the optional read never resolves.
+    const groups = matched.groups;
 
     const candidates = new Map<string, BoundValue[]>();
     // Date tokens are resolved together per variable: a date split across tokens
@@ -328,7 +328,7 @@ export class TemplateEngine {
     // rather than have each token parse to a full moment-defaulted date.
     const dateTokens = new Map<string, DateCapture[]>();
     for (const [index, token] of captureTokens.entries()) {
-      const capture = groups[`v_${index}`];
+      const capture = groups?.[`v_${index}`];
       if (capture === undefined) continue;
       const spec = context.get(token.name);
       if (!spec || spec.kind === "derived") continue;

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -207,7 +207,17 @@ export interface TestContainerOptions {
    *
    * `dataRepair` — the test exercises the settings repair path with a deliberately broken fixture.
    */
-  readonly allow?: { readonly hostState?: boolean; readonly dataRepair?: boolean };
+  readonly allow?: {
+    readonly hostState?: boolean;
+    readonly dataRepair?: boolean;
+    /**
+     * Pre-migration keys this seed carries on purpose. `data` is consumed before migrations run,
+     * but the guard validates against post-migration slice and collection registrations, so a
+     * legacy blob would otherwise always throw. Naming the keys keeps a mis-keyed seed loud: a key
+     * absent from this list still throws.
+     */
+    readonly legacySeedKeys?: readonly string[];
+  };
 }
 
 export interface TestHarness {
@@ -307,6 +317,7 @@ export async function testContainer(options: TestContainerOptions = {}): Promise
   if (seededKeys.length > 0) {
     const registered = new Set([
       "version",
+      ...(options.allow?.legacySeedKeys ?? []),
       ...container.resolve(SliceDefinitionToken).map((slice) => slice.key),
       ...container.resolve(CollectionDefinitionToken).map((collection) => collection.key),
     ]);

--- a/src/ui/UiIcon.test.ts
+++ b/src/ui/UiIcon.test.ts
@@ -46,4 +46,10 @@ describe("UiIcon", () => {
 
     expect(container.querySelector("svg")).toBeNull();
   });
+
+  it("leaves the host empty when the icon name is not registered", () => {
+    const { container } = render(UiIcon, { props: { name: "definitely-not-an-icon" } });
+
+    expect(container.querySelector("span")?.childNodes).toHaveLength(0);
+  });
 });

--- a/src/ui/UiIcon.test.ts
+++ b/src/ui/UiIcon.test.ts
@@ -1,10 +1,19 @@
 import { render } from "@testing-library/vue";
-import { describe, expect, it } from "vitest";
+import { __testing } from "obsidian";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { nextTick } from "vue";
 
 import UiIcon from "./UiIcon.vue";
 
 describe("UiIcon", () => {
+  beforeEach(() => {
+    __testing.seedIcons(["search", "first", "second", "present"]);
+  });
+
+  afterEach(() => {
+    __testing.resetIcons();
+  });
+
   it("appends the icon returned by renderIcon on mount", () => {
     const { container } = render(UiIcon, { props: { name: "search" } });
 
@@ -28,6 +37,12 @@ describe("UiIcon", () => {
 
     await rerender({ name: "" });
     await nextTick();
+
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  it("renders nothing when the icon name is not registered", () => {
+    const { container } = render(UiIcon, { props: { name: "definitely-not-an-icon" } });
 
     expect(container.querySelector("svg")).toBeNull();
   });

--- a/src/ui/UiPropertySuggest.test.ts
+++ b/src/ui/UiPropertySuggest.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { __testing } from "obsidian";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { VaultProperty } from "@/infrastructure/host";
 import { testContainer, type FakeHost } from "@/testing";
@@ -15,6 +16,14 @@ async function mount(modelValue = "", seed: (host: FakeHost) => void = () => und
 }
 
 describe("UiPropertySuggest", () => {
+  beforeEach(() => {
+    __testing.seedIcons([icons.propertyType.number, icons.propertyType.date]);
+  });
+
+  afterEach(() => {
+    __testing.resetIcons();
+  });
+
   it("offers the vault properties matching the query", async () => {
     const { handle } = await mount("", (host) => {
       host.setPropertyType("rating", "number");

--- a/src/ui/UiSegmentedControl.test.ts
+++ b/src/ui/UiSegmentedControl.test.ts
@@ -1,6 +1,7 @@
 import userEvent from "@testing-library/user-event";
 import { render, screen } from "@testing-library/vue";
 import { describe, expect, it } from "vitest";
+import { defineComponent } from "vue";
 
 import UiSegmentedControl from "./UiSegmentedControl.vue";
 
@@ -8,6 +9,8 @@ const options = [
   { value: "alpha", label: "Alpha" },
   { value: "beta", label: "Beta" },
 ];
+
+const nameOf = (group: HTMLElement) => group.querySelector("input[type=radio]")?.getAttribute("name");
 
 describe("UiSegmentedControl", () => {
   it("renders a radio for each option", () => {
@@ -36,5 +39,32 @@ describe("UiSegmentedControl", () => {
     for (const radio of screen.getAllByRole<HTMLInputElement>("radio")) {
       expect(radio.disabled).toBe(true);
     }
+  });
+
+  it("gives each instance its own radio group", () => {
+    const TwoInstances = defineComponent({
+      components: { UiSegmentedControl },
+      setup() {
+        return { options };
+      },
+      template: `
+        <UiSegmentedControl model-value="alpha" :options="options" />
+        <UiSegmentedControl model-value="alpha" :options="options" />
+      `,
+    });
+
+    render(TwoInstances);
+
+    const groups = screen.getAllByRole("radiogroup");
+    expect(groups).toHaveLength(2);
+
+    const firstName = nameOf(groups[0]);
+    const secondName = nameOf(groups[1]);
+
+    expect(firstName).toEqual(expect.any(String));
+    expect(firstName).not.toBe("");
+    expect(secondName).toEqual(expect.any(String));
+    expect(secondName).not.toBe("");
+    expect(firstName).not.toBe(secondName);
   });
 });

--- a/src/views/default-view.test.ts
+++ b/src/views/default-view.test.ts
@@ -84,4 +84,10 @@ describe("defaultCalendarView", () => {
     const pick = itemsOf(0).find((item) => item.key === "button");
     expect((pick!.config as { icon?: string }).icon).toBe(icons.action.pickDate);
   });
+
+  // A migrated vault must not gain a ribbon icon it never had: this seed also feeds the
+  // v3-to-v4 migration, so flipping it changes an existing user's data shape.
+  it("keeps the seeded view off the ribbon", () => {
+    expect(defaultCalendarView().showInRibbon).toBe(false);
+  });
 });

--- a/src/views/repository.test.ts
+++ b/src/views/repository.test.ts
@@ -4,6 +4,7 @@ import { journalsCoreModule } from "@/journals/module";
 import { shelvesCoreModule } from "@/shelves/module";
 import { testContainer, type TestHarness } from "@/testing";
 
+import { InvalidViewUpdateError } from "./errors";
 import { viewsCoreModule } from "./module";
 import { ViewsRepository } from "./repository";
 import { buildView } from "./testing";
@@ -42,6 +43,17 @@ describe("ViewsRepository", () => {
       const repo = harness.resolve(ViewsRepository);
       const ids = [...repo.find().entries()].map(([id]) => id);
       expect(ids).toEqual([ID_A, ID_B]);
+    });
+  });
+
+  describe("inherited update", () => {
+    it("rejects an id change via update with InvalidViewUpdateError", async () => {
+      const harness = await buildRepo({ [ID_A]: buildView(ID_A) });
+      const repo = harness.resolve(ViewsRepository);
+
+      const result = repo.update(ID_A as ViewId, { id: ID_B as ViewId });
+
+      expect(result.isErr() && result.error).toBeInstanceOf(InvalidViewUpdateError);
     });
   });
 });

--- a/src/views/service.test.ts
+++ b/src/views/service.test.ts
@@ -1,6 +1,6 @@
 import * as v from "valibot";
 import { describe, expect, it, vi } from "vitest";
-import { reactive } from "vue";
+import { isReactive, reactive, toRaw } from "vue";
 
 import type { Module } from "@/infrastructure/di";
 import { expectErr, expectOk } from "@/infrastructure/result/testing";
@@ -197,7 +197,7 @@ describe("ViewsService", () => {
       expect(listener).toHaveBeenCalledWith(result.value);
     });
 
-    it("clones block config that holds a reactive proxy nested at depth", async () => {
+    it("strips a reactive proxy nested in block config when cloning a view", async () => {
       const { service, repo } = await build({ blocks: [testBlockModule()] });
       const created = await service.create({ name: "Source" });
       expectOk(created);
@@ -213,8 +213,15 @@ describe("ViewsService", () => {
       const result = await service.clone(created.value);
 
       expectOk(result);
-      const cloned = repo.get(result.value).match({ some: (view) => view, none: () => null });
-      expect(cloned?.blocks[0]?.config).toEqual({ x: 0, nested: { count: 1 } });
+      // repo.get() reads through SettingsService's own deeply-reactive record, which re-wraps
+      // any nested plain object into a proxy on access -- that would mask a shallow toRaw just
+      // as readily as it hides behind cloneFnJSON. toRaw() on the returned view bypasses that
+      // read-time re-wrap and exposes exactly what clone() persisted.
+      const cloned = toRaw(repo.get(result.value).match({ some: (view) => view, none: () => null }));
+      const config = cloned?.blocks[0]?.config as { nested?: unknown } | undefined;
+      expect(config).toEqual({ x: 0, nested: { count: 1 } });
+      expect(isReactive(config?.nested)).toBe(false);
+      expect(() => structuredClone(config)).not.toThrow();
     });
   });
 

--- a/src/views/service.test.ts
+++ b/src/views/service.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { isReactive, reactive, toRaw } from "vue";
 
 import type { Module } from "@/infrastructure/di";
+import { Err } from "@/infrastructure/result";
 import { expectErr, expectOk } from "@/infrastructure/result/testing";
 import { journalsCoreModule } from "@/journals/module";
 import { ShelvesRepository } from "@/shelves";
@@ -10,6 +11,7 @@ import { shelvesCoreModule } from "@/shelves/module";
 import { buildShelf } from "@/shelves/testing";
 import { testContainer, type TestHarness } from "@/testing";
 
+import { UnknownViewError } from "./errors";
 import { viewsCoreModule } from "./module";
 import { ViewsRepository } from "./repository";
 import { ViewsService } from "./service";
@@ -117,6 +119,22 @@ describe("ViewsService", () => {
       shelves.deleteWith("work");
       expect(repo.get(SCOPED_VIEW_ID as ViewId).match({ some: (v) => v.defaultShelf, none: () => "gone" })).toBe(
         "personal",
+      );
+    });
+
+    it("logs the failure when persisting a shelf reference update fails", async () => {
+      const { harness, repo, shelves } = await buildScopedToShelf("work");
+      const failure = new UnknownViewError(SCOPED_VIEW_ID as ViewId);
+      vi.spyOn(repo, "update").mockReturnValueOnce(new Err(failure));
+
+      shelves.rename("work", "office");
+
+      expect(harness.logs.records).toContainEqual(
+        expect.objectContaining({
+          level: "error",
+          message: "failed to update a view's shelf reference",
+          fields: { view: SCOPED_VIEW_ID, error: failure },
+        }),
       );
     });
   });
@@ -385,6 +403,17 @@ describe("ViewsService", () => {
       expect(calledId).toBe(created.value);
       expect(Array.isArray(calledView.blocks)).toBe(true);
     });
+
+    it("surfaces UnknownViewError when the repository rejects the persisted blocks", async () => {
+      const { service, repo } = await build({ blocks: [testBlockModule()] });
+      const created = await service.create({ name: "X" });
+      expectOk(created);
+      vi.spyOn(repo, "update").mockReturnValueOnce(new Err(new UnknownViewError(created.value)));
+
+      const result = await service.addBlock(created.value, "test-block");
+      expectErr(result);
+      expect(result.error.kind).toBe("unknown-view");
+    });
   });
 
   describe("removeBlock", () => {
@@ -414,6 +443,19 @@ describe("ViewsService", () => {
       expectOk(created);
       await service.removeBlock(created.value, "missing-id" as BlockInstanceId);
       expect(repo.get(created.value).match({ some: (v) => v.blocks, none: () => null })).toEqual([]);
+    });
+
+    it("surfaces UnknownViewError when the repository rejects the persisted blocks", async () => {
+      const { service, repo } = await build({ blocks: [testBlockModule()] });
+      const created = await service.create({ name: "X" });
+      expectOk(created);
+      const added = await service.addBlock(created.value, "test-block");
+      expectOk(added);
+      vi.spyOn(repo, "update").mockReturnValueOnce(new Err(new UnknownViewError(created.value)));
+
+      const result = await service.removeBlock(created.value, added.value);
+      expectErr(result);
+      expect(result.error.kind).toBe("unknown-view");
     });
   });
 
@@ -482,6 +524,21 @@ describe("ViewsService", () => {
       expectErr(result);
       expect(result.error.kind).toBe("unknown-view");
     });
+
+    it("surfaces UnknownViewError when the repository rejects the reordered blocks", async () => {
+      const { service, repo } = await build({ blocks: [testBlockModule()] });
+      const created = await service.create({ name: "X" });
+      expectOk(created);
+      const a = await service.addBlock(created.value, "test-block");
+      const b = await service.addBlock(created.value, "test-block");
+      expectOk(a);
+      expectOk(b);
+      vi.spyOn(repo, "update").mockReturnValueOnce(new Err(new UnknownViewError(created.value)));
+
+      const result = await service.setBlockOrder(created.value, [b.value, a.value]);
+      expectErr(result);
+      expect(result.error.kind).toBe("unknown-view");
+    });
   });
 
   describe("updateBlockConfig", () => {
@@ -505,6 +562,58 @@ describe("ViewsService", () => {
       await service.updateBlockConfig(created.value, added.value, { x: 42 });
       const config = repo.get(created.value).match({ some: (v) => v.blocks[0]?.config, none: () => null });
       expect(config).toEqual({ x: 42 });
+    });
+
+    it("is an Ok no-op when the block instance id does not exist", async () => {
+      const { service, repo } = await build({ blocks: [testBlockModule()] });
+      const created = await service.create({ name: "X" });
+      expectOk(created);
+      const result = await service.updateBlockConfig(created.value, "missing-id" as BlockInstanceId, { x: 1 });
+      expectOk(result);
+      expect(repo.get(created.value).match({ some: (v) => v.blocks, none: () => null })).toEqual([]);
+    });
+
+    it("persists without validation and logs when the block key is unregistered", async () => {
+      const { service, repo } = await build({ blocks: [testBlockModule()] });
+      const created = await service.create({ name: "X" });
+      expectOk(created);
+      const added = await service.addBlock(created.value, "test-block");
+      expectOk(added);
+      const view = repo.get(created.value).match({ some: (v) => v, none: () => null })!;
+      repo.update(created.value, { blocks: view.blocks.map((b) => ({ ...b, key: "unregistered-key" })) });
+
+      const result = await service.updateBlockConfig(created.value, added.value, { anything: true });
+      expectOk(result);
+      const config = repo.get(created.value).match({ some: (v) => v.blocks[0]?.config, none: () => null });
+      expect(config).toEqual({ anything: true });
+    });
+
+    it("leaves the other blocks in the view unchanged", async () => {
+      const { service, repo } = await build({ blocks: [testBlockModule()] });
+      const created = await service.create({ name: "X" });
+      expectOk(created);
+      const first = await service.addBlock(created.value, "test-block");
+      const second = await service.addBlock(created.value, "test-block");
+      expectOk(first);
+      expectOk(second);
+      await service.updateBlockConfig(created.value, first.value, { x: 42 });
+      const secondConfig = repo
+        .get(created.value)
+        .match({ some: (v) => v.blocks.find((b) => b.id === second.value)?.config, none: () => null });
+      expect(secondConfig).toEqual({ x: 0 });
+    });
+
+    it("surfaces UnknownViewError when the repository rejects the persisted config", async () => {
+      const { service, repo } = await build({ blocks: [testBlockModule()] });
+      const created = await service.create({ name: "X" });
+      expectOk(created);
+      const added = await service.addBlock(created.value, "test-block");
+      expectOk(added);
+      vi.spyOn(repo, "update").mockReturnValueOnce(new Err(new UnknownViewError(created.value)));
+
+      const result = await service.updateBlockConfig(created.value, added.value, { x: 1 });
+      expectErr(result);
+      expect(result.error.kind).toBe("unknown-view");
     });
   });
 });
@@ -563,6 +672,16 @@ describe("ViewsService – toolbar-item operations", () => {
       expectErr(result);
       expect(result.error.kind).toBe("unknown-toolbar-item-key");
     });
+
+    it("returns Ok(null) when the block id does not belong to the view", async () => {
+      const { service } = await build({ items: [testItemModule()] });
+      const created = await service.create({ name: "X" });
+      expectOk(created);
+
+      const result = await service.addToolbarItem(created.value, "missing-block" as BlockInstanceId, "dummy");
+      expectOk(result);
+      expect(result.value).toBeNull();
+    });
   });
 
   describe("removeToolbarItem", () => {
@@ -582,6 +701,28 @@ describe("ViewsService – toolbar-item operations", () => {
         .get(created.value)
         .match({ some: (v) => (v.blocks[0]?.config as { items: unknown[] }).items, none: () => null });
       expect(items).toHaveLength(0);
+    });
+
+    it("is an Ok no-op when the item id does not exist in the block", async () => {
+      const { service, repo } = await build({ items: [testItemModule()] });
+      const created = await service.create({ name: "X" });
+      expectOk(created);
+      const blockAdded = await service.addBlock(created.value, "toolbar");
+      expectOk(blockAdded);
+      const itemAdded = await service.addToolbarItem(created.value, blockAdded.value, "dummy");
+      expectOk(itemAdded);
+
+      const result = await service.removeToolbarItem(
+        created.value,
+        blockAdded.value,
+        "missing-item" as BlockInstanceId,
+      );
+      expectOk(result);
+
+      const items = repo
+        .get(created.value)
+        .match({ some: (v) => (v.blocks[0]?.config as { items: unknown[] }).items, none: () => null });
+      expect(items).toHaveLength(1);
     });
   });
 
@@ -701,6 +842,30 @@ describe("ViewsService – toolbar-item operations", () => {
         none: () => null,
       });
       expect(config).toEqual({ anything: true });
+    });
+
+    it("is an Ok no-op when the item id does not exist in the block", async () => {
+      const { service, repo } = await build({ items: [testItemModule()] });
+      const created = await service.create({ name: "X" });
+      expectOk(created);
+      const blockAdded = await service.addBlock(created.value, "toolbar");
+      expectOk(blockAdded);
+      const itemAdded = await service.addToolbarItem(created.value, blockAdded.value, "dummy");
+      expectOk(itemAdded);
+
+      const result = await service.updateToolbarItemConfig(
+        created.value,
+        blockAdded.value,
+        "missing-item" as BlockInstanceId,
+        { x: 1 },
+      );
+      expectOk(result);
+
+      const config = repo.get(created.value).match({
+        some: (v) => (v.blocks[0]?.config as { items: { config: unknown }[] }).items[0]?.config,
+        none: () => null,
+      });
+      expect(config).toEqual({ x: 0 });
     });
   });
 

--- a/src/views/ui/ConfirmRepositionModal.test.ts
+++ b/src/views/ui/ConfirmRepositionModal.test.ts
@@ -1,0 +1,32 @@
+import userEvent from "@testing-library/user-event";
+import { screen } from "@testing-library/vue";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { m } from "@/i18n";
+import { testContainer, type TestHarness } from "@/testing";
+
+import ConfirmRepositionModal from "./ConfirmRepositionModal.vue";
+
+describe("ConfirmRepositionModal", () => {
+  let harness: TestHarness;
+
+  beforeEach(async () => {
+    harness = await testContainer();
+  });
+
+  it("submits when the user confirms the move", async () => {
+    const { submit } = harness.renderModal(ConfirmRepositionModal, { props: { location: "the right sidebar" } });
+
+    await userEvent.click(screen.getByText(m.view_reposition_modal_confirm()));
+
+    expect(submit).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels when the user clicks Cancel", async () => {
+    const { cancel } = harness.renderModal(ConfirmRepositionModal, { props: { location: "the right sidebar" } });
+
+    await userEvent.click(screen.getByText(m.common_action_cancel()));
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/views/use-follow-active-note.test.ts
+++ b/src/views/use-follow-active-note.test.ts
@@ -174,6 +174,10 @@ describe("useFollowActiveNote", () => {
     expect(followed).toEqual(["2026-01-01"]);
   });
 
+  // An implementation that derives the interval from the view's date instead of the
+  // entry's anchor makes coverage trivially true, so this alone cannot prove
+  // correctness — see "follows the opened custom interval when it does not contain
+  // the view's date" for the discriminating case.
   it("holds the view's date when the opened custom interval contains it", async () => {
     // The sprint anchored 2026-01-05 repeats every two weeks, so 2026-07-06 starts one that
     // runs through 2026-07-19.
@@ -183,5 +187,16 @@ describe("useFollowActiveNote", () => {
     await nextTick();
 
     expect(followed).toEqual([]);
+  });
+
+  it("follows the opened custom interval when it does not contain the view's date", async () => {
+    // The sprint anchored 2026-01-05 repeats every two weeks, so 2026-07-06 starts one that
+    // runs through 2026-07-19 — well before the view's date here.
+    const { harness, followed } = await mount({ currentDate: "2026-08-15" });
+
+    openEntry(harness, "sprint", "2026-07-06" as AnchorString);
+    await nextTick();
+
+    expect(followed).toEqual(["2026-07-06"]);
   });
 });

--- a/src/views/view-host.test.ts
+++ b/src/views/view-host.test.ts
@@ -41,6 +41,7 @@ async function build(seeds: Record<string, View> = {}, shelves: Record<string, S
     repo: harness.resolve(ViewsRepository),
     storage: harness.settings.recordOf(viewsCollection),
     suggests: harness.suggests,
+    notices: harness.notices,
   };
 }
 
@@ -156,6 +157,17 @@ describe("ViewHostService", () => {
       expect(host.commands.get(`change-shelf:${VIEW_A}`)?.checkCallback?.(true)).toBe(false);
     });
 
+    it("opens the picker instead of noticing when no shelves exist but the view is open", async () => {
+      const { host, suggests, notices } = await build({ [VIEW_A]: buildView(VIEW_A) });
+      openVia(host, VIEW_A);
+      await Promise.resolve();
+
+      host.commands.get(`change-shelf:${VIEW_A}`)?.checkCallback?.(false);
+
+      expect(suggests.opens).toHaveLength(1);
+      expect(notices.messages).toEqual([]);
+    });
+
     it("hides the command while the view is not open", async () => {
       const { host } = await build({ [VIEW_A]: buildView(VIEW_A) }, { work: buildShelf("work") });
       expect(host.commands.get(`change-shelf:${VIEW_A}`)?.checkCallback?.(true)).toBe(false);
@@ -170,6 +182,14 @@ describe("ViewHostService", () => {
       await Promise.resolve();
       host.commands.get(`change-shelf:${VIEW_A}`)?.checkCallback?.(false);
       expect(suggests.lastOpen().input).toEqual([m.common_label_all_journals(), "work", "home"]);
+    });
+
+    it("notices instead of doing nothing when invoked with no open view", async () => {
+      const { host, notices } = await build({ [VIEW_A]: buildView(VIEW_A, { name: "Calendar" }) });
+
+      host.commands.get(`change-shelf:${VIEW_A}`)?.checkCallback?.(false);
+
+      expect(notices.messages).toContain(m.command_view_shelf_needs_open_view({ name: "Calendar" }));
     });
   });
 

--- a/src/views/view-host.test.ts
+++ b/src/views/view-host.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { m } from "@/i18n";
 import { journalsCoreModule } from "@/journals/module";
@@ -20,6 +20,7 @@ import type { WorkspaceLeaf } from "obsidian";
 const VIEW_A = "11111111-1111-4111-8111-111111111111" as ViewId;
 const VIEW_B = "22222222-2222-4222-8222-222222222222" as ViewId;
 const VIEW_NEW = "33333333-3333-4333-8333-333333333333" as ViewId;
+const VIEW_UNKNOWN = "44444444-4444-4444-8444-444444444444" as ViewId;
 
 function openVia(host: FakeHost, id: ViewId): void {
   host.commands.get(`open-view:${id}`)?.callback?.();
@@ -42,6 +43,7 @@ async function build(seeds: Record<string, View> = {}, shelves: Record<string, S
     storage: harness.settings.recordOf(viewsCollection),
     suggests: harness.suggests,
     notices: harness.notices,
+    logs: harness.logs,
   };
 }
 
@@ -82,6 +84,19 @@ describe("ViewHostService", () => {
       events.emit("created", VIEW_NEW);
       expect(host.registeredViews.has(`journal-view:${VIEW_NEW}`)).toBe(true);
     });
+
+    it("does not add a second ribbon icon when created fires for a view already registered", async () => {
+      const { host, events } = await build({ [VIEW_A]: buildView(VIEW_A, { showInRibbon: true }) });
+      events.emit("created", VIEW_A);
+      const matches = host.ribbonIcons.filter((r) => r.id === `journal-command:open-view:${VIEW_A}`);
+      expect(matches).toHaveLength(1);
+    });
+
+    it("warns and skips registration when created fires for a view missing from storage", async () => {
+      const { host, events } = await build();
+      events.emit("created", VIEW_NEW);
+      expect(host.registeredViews.has(`journal-view:${VIEW_NEW}`)).toBe(false);
+    });
   });
 
   describe("updated event", () => {
@@ -111,6 +126,19 @@ describe("ViewHostService", () => {
       storage[VIEW_A].icon = "star";
       expect(() => events.emit("updated", VIEW_A, { icon: "star" })).not.toThrow();
     });
+
+    it("skips resync for a view present in storage but never registered", async () => {
+      const { host, events, storage } = await build();
+      storage[VIEW_NEW] = buildView(VIEW_NEW);
+      events.emit("updated", VIEW_NEW, {});
+      expect(host.commands.has(`open-view:${VIEW_NEW}`)).toBe(false);
+    });
+
+    it("does not throw when updated fires after the view's storage entry is removed", async () => {
+      const { events, storage } = await build({ [VIEW_A]: buildView(VIEW_A) });
+      delete storage[VIEW_A];
+      expect(() => events.emit("updated", VIEW_A, {})).not.toThrow();
+    });
   });
 
   describe("deleted event", () => {
@@ -132,6 +160,11 @@ describe("ViewHostService", () => {
       events.emit("deleted", VIEW_A);
       expect(host.ribbonIcons.some((r) => r.id === `journal-command:open-view:${VIEW_A}`)).toBe(false);
     });
+
+    it("does nothing when deleted fires for a view that was never registered", async () => {
+      const { events } = await build();
+      expect(() => events.emit("deleted", VIEW_NEW)).not.toThrow();
+    });
   });
 
   describe("stale viewType", () => {
@@ -142,6 +175,33 @@ describe("ViewHostService", () => {
       const leafStub = { containerEl: document.createElement("div") } as unknown as WorkspaceLeaf;
       const result = factory(leafStub);
       expect(result.getDisplayText()).toBe("Stale view");
+    });
+
+    it("keeps answering the original view type once stale", async () => {
+      const { host, events } = await build({ [VIEW_A]: buildView(VIEW_A) });
+      const factory = host.registeredViews.get(`journal-view:${VIEW_A}`)!.factory;
+      events.emit("deleted", VIEW_A);
+      const leafStub = { containerEl: document.createElement("div") } as unknown as WorkspaceLeaf;
+      const result = factory(leafStub);
+      expect(result.getViewType()).toBe(`journal-view:${VIEW_A}`);
+    });
+
+    it("warns when a stale leaf is actually opened", async () => {
+      const { host, events, logs } = await build({ [VIEW_A]: buildView(VIEW_A) });
+      const factory = host.registeredViews.get(`journal-view:${VIEW_A}`)!.factory;
+      events.emit("deleted", VIEW_A);
+      const leafStub = { containerEl: document.createElement("div") } as unknown as WorkspaceLeaf;
+      const result = factory(leafStub);
+      await (result as unknown as { onOpen: () => Promise<void> }).onOpen();
+      expect(logs.records.some((r) => r.message === "opened stale view")).toBe(true);
+    });
+
+    it("builds a live view leaf for a view type that was never marked stale", async () => {
+      const { host } = await build({ [VIEW_A]: buildView(VIEW_A, { name: "Something" }) });
+      const factory = host.registeredViews.get(`journal-view:${VIEW_A}`)!.factory;
+      const leafStub = { containerEl: document.createElement("div") } as unknown as WorkspaceLeaf;
+      const result = factory(leafStub);
+      expect(result.getDisplayText()).toBe("Something");
     });
   });
 
@@ -190,6 +250,51 @@ describe("ViewHostService", () => {
       host.commands.get(`change-shelf:${VIEW_A}`)?.checkCallback?.(false);
 
       expect(notices.messages).toContain(m.command_view_shelf_needs_open_view({ name: "Calendar" }));
+    });
+
+    it("stops at the cancelled picker without looking up the view's leaves", async () => {
+      const { host, suggests } = await build({ [VIEW_A]: buildView(VIEW_A) }, { work: buildShelf("work") });
+      openVia(host, VIEW_A);
+      await Promise.resolve();
+      host.commands.get(`change-shelf:${VIEW_A}`)?.checkCallback?.(false);
+      const spy = vi.spyOn(host.app.workspace, "getLeavesOfType");
+
+      suggests.lastOpen().cancel();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(spy).not.toHaveBeenCalledWith(`journal-view:${VIEW_A}`);
+    });
+
+    it("looks up the view's leaves once a shelf is chosen", async () => {
+      const { host, suggests } = await build({ [VIEW_A]: buildView(VIEW_A) }, { work: buildShelf("work") });
+      openVia(host, VIEW_A);
+      await Promise.resolve();
+      host.commands.get(`change-shelf:${VIEW_A}`)?.checkCallback?.(false);
+      const spy = vi.spyOn(host.app.workspace, "getLeavesOfType");
+
+      suggests.lastOpen<string[], string>().choose("work");
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(spy).toHaveBeenCalledWith(`journal-view:${VIEW_A}`);
+    });
+
+    it("looks up the view's leaves once all journals is chosen", async () => {
+      const { host, suggests } = await build({ [VIEW_A]: buildView(VIEW_A) }, { work: buildShelf("work") });
+      openVia(host, VIEW_A);
+      await Promise.resolve();
+      host.commands.get(`change-shelf:${VIEW_A}`)?.checkCallback?.(false);
+      const spy = vi.spyOn(host.app.workspace, "getLeavesOfType");
+
+      suggests.lastOpen<string[], string>().choose(m.common_label_all_journals());
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(spy).toHaveBeenCalledWith(`journal-view:${VIEW_A}`);
     });
   });
 
@@ -328,6 +433,16 @@ describe("ViewHostService", () => {
       expect(host.workspace.viewStateCalls).toEqual([]);
       expect(host.workspace.detachedTypes).toEqual([]);
     });
+
+    it("falls back to the default right placement for a view with no stored config", async () => {
+      const { service, host } = await build();
+      await host.app.workspace.getRightLeaf(false)!.setViewState({ type: `journal-view:${VIEW_UNKNOWN}` });
+      host.workspace.viewStateCalls.length = 0;
+
+      await service.reposition(VIEW_UNKNOWN);
+
+      expect(host.workspace.viewStateCalls).toEqual([{ type: `journal-view:${VIEW_UNKNOWN}`, placement: "right" }]);
+    });
   });
 
   describe("initialize", () => {
@@ -365,6 +480,23 @@ describe("ViewHostService", () => {
       await Promise.resolve();
       expect(host.workspace.viewStateCalls).toEqual([{ type: `journal-view:${VIEW_A}`, placement: "right" }]);
       expect(host.workspace.revealLeafCalls).toBe(0);
+      expect(host.workspace.activatedTypes).toEqual([]);
+    });
+
+    it("logs and continues past a view whose startup placement throws", async () => {
+      const { service, host, storage, logs } = await build({
+        [VIEW_A]: buildView(VIEW_A, { openOnStartup: true }),
+        [VIEW_B]: buildView(VIEW_B, { openOnStartup: true }),
+      });
+      storage[VIEW_A].leaf = "invalid" as unknown as View["leaf"];
+      host.workspace.layoutReady = false;
+      service.initialize();
+      host.setLayoutReady();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(host.workspace.viewStateCalls).toEqual([{ type: `journal-view:${VIEW_B}`, placement: "right" }]);
+      expect(logs.records.some((r) => r.message === "failed to open view on startup")).toBe(true);
     });
 
     it("leaves a view already restored from the layout untouched on startup", async () => {
@@ -396,6 +528,12 @@ describe("ViewHostService", () => {
       await Promise.resolve();
       expect(host.workspace.activatedTypes).toEqual([]);
     });
+
+    it("falls back to the default right placement for a view with no stored config", async () => {
+      const { service, host } = await build();
+      await service.open(VIEW_UNKNOWN);
+      expect(host.workspace.viewStateCalls).toEqual([{ type: `journal-view:${VIEW_UNKNOWN}`, placement: "right" }]);
+    });
   });
 
   describe("dispose", () => {
@@ -404,6 +542,12 @@ describe("ViewHostService", () => {
       service.dispose();
       expect(host.workspace.detachedTypes).toContain(`journal-view:${VIEW_A}`);
       expect(host.workspace.detachedTypes).toContain(`journal-view:${VIEW_B}`);
+    });
+
+    it("disposes every registration when the plugin unloads", async () => {
+      const { host } = await build({ [VIEW_A]: buildView(VIEW_A) });
+      host.triggerUnload();
+      expect(host.workspace.detachedTypes).toContain(`journal-view:${VIEW_A}`);
     });
   });
 });

--- a/src/views/view-host.ts
+++ b/src/views/view-host.ts
@@ -3,6 +3,7 @@ import { match } from "ts-pattern";
 
 import { m } from "@/i18n";
 import { inject, InjectorToken } from "@/infrastructure/di";
+import { NoticeService } from "@/infrastructure/host";
 import { CommandService } from "@/infrastructure/host/commands";
 import { InternalObsidianAppToken, InternalPluginToken } from "@/infrastructure/host/internal/tokens";
 import { SuggestService } from "@/infrastructure/host/suggests";
@@ -24,6 +25,7 @@ export class ViewHostService {
   readonly #repo = inject(ViewsRepository);
   readonly #shelves = inject(ShelvesRepository);
   readonly #suggests = inject(SuggestService);
+  readonly #notices = inject(NoticeService);
   readonly #events = inject(ViewsEventsToken);
   readonly #logger = inject(LoggerFactoryToken).named("view-host");
   readonly #injector = inject(InjectorToken);
@@ -153,9 +155,16 @@ export class ViewHostService {
       icon: view.icon || FALLBACK_VIEW_ICON,
       ribbon: false,
       check: () => this.#shelves.count() > 0 && this.isOpen(id),
-      // check only hides the command from the palette; a hotkey still reaches execute, and
-      // picking a shelf for a view with no open leaf has nothing to apply it to.
-      execute: () => (this.isOpen(id) ? this.#pickShelf(id) : undefined),
+      // check only hides the command from the palette; a hotkey still reaches execute. Picking a
+      // shelf for a view with no open leaf has nothing to apply it to, so say so rather than
+      // doing nothing. Zero shelves is not a dead end — the picker still offers "all journals".
+      execute: () => {
+        if (!this.isOpen(id)) {
+          this.#notices.show(m.command_view_shelf_needs_open_view({ name: view.name }));
+          return;
+        }
+        void this.#pickShelf(id);
+      },
     };
   }
 

--- a/src/views/view-leaf.test.ts
+++ b/src/views/view-leaf.test.ts
@@ -256,17 +256,22 @@ describe("JournalViewLeaf", () => {
       const view = buildView(VIEW_A, { blocks: [{ id: BLOCK_STUB, key: "context-probe", config: {} }] });
       const { leafInstance } = await buildLeaf(view, { modules: [testBlocksModule([block])] });
       const leaf = leafInstance as unknown as { onOpen(): Promise<void>; onClose(): Promise<void> };
-      await leaf.onOpen();
+      // try/finally so a failed assertion still unmounts the view and releases the shared
+      // useToday() instance, rather than leaking it armed under a stopped fake clock into
+      // whichever test runs next.
+      try {
+        await leaf.onOpen();
 
-      expect(probe.context?.refDate.value).toBe("2026-03-09");
+        expect(probe.context?.refDate.value).toBe("2026-03-09");
 
-      vi.setSystemTime(new Date(2026, 2, 10, 0, 0, 1));
-      await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
-      await nextTick();
+        vi.setSystemTime(new Date(2026, 2, 10, 0, 0, 1));
+        await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+        await nextTick();
 
-      expect(probe.context?.refDate.value).toBe("2026-03-10");
-
-      await leaf.onClose();
+        expect(probe.context?.refDate.value).toBe("2026-03-10");
+      } finally {
+        await leaf.onClose();
+      }
     });
   });
 
@@ -274,7 +279,7 @@ describe("JournalViewLeaf", () => {
     it("reports a follow origin when an in-scope journal note opens", async () => {
       const { harness, leaf, leafInstance, probe } = await buildFollowingView();
       // Seeded so the view's date sits outside the daily note's own day, independent of the
-      // real wall clock — otherwise the Task 3 follow guard would hold on any run where
+      // real wall clock — otherwise the follow guard would hold on any run where
       // today happens to land on 2026-03-09.
       await leafInstance.setState({ refDate: "2026-01-01" }, {});
       await leaf.onOpen();

--- a/src/views/view-leaf.test.ts
+++ b/src/views/view-leaf.test.ts
@@ -1,5 +1,5 @@
 import * as v from "valibot";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { h, nextTick } from "vue";
 
 import type { AnchorString } from "@/calendar/types";
@@ -239,6 +239,33 @@ describe("JournalViewLeaf", () => {
       const leaf = leafInstance as unknown as { onOpen(): Promise<void>; onClose(): Promise<void> };
       await leaf.onOpen();
       expect(containerEl.textContent).toContain(m.view_block_config_error());
+      await leaf.onClose();
+    });
+  });
+
+  describe("refDate wall clock", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("moves the leaf's ref date when the day changes under an open view", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2026, 2, 9, 23, 0, 0));
+
+      const { block, probe } = contextProbeBlock();
+      const view = buildView(VIEW_A, { blocks: [{ id: BLOCK_STUB, key: "context-probe", config: {} }] });
+      const { leafInstance } = await buildLeaf(view, { modules: [testBlocksModule([block])] });
+      const leaf = leafInstance as unknown as { onOpen(): Promise<void>; onClose(): Promise<void> };
+      await leaf.onOpen();
+
+      expect(probe.context?.refDate.value).toBe("2026-03-09");
+
+      vi.setSystemTime(new Date(2026, 2, 10, 0, 0, 1));
+      await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+      await nextTick();
+
+      expect(probe.context?.refDate.value).toBe("2026-03-10");
+
       await leaf.onClose();
     });
   });

--- a/src/views/view-leaf.ts
+++ b/src/views/view-leaf.ts
@@ -2,8 +2,8 @@ import { ItemView, type WorkspaceLeaf } from "obsidian";
 import * as v from "valibot";
 import { computed, createApp, defineComponent, h, reactive, shallowRef, type App as VueApp, type VNode } from "vue";
 
-import { CalendarDate } from "@/calendar/calendar-date";
 import type { AnchorString } from "@/calendar/types";
+import { useToday } from "@/calendar/ui/use-today";
 import { m } from "@/i18n";
 import { provideInjectorOnApp, type Injector } from "@/infrastructure/di";
 import { InternalObsidianAppToken } from "@/infrastructure/host/internal/tokens";
@@ -110,10 +110,6 @@ export class JournalViewLeaf extends ItemView {
   }
 }
 
-function todayAnchor(): AnchorString {
-  return CalendarDate.today().toAnchor();
-}
-
 function buildRootComponent(viewId: ViewId, leafState: JournalViewLeafState, injector: Injector) {
   return defineComponent({
     setup() {
@@ -123,15 +119,16 @@ function buildRootComponent(viewId: ViewId, leafState: JournalViewLeafState, inj
       const logger = injector.resolve(LoggerFactoryToken).named("view-leaf");
 
       const view = computed(() => repo.get(viewId).match({ some: (current) => current, none: () => null }));
+      const today = useToday();
 
-      // Set only by the view-level follow writer (Task 2) and cleared by every explicit
+      // Set only by the view-level follow writer and cleared by every explicit
       // navigation, so refDateOrigin can tell the two apart without a second date.
       const followedAnchor = shallowRef<AnchorString | null>(null);
 
       const context: ViewContext = {
         viewId,
         viewName: computed(() => view.value?.name ?? ""),
-        refDate: computed(() => leafState.refDate ?? todayAnchor()),
+        refDate: computed(() => leafState.refDate ?? today.value.toAnchor()),
         refDateOrigin: computed(() => (leafState.refDate === followedAnchor.value ? "follow" : "navigate")),
         shelf: computed(() =>
           resolveLeafShelf(leafState.shelf, view.value?.defaultShelf ?? null, (name) => shelves.get(name).isSome()),

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -442,10 +442,64 @@ export default defineConfig({
         // suite pushes an update through the rejecting path. `src/views/repository.ts` also keeps
         // the pre-existing uncovered `InvalidViewNameError` return at `:31`; this branch did not
         // touch it.
-        statements: 92.66,
-        branches: 87.9,
-        functions: 89.86,
-        lines: 94.68,
+        //
+        // Phase 4.5's own closing task re-measured against the merge base with main, `595c2c01`,
+        // which reproduced the numbers above exactly: 92.66 / 87.9 / 89.86 / 94.68 (11093/11971
+        // statements, 4782/5440 branches, 3955/4401 functions, 9688/10232 lines). Diffing every
+        // file's branch numerator and denominator between that base and this tip (`f214a911`)
+        // surfaced twelve files that moved; every other file in the coverage set held identical
+        // branch counts on both sides, not merely the same rounded percentage, so the aggregate
+        // rise below is not hiding a cancellation among files this comment omits.
+        //
+        // `src/main.ts` 0/4 -> 4/4 (`3b447325`, "cover onload failure, api ordering and unload").
+        // `src/api/journals-api.ts` 73/99 -> 82/99, total held (`ade31b23`, probing the three
+        // error codes no prior test asserted). `src/code-blocks/nav/settings/ui/EditNavBlockSegmentModal.vue`
+        // 54/59 -> 55/59, total held (`7e6164eb`, the code-blocks nav/timeline/home sweep).
+        // `src/maintenance/ui/MaintenanceBlock.vue` 0/2 -> 2/2 and
+        // `src/views/ui/ConfirmRepositionModal.vue` 0/4 -> 4/4, both their first tests ever
+        // (`f214a911`, "cover the remaining zero-coverage surfaces"). `src/notes-calendar/ui/NotesWeekView.vue`
+        // 27/28 -> 28/28, total held (`d03fbe68`, the notes-calendar week/cell/timeline sweep).
+        // `src/settings/legacy/data-migration-service.ts` 39/52 -> 41/52, total held (`a9079711`,
+        // "separate the two data-migration undefined arms"). `src/settings/legacy/journal-conversion.ts`
+        // 31/53 -> 52/53, total held — five settings commits (`e771e544`, `20209175`, `e29f011a`,
+        // `d3eed9a4`, `3f007cd6`) added targeted tests for the year-reset divisors, the interval
+        // frontmatter/ribbon paths and nav block row conversion, closing nearly every
+        // previously-untested arm in this one file. `src/ui/UiIcon.vue` 4/6 -> 5/6, total held
+        // (`2fcecee6`/`83c63beb`, the icon-null-append assertion and the fake `getIcon` fix it
+        // needed). `src/views/service.ts` 32/48 -> 42/48, total held (`05678d2f` and `f214a911`).
+        // `src/views/view-host.ts` 28/44 -> 42/44 — branch total held, but this file's own
+        // statement/line totals also grew (135->139, 118->122): `699a67bc` is a real bug fix, not a
+        // test-only change. The shelf-picker command used to no-op silently when its view had no
+        // open leaf; it now shows a notice (`command_view_shelf_needs_open_view` in
+        // `messages/en.json`, this phase's one message-key addition), which is a new, testable
+        // guard branch. `9ce1e116` then closed the rest of this file's pre-existing guard branches,
+        // unrelated to the fix.
+        //
+        // `src/templates/engine.ts` 161/179 -> 159/177 is the one file where *covered* fell, not
+        // just total, and reads differently from "an unreachable branch removed" on a closer look.
+        // `dc34311b` deletes `matched.groups ?? {}` — a nullish-coalescing branch whose both arms
+        // were already exercised, 2/2 covered — and reads `matched.groups` directly, pushing the
+        // one downstream access through `groups?.[...]` instead. That is a real
+        // behavior-preserving simplification (the deleted comment already explained the fallback
+        // never mattered: the loop that would read it never runs when there are no capture
+        // groups), but the optional-chaining replacement does not register as a same-size branch
+        // pair under this project's v8 coverage provider, so the file's branch total *and* covered
+        // count both drop by two — statements and lines on this file are unchanged, 264/282 and
+        // 241/251 on both sides. Nothing that used to be exercised stopped being exercised; the raw
+        // branch numbers just do not show "covered unchanged" the way a first read of "removed an
+        // unreachable branch" suggests — they show covered falling in step with total.
+        //
+        // The aggregate below still rises on every one of the four metrics net of that fall: the
+        // eleven other files' gains outweigh it. That net rise is exactly why per-file reading
+        // matters here — an aggregate-only read would show four clean increases and never surface
+        // that one file's branch coverage fell at all.
+        //
+        // Tip: 93.99 / 89.16 / 90.86 / 95.94 (11256/11975 statements, 4849/5438 branches,
+        // 3998/4400 functions, 9821/10236 lines).
+        statements: 93.99,
+        branches: 89.16,
+        functions: 90.86,
+        lines: 95.94,
       },
     },
     projects: [


### PR DESCRIPTION
Closes the Phase 4.5 charter: every gap the six Phase 3 sweeps recorded and could not fill.

## Baseline → tip

Measured at `595c2c01` and at this tip.

```
Test files  395 → 403
Tests       4219 → 4309   (+90)
```

| metric | base | tip |
| --- | --- | --- |
| statements | 92.66 (11093/11971) | **93.99** (11256/11975) |
| branches | 87.90 (4782/5440) | **89.16** (4849/5438) |
| functions | 89.86 (3955/4401) | **90.86** (3998/4400) |
| lines | 94.68 (9688/10232) | **95.94** (9821/10236) |

e2e: 59 specs, 310 tests, 0 failures. All of `check:types`, `check:lint`, `check:i18n`, `check:api`, `npm test`, `npm run coverage` and `npm run build` are green.

`messages/en.json` gains exactly one line (`command_view_shelf_needs_open_view`, D2). No `messages/*.json` reformatting: `git diff --stat 595c2c01..HEAD -- messages/` is `1 file changed, 1 insertion(+)`.

## Per-file branch attribution

Twelve files moved. Every other file in the coverage set was verified identical on both sides — **not** inferred from a flat aggregate. That distinction is the point: an earlier sweep read "branches exactly flat" as proof nothing regressed, when the next sweep's flatness was a *cancellation* of two opposite movements.

| file | branches | direction |
| --- | --- | --- |
| `src/main.ts` | 0/4 → 4/4 | covered rose (`3b447325`) |
| `src/settings/legacy/journal-conversion.ts` | 31/53 → 52/53 | covered rose (`e29f011a`,`e771e544`,`20209175`,`3f007cd6`,`d3eed9a4`) |
| `src/views/view-host.ts` | 28/44 → 42/44 | covered rose (`9ce1e116`); statement/line **totals** also grew (135→139, 118→122) because `699a67bc` adds a real production guard |
| `src/views/service.ts` | 32/48 → 42/48 | covered rose (`05678d2f`, `f214a911`) |
| `src/api/journals-api.ts` | 73/99 → 82/99 | covered rose (`ade31b23`) |
| `src/settings/legacy/data-migration-service.ts` | 39/52 → 41/52 | covered rose (`a9079711`) |
| `src/views/ui/ConfirmRepositionModal.vue` | 0/4 → 4/4 | covered rose (`f214a911`) |
| `src/maintenance/ui/MaintenanceBlock.vue` | 0/2 → 2/2 | covered rose (`f214a911`) |
| `src/ui/UiIcon.vue` | 4/6 → 5/6 | covered rose (`83c63beb`, `2fcecee6`) |
| `src/notes-calendar/ui/NotesWeekView.vue` | 27/28 → 28/28 | covered rose (`d03fbe68`) |
| `src/code-blocks/nav/settings/ui/EditNavBlockSegmentModal.vue` | 54/59 → 55/59 | covered rose (`7e6164eb`) |
| **`src/templates/engine.ts`** | **161/179 → 159/177** | **total dropped *and* covered fell** (`dc34311b`) |

`engine.ts` is the only regression-shaped movement, and it is benign: `dc34311b` deletes an unreachable `?? {}` fallback in favour of `?.`, and optional chaining does not register as an equivalent branch pair under the v8 provider. Statements and lines on that file are **identical** on both sides (264/282, 241/251) — nothing that used to execute stopped executing.

Note this fall is invisible in the aggregate: all four aggregate metrics rose. Only the per-file read surfaces it.

## Charter entries

### Section A — guards that cannot fail

| entry | outcome |
| --- | --- |
| A1 migration ordering | **closed** `b35abe31` — `toEqual` on mark flags pins occurrence, not sequence; now records call order |
| A2 repair-derivation name | **closed** `7e41e95a` — renamed to what it falsifies (the stored *kind* reaching `defaultItem`) |
| A3 weekly repair | **recorded** `b80019ac` — two independent mechanisms produce the outcome; no single mutation discriminates. The per-mechanism guard already exists in `journals/config.test.ts` |
| A4 follow-active-note interval | **closed** `66fe7093` — closed by *adding the complement*; the existing test is structurally unfalsifiable since the wrong implementation makes coverage trivially true |
| A5 default view off the ribbon | **closed** `4e728445` |
| A6 unreachable capture-group fallback | **closed** `dc34311b` — deleted; zero test files changed |

### Section B — coverage targets

| target | branches | outcome |
| --- | --- | --- |
| `journal-conversion.ts` | 58.49% → **98.11%** | closed; one branch left (calendar template carry-over, a distinct fourth condition) |
| `journals-api.ts` | 73.73% → **82.82%** | closed with C1 |
| `view-host.ts` | 63.63% → **95.45%** | closed with C18; two branches recorded (see below) |
| `views/service.ts` | 66.66% → **87.5%** | closed; six branches recorded as unreachable by design |

Zero-coverage list: `main.ts` **0% → 100%**; `plugin-setting-tab.ts`, `ConfirmCreationModal.vue`, `ConfirmRepositionModal.vue`, `MaintenanceBlock.vue` all closed (`3b447325`, `f214a911`).

**Recorded, with owner:**
- `infrastructure/host/internal/markdown-render-service.ts` — permanently out of scope; `src/infrastructure/**` is what `testContainer` is built from. *Owner: standing charter boundary.*
- `Calendar/Journal/ShelfDecorations*.vue` (1 line each) — pure wiring shells forwarding one derived prop to `DecorationsSection`, which has its own tests. *Owner: testing-strategy maintainer, as a coverage-`exclude` candidate in Phase 6.*
- `views/service.ts`'s six residual branches — the throw side of four `mapErr` invariant guards (unreachable *by type*: `patch` structurally excludes `id`) and `setBlockOrder`'s dead ternary arm (excluded by the permutation guard above it). *Owner: views maintainer.*
- `view-host.ts`'s two — `view?.leaf ?? "right"` needs the repository to disagree with itself inside one synchronous stack; `#pickShelf`'s `instanceof JournalViewLeaf` arm is blocked by the harness (see *Raised*). *Owner: views maintainer.*

### Section C — the ledger

**Closed:** C1 `ade31b23` · C2 `2a0397df` · C3 `7e6164eb` · C4 `d03fbe68` · C6 `d03fbe68` · C7 `7e6164eb` · C8 `7e6164eb` · C9 `7e6164eb` · C12 `08096c85` · C16 `08096c85` · C18 `9ce1e116` · C20 (views half) `05678d2f` · C21 `2fcecee6` · C22 `2fcecee6` · C23 `a9079711` · C24 (views half) `9bffea5b`

**Recorded, with reason and owner:**

| entry | reason | owner |
| --- | --- | --- |
| C10 | **Not a gap.** The existing assertion already discriminates — inverting `TimelineMonth.vue`'s `outside-dates` reddens it | — |
| C11 | `scale` unobservable: `v-bind()`-in-`<style>` is inert here (see *Raised*) | toolchain |
| C13 | **Nothing to clean.** The `checkWeekday` claim holds (`format("d")` is locale-independent) but no false dependency exists to delete | — |
| C14 | **Already guarded.** `ConditionProperty.test.ts` has three dedicated tests for the watcher; the charter scoped one file too narrowly | — |
| C15 | **Claims match nothing.** The real cluster uses scoped `querySelector`, not `screen.getByText`; `entry.kind` appears only in an unrelated modal. All six tests discriminate | — |
| C17 | **Already guarded accidentally.** A pre-existing test dies on the same mutation, because `@vue/test-utils` deep-wraps every object prop. Test kept to pin it deliberately | decorations maintainer |
| C19 | Structurally unfalsifiable: `periodMatchesWrite` matches `custom` only against `day` periods, and this component renders only week/month/quarter/year | views maintainer |
| C20 (decorations half) | vee-validate's `klona` **and** valibot's `cast` both sanitize upstream of the guard; no black-box assertion can distinguish the two implementations | decorations maintainer |
| C23 (arm independence) | The two arms are **coupled**: `anchorOf` returns `None` only when the same repository lookup misses, so `config === undefined` is never the deciding term | settings maintainer |
| C24 (commands half) | `idKey` is `undefined`, so the guard short-circuits — unreachable, not untested | see *Raised* |

C5 was already recorded by the charter as a gap that does not exist. Confirmed; no work.

### Section D — production

- **D1** `c2a2fe99` — `view-leaf` now reads today through `useToday()`; the wall-clock-in-`computed` bug (#275 shape).
- **D2** `699a67bc` — the shelf command now notices when no view is open. **One** dead end, not two.

### Section E — harness

E1 `83c63beb` · E2 `1ddeee87` · E3 `2e885fe2` · E4 `79dc1ea6` (+ `b80dbbe0` docs) · E5 `845a6af3` — all closed. E6: half was already closed; the remaining `RuleTester` half is a Phase 6 item (see *Raised*).

## Corrections this phase made to the charter

So the next reader does not re-derive them:

1. **C24 is half what it claimed.** `commands/repository.ts`'s `invalidUpdateError` is *unreachable* (`idKey` is `undefined`), not untested. Coverage cannot distinguish the two — that is this phase's thesis in one entry.
2. **D2 has one dead end, not two.** Zero shelves with an open view still opens a working one-option picker.
3. **`src/main.ts` is not pure wiring.** It holds five real behaviours; the coverage-exclude answer would have violated the glob's own caveat. The mock had no `Plugin` class at all.
4. **C14 and C17 were never open.** Both were already guarded — one by a leaf component's own test file, one accidentally by an unlabeled test.
5. **C13 and C15's premises were wrong.** C13 has nothing to delete; C15's cited symptoms exist nowhere in the cluster.
6. **A3's and C23's arms are coupled, not independent** — in both cases one mechanism masks the other in every reachable state.
7. **C12's second half was a corrected attribution carried forward as a gap** in every handoff since sweep 4. `engine.ts`'s call site is guarded.
8. **A6's coverage signature was mispredicted.** The plan expected total −1, covered unchanged; the measurement is −2/−2. The `?? {}` fallback *executed* 25 times — it had no falsifier, which is not the same as never running.
9. **`plugin-setting-tab.ts` was not at 0%** by the time it was reached — `main.ts`'s own tests had already covered its constructor and disposal.

## Raised, not absorbed

Phase 6 / follow-up conversations, listed rather than done:

1. **`useCssVars` is a no-op in this test environment.** The resolved `@vue/runtime-dom` is the CJS build, whose `useCssVars` is `function useCssVars(getter) { return; }`. So Vue's `v-bind()`-in-`<style scoped>` never reaches the DOM under vitest — **two charter entries (C11, C19) are recorded solely because of this**, and no test in the repo asserts on bound style output for any of its six users. This is a *toolchain configuration* issue, not an inherent limit: pointing vitest's resolve at `runtime-dom.esm-bundler.js` would unlock the channel. **Highest-value follow-up in this list.**
2. **`unmappable-date` appears unreachable.** `CycleService.anchorOf` returns `None` only for a journal that does not exist, but every name reaching the check came from a filter over journals that do. A published API error code that cannot be produced. The test that pins its string is spy-forced and kept deliberately — `JournalsApiErrorCode`'s `(string & {})` widener means **the compiler cannot catch a typo in it**.
3. **`makeLeaf` never populates `leaf.view`**, making `#pickShelf`'s `instanceof` branch untestable suite-wide — and its `setShelf` dispatch has never been behaviourally verified, only its absence-of-crash. Tractable harness fix; ~29 files.
4. **`BaseRepository`'s `idKey`/`invalidUpdateError` pairing** — requiring them together or neither would make an unreachable member a compile error instead of a comment.
5. **E5's lint selector** does not match `build<Entity>` factories whose entity is not in its alternation.
6. **E6's `RuleTester` option** — the remaining half of E6.
7. **`calendar.ts`'s comment claims `null`** where `az`'s `ordinal(-3,"D")` returns `NaN`.

## Notes for the reviewer

- **One shared-config change:** `eslint.config.mjs` gains a single-file carve-out for `plugin-setting-tab.test.ts`. Inline `eslint-disable` is banned repo-wide (`eslint-comments/no-use` with `allow: []`), so a `files: [...]` override is the only mechanism — matching five existing precedents. `display()` is deprecated at Obsidian 1.13.0; `manifest.json` pins 1.8.7, so it remains production's only rendering path. Lint stays at 0 errors / 12 pre-existing warnings.
- **Known flaky tests**, both timing rather than assertion, seen during this work: `NotesCalendarCell.test.ts`'s wall-clock "today marker" tests, and `kinds.isolated.test.ts`'s uk-locale ordinal round-trip under load.
