### PR TITLE
test(e2e): select the rename dialog by a class the version floor has

### DIFF
--- a/e2e/support/rename-links-dialog.ts
+++ b/e2e/support/rename-links-dialog.ts
@@ -5,12 +5,17 @@ import { UpdateLinksDialogButtonMissingError } from "./errors.js";
 // Obsidian's own confirm dialog, opened by `fileManager.renameFile` whenever the vault's
 // `alwaysUpdateLinks` config is off (the default) AND the renamed file has at least one link
 // pointing at it.
-// It is a real `ConfirmModal`, not a plugin dialog, so it is a SECOND `.modal-container` distinct
-// from the one `e2e/support/settings.ts` scopes plugin dialogs to (that one excludes only the
-// settings panel, so it would otherwise match this dialog too). `mod-confirmation` is the class
-// Obsidian's own FileManager stamps on this dialog's containerEl — unique to it in this codebase,
-// so there is nothing to disambiguate against.
-const UPDATE_LINKS_DIALOG = ".modal-container.mod-confirmation";
+// It is not a plugin dialog, so it is a SECOND `.modal-container` distinct from the one
+// `e2e/support/settings.ts` scopes plugin dialogs to (that one excludes only the settings panel,
+// so it would otherwise match this dialog too). `.modal-button-container` is the discriminator:
+// Obsidian's own FileManager builds this dialog's button row into one, and no plugin dialog in
+// this codebase emits that class — every plugin modal composes from `UiSettingRow` instead.
+// Do NOT narrow this to `.mod-confirmation`. That class comes from the confirmation-modal
+// subclass, which FileManager only started building this dialog from after the supported floor:
+// at `manifest.minAppVersion` (1.8.7) it is a bare `Modal` that hand-rolls the same row
+// (`modalEl.createDiv("modal-button-container")`), so a `.mod-confirmation` selector matches
+// nothing there and the wait times out on every `earliest` combo while `latest` stays green.
+const UPDATE_LINKS_DIALOG = ".modal-container:has(.modal-button-container)";
 
 function updateLinksDialog(): ReturnType<typeof $> {
   return $(UPDATE_LINKS_DIALOG);


### PR DESCRIPTION
Fixes the nightly matrix, red since the creation-prompts specs landed in #310.

## What broke

`clicking an unresolved journal link to a prompted journal > prompts, renames the placeholder-named file and attaches it` failed on **ubuntu, windows and macos, `earliest/earliest` only** — `expected Obsidian's native "Update links?" dialog to open`, 15.5s timeout, 319/320 otherwise passing. Every `latest/*` combo was green. Run: https://github.com/srg-kostyrko/obsidian-journal/actions/runs/33253704521

## Why

`rename-links-dialog.ts` selected the dialog as `.modal-container.mod-confirmation`. Reading `app.js` out of the cached asars for both floors:

- **1.12.7 / 1.13.x** — FileManager builds the dialog from the confirmation-modal subclass, whose constructor does `containerEl.addClass("mod-confirmation")` and pre-creates `buttonContainerEl`.
- **1.8.7** (`manifest.minAppVersion`) — it is the **base `Modal`** (`Modal:()=>XA` in the export map) and hand-rolls the row: `i.modalEl.createDiv("modal-button-container")`. Nothing carries `mod-confirmation`.

So the dialog *does* open at the floor; the selector just never matched it. This is the "a selector can encode a version floor tighter than `manifest.minAppVersion`" trap in CLAUDE.md.

The spec merged with #310 at 12:23 today and the 12:55 schedule was the first full-matrix run to include it — the PR gate runs `latest/latest` only, so nothing exercised the floor before merge.

## The change

One selector, plus a comment recording the drift so it does not get "tidied" back:

```
-const UPDATE_LINKS_DIALOG = ".modal-container.mod-confirmation";
+const UPDATE_LINKS_DIALOG = ".modal-container:has(.modal-button-container)";
```

`.modal-button-container` is built by both shapes, and no plugin dialog in this codebase emits it — plugin modals compose from `UiSettingRow`. `settings.ts` already relies on `:has()` working across the matrix. `confirmUpdateLinksDialog`'s middle-button targeting needs no change: 1.8.7 creates the same three buttons in the same order (Always update / Just once / Don't update).

## Verification

- `creation-prompts.e2e.ts` at `OBSIDIAN_VERSIONS=earliest/earliest` (Obsidian 1.8.7, installer 1.5.8): **8 passing** — was the failing combo.
- Same spec at the default `latest/latest`: **8 passing** — no regression.
- `check:lint` 0 errors, `check:types` clean.
- Falsifier for the old selector is the linked CI run itself: three OSes, same timeout, `latest` green.

Full matrix triggered on this branch; will report back.