### PR TITLE
feat(settings): repair nested collection entries entry-wise

### DIFF
--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -1,8 +1,10 @@
 export {
   defineCollection,
+  defineNestedCollection,
   defineSlice,
   type CollectionDefinition,
   type Migration,
+  type NestedCollectionDefinition,
   type SliceDefinition,
 } from "./schema";
 export {

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -9,6 +9,14 @@ export interface SliceDefinition<TKey extends string, TSchema extends AnySchema>
   readonly defaults: InferOutput<TSchema>;
 }
 
+// Keyed on the item type's own field names so a nested definition for a key the item schema
+// doesn't have is a compile error. The stronger invariant — that a NestedCollectionDefinition's
+// itemSchema IS the schema that validates values stored at that key — has no type to express it
+// and must be gotten right by construction.
+export type CollectionNested<TItem extends AnySchema> = Readonly<
+  Partial<Record<Extract<keyof InferOutput<TItem>, string>, AnyNestedCollectionDefinition>>
+>;
+
 export interface CollectionDefinition<TKey extends string, TItem extends AnySchema> {
   readonly __brand: "collection";
   readonly key: TKey;
@@ -16,7 +24,7 @@ export interface CollectionDefinition<TKey extends string, TItem extends AnySche
   /** `raw` is the stored entry that failed validation, so a default can keep what still parses. */
   readonly defaultItem: (id: string, raw?: unknown) => InferOutput<TItem>;
   readonly seed?: () => Record<string, InferOutput<TItem>>;
-  readonly nested?: Readonly<Record<string, AnyNestedCollectionDefinition>>;
+  readonly nested?: CollectionNested<TItem>;
 }
 
 export interface NestedCollectionDefinition<TItem extends AnySchema> {
@@ -49,7 +57,7 @@ export function defineCollection<TKey extends string, TItem extends AnySchema>(
   defaultItem: (id: string, raw?: unknown) => InferOutput<TItem>,
   options?: {
     seed?: () => Record<string, InferOutput<TItem>>;
-    nested?: Readonly<Record<string, AnyNestedCollectionDefinition>>;
+    nested?: CollectionNested<TItem>;
   },
 ): CollectionDefinition<TKey, TItem> {
   return { __brand: "collection", key, itemSchema, defaultItem, seed: options?.seed, nested: options?.nested };

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -16,10 +16,24 @@ export interface CollectionDefinition<TKey extends string, TItem extends AnySche
   /** `raw` is the stored entry that failed validation, so a default can keep what still parses. */
   readonly defaultItem: (id: string, raw?: unknown) => InferOutput<TItem>;
   readonly seed?: () => Record<string, InferOutput<TItem>>;
+  readonly nested?: Readonly<Record<string, AnyNestedCollectionDefinition>>;
+}
+
+export interface NestedCollectionDefinition<TItem extends AnySchema> {
+  readonly itemSchema: TItem;
+  readonly defaultItem: (id: string, raw?: unknown) => InferOutput<TItem>;
 }
 
 export type AnySliceDefinition = SliceDefinition<string, AnySchema>;
 export type AnyCollectionDefinition = CollectionDefinition<string, AnySchema>;
+export type AnyNestedCollectionDefinition = NestedCollectionDefinition<AnySchema>;
+
+export function defineNestedCollection<TItem extends AnySchema>(
+  itemSchema: TItem,
+  defaultItem: (id: string, raw?: unknown) => InferOutput<TItem>,
+): NestedCollectionDefinition<TItem> {
+  return { itemSchema, defaultItem };
+}
 
 export function defineSlice<TKey extends string, TSchema extends AnySchema>(
   key: TKey,
@@ -33,9 +47,12 @@ export function defineCollection<TKey extends string, TItem extends AnySchema>(
   key: TKey,
   itemSchema: TItem,
   defaultItem: (id: string, raw?: unknown) => InferOutput<TItem>,
-  options?: { seed?: () => Record<string, InferOutput<TItem>> },
+  options?: {
+    seed?: () => Record<string, InferOutput<TItem>>;
+    nested?: Readonly<Record<string, AnyNestedCollectionDefinition>>;
+  },
 ): CollectionDefinition<TKey, TItem> {
-  return { __brand: "collection", key, itemSchema, defaultItem, seed: options?.seed };
+  return { __brand: "collection", key, itemSchema, defaultItem, seed: options?.seed, nested: options?.nested };
 }
 
 export interface Migration {

--- a/src/settings/settings-service.test.ts
+++ b/src/settings/settings-service.test.ts
@@ -106,6 +106,49 @@ const checkedPetCollection = defineCollection(
   petDefaults,
 );
 
+// A nested repair can produce an entry that is individually valid but collides with a
+// sibling field once composed back into the whole item — here a repaired treat's label
+// (the nested defaultItem falls back to the entry id) equals the pet's own name.
+const clashTreatPetSchema = v.pipe(
+  v.object({
+    name: v.pipe(v.string(), v.minLength(1)),
+    kind: v.picklist(["cat", "dog"]),
+    sound: v.pipe(v.string(), v.minLength(1)),
+    treats: v.optional(v.record(v.string(), treatSchema), {}),
+  }),
+  v.check(
+    (pet) => Object.values(pet.treats).every((treat) => treat.label !== pet.name),
+    "no treat may share the pet's own name",
+  ),
+);
+
+const clashTreatPetCollection = defineCollection(
+  "pets",
+  clashTreatPetSchema,
+  (id, raw) => ({ name: id, kind: storedKind(raw), sound: sounds[storedKind(raw)], treats: {} }),
+  { nested: { treats: defineNestedCollection(treatSchema, treatDefaults) } },
+);
+
+// The parent object's own "treats" field is validated against the loose, unchecked treatSchema,
+// while the nested collection declares the stricter checkedTreatSchema for repair — a mismatch
+// the type system cannot catch (see the `why` comment on CollectionNested in schema.ts). Its
+// defaultItem deliberately returns a value the strict schema rejects.
+const brokenNestedTreatDefaults = (): v.InferOutput<typeof treatSchema> => ({ label: "forbidden", crunchy: false });
+
+const mismatchedNestedPetSchema = v.object({
+  name: v.pipe(v.string(), v.minLength(1)),
+  kind: v.picklist(["cat", "dog"]),
+  sound: v.pipe(v.string(), v.minLength(1)),
+  treats: v.optional(v.record(v.string(), treatSchema), {}),
+});
+
+const mismatchedNestedPetCollection = defineCollection(
+  "pets",
+  mismatchedNestedPetSchema,
+  (id, raw) => ({ name: id, kind: storedKind(raw), sound: sounds[storedKind(raw)], treats: {} }),
+  { nested: { treats: defineNestedCollection(checkedTreatSchema, brokenNestedTreatDefaults) } },
+);
+
 // Supplies this file's synthetic slice/collection/migration definitions to testContainer's
 // `modules`. A bare testContainer() registers zero slices and zero collections, so these
 // deliberately shadow-named keys (`calendar`, `journals`, `pets`) collide with nothing real.
@@ -342,6 +385,52 @@ describe("SettingsService", () => {
       );
       expect(resets).toHaveLength(1);
       expect(resets[0]?.fields).toMatchObject({ fields: ["treats.t1.label"] });
+    });
+
+    it("retries with the whole nested field reset when a partial nested repair still fails an item-level check", async () => {
+      // sound is customized away from what defaultItem would derive from kind ("woof"), so a
+      // whole-entity reset (the pre-fix behavior when the final safeParse fails) is distinguishable
+      // from the correct whole-*field* reset, which must leave it untouched.
+      const harness = await testContainer({
+        modules: [testSettingsModule({ collections: [clashTreatPetCollection] })],
+        data: {
+          pets: {
+            Rex: { name: "Rex", kind: "dog", sound: "arf", treats: { Rex: { label: "", crunchy: true } } },
+          },
+        },
+        allow: { dataRepair: true },
+      });
+
+      expect(harness.settings.recordOf(clashTreatPetCollection).Rex).toEqual({
+        name: "Rex",
+        kind: "dog",
+        sound: "arf",
+        treats: {},
+      });
+    });
+
+    it("discards a whole nested field rather than write an entry fallback default that fails its own schema", async () => {
+      const harness = await testContainer({
+        modules: [testSettingsModule({ collections: [mismatchedNestedPetCollection] })],
+        data: {
+          pets: {
+            Rex: {
+              name: "Rex",
+              kind: "dog",
+              sound: "woof",
+              treats: { t1: { label: "Bone", crunchy: false }, t2: { label: "", crunchy: false } },
+            },
+          },
+        },
+        allow: { dataRepair: true },
+      });
+
+      expect(harness.settings.recordOf(mismatchedNestedPetCollection).Rex).toEqual({
+        name: "Rex",
+        kind: "dog",
+        sound: "woof",
+        treats: {},
+      });
     });
   });
 

--- a/src/settings/settings-service.test.ts
+++ b/src/settings/settings-service.test.ts
@@ -78,6 +78,25 @@ const nestedPetCollection = defineCollection(
   { nested: { treats: defineNestedCollection(treatSchema, treatDefaults) } },
 );
 
+const checkedTreatSchema = v.pipe(
+  v.object({ label: v.pipe(v.string(), v.minLength(1)), crunchy: v.boolean() }),
+  v.check((treat) => treat.label !== "forbidden", "label must not be forbidden"),
+);
+
+const checkedTreatPetSchema = v.object({
+  name: v.pipe(v.string(), v.minLength(1)),
+  kind: v.picklist(["cat", "dog"]),
+  sound: v.pipe(v.string(), v.minLength(1)),
+  treats: v.optional(v.record(v.string(), checkedTreatSchema), {}),
+});
+
+const checkedTreatPetCollection = defineCollection(
+  "pets",
+  checkedTreatPetSchema,
+  (id, raw) => ({ name: id, kind: storedKind(raw), sound: sounds[storedKind(raw)], treats: {} }),
+  { nested: { treats: defineNestedCollection(checkedTreatSchema, treatDefaults) } },
+);
+
 const checkedPetCollection = defineCollection(
   "pets",
   v.pipe(
@@ -256,6 +275,30 @@ describe("SettingsService", () => {
         kind: "dog",
         sound: "woof",
         treats: { t1: { label: "t1", crunchy: true }, t2: { label: "Bone", crunchy: false } },
+      });
+    });
+
+    it("resets a nested entry whose issue names no field, keeping its siblings", async () => {
+      const harness = await testContainer({
+        modules: [testSettingsModule({ collections: [checkedTreatPetCollection] })],
+        data: {
+          pets: {
+            Rex: {
+              name: "Rex",
+              kind: "dog",
+              sound: "woof",
+              treats: { t1: { label: "forbidden", crunchy: true }, t2: { label: "Bone", crunchy: false } },
+            },
+          },
+        },
+        allow: { dataRepair: true },
+      });
+
+      expect(harness.settings.recordOf(checkedTreatPetCollection).Rex).toEqual({
+        name: "Rex",
+        kind: "dog",
+        sound: "woof",
+        treats: { t1: { label: "t1", crunchy: false }, t2: { label: "Bone", crunchy: false } },
       });
     });
   });

--- a/src/settings/settings-service.test.ts
+++ b/src/settings/settings-service.test.ts
@@ -305,6 +305,7 @@ describe("SettingsService", () => {
     it.each([
       ["a string", "nonsense"],
       ["null", null],
+      ["a non-empty array", [{ label: "", crunchy: true }]],
     ])("resets a nested field stored as %s without touching the rest of the item", async (_label, stored) => {
       const harness = await testContainer({
         modules: [testSettingsModule({ collections: [nestedPetCollection] })],

--- a/src/settings/settings-service.test.ts
+++ b/src/settings/settings-service.test.ts
@@ -319,6 +319,29 @@ describe("SettingsService", () => {
         treats: {},
       });
     });
+
+    it("names the repaired nested entry and field in the warning", async () => {
+      const harness = await testContainer({
+        modules: [testSettingsModule({ collections: [nestedPetCollection] })],
+        data: {
+          pets: {
+            Rex: {
+              name: "Rex",
+              kind: "dog",
+              sound: "woof",
+              treats: { t1: { label: "", crunchy: true } },
+            },
+          },
+        },
+        allow: { dataRepair: true },
+      });
+
+      const resets = harness.logs.records.filter(
+        (record) => record.message === "collection entry fields reset to defaults",
+      );
+      expect(resets).toHaveLength(1);
+      expect(resets[0]?.fields).toMatchObject({ fields: ["treats.t1.label"] });
+    });
   });
 
   // A v2 vault whose journals cleared the date format loaded every journal as a *day*

--- a/src/settings/settings-service.test.ts
+++ b/src/settings/settings-service.test.ts
@@ -149,6 +149,27 @@ const mismatchedNestedPetCollection = defineCollection(
   { nested: { treats: defineNestedCollection(checkedTreatSchema, brokenNestedTreatDefaults) } },
 );
 
+// A container-level check (spanning the whole "treats" record, not one entry) reports an
+// issue with no entry id, alongside a genuine per-entry issue, in the same parse.
+const treatsNoEmptyLabelsSchema = v.pipe(
+  v.record(v.string(), treatSchema),
+  v.check((treats) => Object.values(treats).every((treat) => treat.label !== ""), "no treat may have an empty label"),
+);
+
+const cappedTreatsPetSchema = v.object({
+  name: v.pipe(v.string(), v.minLength(1)),
+  kind: v.picklist(["cat", "dog"]),
+  sound: v.pipe(v.string(), v.minLength(1)),
+  treats: treatsNoEmptyLabelsSchema,
+});
+
+const cappedTreatsPetCollection = defineCollection(
+  "pets",
+  cappedTreatsPetSchema,
+  (id, raw) => ({ name: id, kind: storedKind(raw), sound: sounds[storedKind(raw)], treats: {} }),
+  { nested: { treats: defineNestedCollection(treatSchema, treatDefaults) } },
+);
+
 // Supplies this file's synthetic slice/collection/migration definitions to testContainer's
 // `modules`. A bare testContainer() registers zero slices and zero collections, so these
 // deliberately shadow-named keys (`calendar`, `journals`, `pets`) collide with nothing real.
@@ -387,6 +408,40 @@ describe("SettingsService", () => {
       expect(resets[0]?.fields).toMatchObject({ fields: ["treats.t1.label"] });
     });
 
+    it("repairs both bad fields of one nested entry, leaving the other entry alone", async () => {
+      const harness = await testContainer({
+        modules: [testSettingsModule({ collections: [nestedPetCollection] })],
+        data: {
+          pets: {
+            Rex: {
+              name: "Rex",
+              kind: "dog",
+              sound: "woof",
+              treats: { t1: { label: "", crunchy: "x" }, t2: { label: "Bone", crunchy: false } },
+            },
+          },
+        },
+        allow: { dataRepair: true },
+      });
+
+      expect(harness.settings.recordOf(nestedPetCollection).Rex).toEqual({
+        name: "Rex",
+        kind: "dog",
+        sound: "woof",
+        treats: { t1: { label: "t1", crunchy: false }, t2: { label: "Bone", crunchy: false } },
+      });
+
+      // Both bad fields land under the same nested key ("treats") and the same entry ("t1"),
+      // so a merge line that drops the second issue instead of accumulating it still converges
+      // on the same final value here (t1 falls back to its whole-entry default either way) — the
+      // dropped issue only shows up in what gets reported as repaired.
+      const resets = harness.logs.records.filter(
+        (record) => record.message === "collection entry fields reset to defaults",
+      );
+      expect(resets).toHaveLength(1);
+      expect(resets[0]?.fields).toMatchObject({ fields: ["treats.t1.label", "treats.t1.crunchy"] });
+    });
+
     it("retries with the whole nested field reset when a partial nested repair still fails an item-level check", async () => {
       // sound is customized away from what defaultItem would derive from kind ("woof"), so a
       // whole-entity reset (the pre-fix behavior when the final safeParse fails) is distinguishable
@@ -426,6 +481,30 @@ describe("SettingsService", () => {
       });
 
       expect(harness.settings.recordOf(mismatchedNestedPetCollection).Rex).toEqual({
+        name: "Rex",
+        kind: "dog",
+        sound: "woof",
+        treats: {},
+      });
+    });
+
+    it("resets the whole nested field when one of its issues names no entry, even alongside a repairable entry", async () => {
+      const harness = await testContainer({
+        modules: [testSettingsModule({ collections: [cappedTreatsPetCollection] })],
+        data: {
+          pets: {
+            Rex: {
+              name: "Rex",
+              kind: "dog",
+              sound: "woof",
+              treats: { t1: { label: "", crunchy: true }, t2: { label: "Bone", crunchy: false } },
+            },
+          },
+        },
+        allow: { dataRepair: true },
+      });
+
+      expect(harness.settings.recordOf(cappedTreatsPetCollection).Rex).toEqual({
         name: "Rex",
         kind: "dog",
         sound: "woof",

--- a/src/settings/settings-service.test.ts
+++ b/src/settings/settings-service.test.ts
@@ -301,6 +301,24 @@ describe("SettingsService", () => {
         treats: { t1: { label: "t1", crunchy: false }, t2: { label: "Bone", crunchy: false } },
       });
     });
+
+    it.each([
+      ["a string", "nonsense"],
+      ["null", null],
+    ])("resets a nested field stored as %s without touching the rest of the item", async (_label, stored) => {
+      const harness = await testContainer({
+        modules: [testSettingsModule({ collections: [nestedPetCollection] })],
+        data: { pets: { Rex: { name: "Rex", kind: "dog", sound: "woof", treats: stored } } },
+        allow: { dataRepair: true },
+      });
+
+      expect(harness.settings.recordOf(nestedPetCollection).Rex).toEqual({
+        name: "Rex",
+        kind: "dog",
+        sound: "woof",
+        treats: {},
+      });
+    });
   });
 
   // A v2 vault whose journals cleared the date format loaded every journal as a *day*

--- a/src/settings/settings-service.test.ts
+++ b/src/settings/settings-service.test.ts
@@ -14,6 +14,7 @@ import { SliceKeyConflictError, MigrationFailedError, SettingsSaveError, Unregis
 import { v4ToV5Migration } from "./legacy/v4-to-v5";
 import {
   defineCollection,
+  defineNestedCollection,
   defineSlice,
   type AnyCollectionDefinition,
   type AnySliceDefinition,
@@ -55,6 +56,27 @@ const petDefaults = (id: string, raw: unknown): v.InferOutput<typeof petSchema> 
 });
 
 const petCollection = defineCollection("pets", petSchema, petDefaults);
+
+const treatSchema = v.object({
+  label: v.pipe(v.string(), v.minLength(1)),
+  crunchy: v.boolean(),
+});
+
+const treatDefaults = (id: string): v.InferOutput<typeof treatSchema> => ({ label: id, crunchy: false });
+
+const nestedPetSchema = v.object({
+  name: v.pipe(v.string(), v.minLength(1)),
+  kind: v.picklist(["cat", "dog"]),
+  sound: v.pipe(v.string(), v.minLength(1)),
+  treats: v.optional(v.record(v.string(), treatSchema), {}),
+});
+
+const nestedPetCollection = defineCollection(
+  "pets",
+  nestedPetSchema,
+  (id, raw) => ({ name: id, kind: storedKind(raw), sound: sounds[storedKind(raw)], treats: {} }),
+  { nested: { treats: defineNestedCollection(treatSchema, treatDefaults) } },
+);
 
 const checkedPetCollection = defineCollection(
   "pets",
@@ -210,6 +232,30 @@ describe("SettingsService", () => {
         kind: "dog",
         sound: "woof",
         toys: [],
+      });
+    });
+
+    it("repairs one field of one nested entry, leaving its siblings alone", async () => {
+      const harness = await testContainer({
+        modules: [testSettingsModule({ collections: [nestedPetCollection] })],
+        data: {
+          pets: {
+            Rex: {
+              name: "Rex",
+              kind: "dog",
+              sound: "woof",
+              treats: { t1: { label: "", crunchy: true }, t2: { label: "Bone", crunchy: false } },
+            },
+          },
+        },
+        allow: { dataRepair: true },
+      });
+
+      expect(harness.settings.recordOf(nestedPetCollection).Rex).toEqual({
+        name: "Rex",
+        kind: "dog",
+        sound: "woof",
+        treats: { t1: { label: "t1", crunchy: true }, t2: { label: "Bone", crunchy: false } },
       });
     });
   });

--- a/src/settings/settings-service.ts
+++ b/src/settings/settings-service.ts
@@ -346,13 +346,18 @@ function repairCollectionEntry<TItem extends AnySchema>(
 ): { value: InferOutput<TItem>; fields: string[] } | undefined {
   if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
 
+  // `definition.nested` is keyed on the item schema's own field names (see CollectionNested in
+  // schema.ts) so authors get a compile error for a stray key; that key set is generic here, so
+  // widen to look it up by the runtime string an issue path actually names.
+  const nestedMap = definition.nested as Readonly<Record<string, AnyNestedCollectionDefinition>> | undefined;
+
   const plain = new Set<string>();
   const nested = new Map<string, { definition: AnyNestedCollectionDefinition; issues: BaseIssue<unknown>[] }>();
   for (const issue of issues) {
     // A root-level check reports no path, so there is no field to swap out.
     const key = issue.path?.[0]?.key;
     if (typeof key !== "string") return undefined;
-    const nestedDefinition = definition.nested?.[key];
+    const nestedDefinition = nestedMap?.[key];
     if (nestedDefinition === undefined) {
       plain.add(key);
       continue;
@@ -366,6 +371,7 @@ function repairCollectionEntry<TItem extends AnySchema>(
   const defaults = definition.defaultItem(id, value) as Record<string, unknown>;
   const candidate: Record<string, unknown> = { ...(value as Record<string, unknown>) };
   const fields: string[] = [];
+  const partiallyRepaired = new Set<string>();
   for (const field of plain) {
     candidate[field] = defaults[field];
     fields.push(field);
@@ -379,10 +385,21 @@ function repairCollectionEntry<TItem extends AnySchema>(
     }
     candidate[field] = repaired.value;
     fields.push(...repaired.fields.map((nestedField) => `${field}.${nestedField}`));
+    partiallyRepaired.add(field);
   }
 
   const parsed = v.safeParse(definition.itemSchema, candidate);
-  return parsed.success ? { value: parsed.output, fields } : undefined;
+  if (parsed.success) return { value: parsed.output, fields };
+  if (partiallyRepaired.size === 0) return undefined;
+
+  // A repair that only touched one entry inside a nested field can still fail a check spanning
+  // the whole item (a nested default colliding with a sibling field, say). Retry with the old
+  // whole-field reset for every field a nested repair touched, and only give up if that also
+  // fails — never widen the loss past what the pre-nested-repair code discarded.
+  for (const field of partiallyRepaired) candidate[field] = defaults[field];
+  const retryFields = [...plain, ...nested.keys()];
+  const retried = v.safeParse(definition.itemSchema, candidate);
+  return retried.success ? { value: retried.output, fields: retryFields } : undefined;
 }
 
 function repairNestedCollection(
@@ -408,7 +425,12 @@ function repairNestedCollection(
     const entryValue = out[entryId];
     const repaired = repairNestedEntry(definition, entryId, entryValue, entryIssues);
     if (repaired === undefined) {
-      out[entryId] = definition.defaultItem(entryId, entryValue);
+      const fallback = definition.defaultItem(entryId, entryValue);
+      // defaultItem's contract only promises it keeps what still parses, not that its result
+      // does — a lenient default here would silently escalate this per-entry reset into the
+      // whole-field reset the caller falls back to, so verify before writing it into the container.
+      if (!v.safeParse(definition.itemSchema, fallback).success) return undefined;
+      out[entryId] = fallback;
       fields.push(entryId);
       continue;
     }
@@ -438,8 +460,11 @@ function repairNestedEntry(
   const candidate: Record<string, unknown> = { ...(value as Record<string, unknown>) };
   for (const field of fields) candidate[field] = defaults[field];
 
+  // Store the pre-parse candidate, not parsed.output: repairNestedCollection's caller re-parses
+  // the whole item, so returning the already-transformed output would run any v.transform in
+  // the entry schema twice for a repaired entry while its untouched siblings run it once.
   const parsed = v.safeParse(definition.itemSchema, candidate);
-  return parsed.success ? { value: parsed.output, fields: [...fields] } : undefined;
+  return parsed.success ? { value: candidate, fields: [...fields] } : undefined;
 }
 
 function parseSliceValue<TSchema extends AnySchema>(

--- a/src/settings/settings-service.ts
+++ b/src/settings/settings-service.ts
@@ -19,7 +19,13 @@ import { SnapshotService } from "./snapshots/snapshot-service";
 import { CollectionDefinitionToken, MigrationToken, SettingsEventsToken, SliceDefinitionToken } from "./tokens";
 import { CURRENT_VERSION } from "./version";
 
-import type { AnyCollectionDefinition, AnySliceDefinition, CollectionDefinition, SliceDefinition } from "./schema";
+import type {
+  AnyCollectionDefinition,
+  AnyNestedCollectionDefinition,
+  AnySliceDefinition,
+  CollectionDefinition,
+  SliceDefinition,
+} from "./schema";
 import type { SliceHandle } from "./types";
 import type { BaseIssue, BaseSchema, InferOutput } from "valibot";
 
@@ -340,16 +346,95 @@ function repairCollectionEntry<TItem extends AnySchema>(
 ): { value: InferOutput<TItem>; fields: string[] } | undefined {
   if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
 
-  const fields = new Set<string>();
+  const plain = new Set<string>();
+  const nested = new Map<string, { definition: AnyNestedCollectionDefinition; issues: BaseIssue<unknown>[] }>();
   for (const issue of issues) {
     // A root-level check reports no path, so there is no field to swap out.
     const key = issue.path?.[0]?.key;
+    if (typeof key !== "string") return undefined;
+    const nestedDefinition = definition.nested?.[key];
+    if (nestedDefinition === undefined) {
+      plain.add(key);
+      continue;
+    }
+    const existing = nested.get(key);
+    if (existing) existing.issues.push(issue);
+    else nested.set(key, { definition: nestedDefinition, issues: [issue] });
+  }
+  if (plain.size === 0 && nested.size === 0) return undefined;
+
+  const defaults = definition.defaultItem(id, value) as Record<string, unknown>;
+  const candidate: Record<string, unknown> = { ...(value as Record<string, unknown>) };
+  const fields: string[] = [];
+  for (const field of plain) {
+    candidate[field] = defaults[field];
+    fields.push(field);
+  }
+  for (const [field, entry] of nested) {
+    const repaired = repairNestedCollection(entry.definition, candidate[field], entry.issues);
+    if (repaired === undefined) {
+      candidate[field] = defaults[field];
+      fields.push(field);
+      continue;
+    }
+    candidate[field] = repaired.value;
+    fields.push(...repaired.fields.map((nestedField) => `${field}.${nestedField}`));
+  }
+
+  const parsed = v.safeParse(definition.itemSchema, candidate);
+  return parsed.success ? { value: parsed.output, fields } : undefined;
+}
+
+function repairNestedCollection(
+  definition: AnyNestedCollectionDefinition,
+  container: unknown,
+  issues: readonly BaseIssue<unknown>[],
+): { value: Record<string, unknown>; fields: string[] } | undefined {
+  if (container === null || typeof container !== "object" || Array.isArray(container)) return undefined;
+
+  const byEntry = new Map<string, BaseIssue<unknown>[]>();
+  for (const issue of issues) {
+    // An issue on the container itself names no entry, so there is nothing to repair inside it.
+    const entryId = issue.path?.[1]?.key;
+    if (typeof entryId !== "string") return undefined;
+    const existing = byEntry.get(entryId);
+    if (existing) existing.push(issue);
+    else byEntry.set(entryId, [issue]);
+  }
+
+  const out: Record<string, unknown> = { ...(container as Record<string, unknown>) };
+  const fields: string[] = [];
+  for (const [entryId, entryIssues] of byEntry) {
+    const entryValue = out[entryId];
+    const repaired = repairNestedEntry(definition, entryId, entryValue, entryIssues);
+    if (repaired === undefined) {
+      out[entryId] = definition.defaultItem(entryId, entryValue);
+      fields.push(entryId);
+      continue;
+    }
+    out[entryId] = repaired.value;
+    fields.push(...repaired.fields.map((field) => `${entryId}.${field}`));
+  }
+  return { value: out, fields };
+}
+
+function repairNestedEntry(
+  definition: AnyNestedCollectionDefinition,
+  entryId: string,
+  value: unknown,
+  issues: readonly BaseIssue<unknown>[],
+): { value: unknown; fields: string[] } | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+
+  const fields = new Set<string>();
+  for (const issue of issues) {
+    const key = issue.path?.[2]?.key;
     if (typeof key !== "string") return undefined;
     fields.add(key);
   }
   if (fields.size === 0) return undefined;
 
-  const defaults = definition.defaultItem(id, value) as Record<string, unknown>;
+  const defaults = definition.defaultItem(entryId, value) as Record<string, unknown>;
   const candidate: Record<string, unknown> = { ...(value as Record<string, unknown>) };
   for (const field of fields) candidate[field] = defaults[field];
 


### PR DESCRIPTION
`repairCollectionEntry` substitutes `defaults[issue.path[0].key]` — the whole top-level
field of a stored item. So a `minLength` failure on one entry inside a keyed field costs
every entry in that field, not just the broken one. Blast radius is set by nesting depth,
not by whether the failing rule is a root-level `v.check`.

A `CollectionDefinition` can now declare a field as a nested keyed collection. Repair
recurses one level: the failing entry's bad fields are substituted from that entry's own
defaults, its siblings are untouched, and the parent item's other fields are untouched.

Details:

- An entry whose issue names no field resets wholesale, mirroring what the top level
  already does for an unrepairable item — and that fallback default is itself validated
  before being written, so a lenient `defaultItem` cannot escalate a per-entry reset.
- A container that is not a keyed object falls back to the existing whole-field reset.
- **The repair can never discard more than the old code did.** If the parent re-parse fails
  after a nested repair, it retries once with every touched field forced to its default —
  the old whole-field reset — and only then gives up. Without that retry, a nested
  `defaultItem` disagreeing with the parent schema would have reset the whole entity where
  the old code reset one field.
- The warning names the repaired path (`treats.t1.label`), so the diagnostic identifies the
  entry rather than only the field.
- `nested` is keyed on the item type's own fields, so a typo cannot name a field that does
  not exist. That `itemSchema` is the schema actually used at that key is not expressible
  in the type system and is recorded as a comment.

No consumer declares `nested` yet — `journalConfigCollection` has no nested field, so every
existing collection takes the unchanged code path.

Note `prompts` and `decorations` are arrays rather than records and do not gain containment
from this change; extending the mechanism to repair array elements by index would be a
separate addition.

Groundwork for notelets (#285), where notelet types nest on the journal config as a record
keyed by a stable id.