### PR TITLE
fix(e2e): pin the Obsidian app version off the Android-only 1.13.8

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,14 @@ jobs:
         # which a manual dispatch can ask for too — a floor-only failure is otherwise
         # unverifiable until the next 07:00 UTC.
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        obsidian: ${{ (github.event_name == 'schedule' || inputs.full_matrix) && fromJSON('["earliest/earliest", "latest/earliest", "latest/latest"]') || fromJSON('["latest/latest"]') }}
+        # The app version is pinned to 1.13.7 rather than `latest` because 1.13.8 is an
+        # Android-only release: its `obsidian-versions.json` entry carries `downloads: ["apk"]`
+        # and no installer bounds, so there is no asar to run and setup dies with
+        # "No asar found for Obsidian version 1.13.8". `latest` skips the 1.14.0 beta but not
+        # an Android-only build, so it lands on a version with no desktop artifact at all.
+        # Unpin — back to `latest` — once Obsidian ships a desktop 1.13.9+ (which moves
+        # `latest` past the Android-only entry) or wdio-obsidian-service filters these out.
+        obsidian: ${{ (github.event_name == 'schedule' || inputs.full_matrix) && fromJSON('["earliest/earliest", "1.13.7/earliest", "1.13.7/1.13.7"]') || fromJSON('["1.13.7/1.13.7"]') }}
 
     runs-on: ${{ matrix.os }}
     permissions:

--- a/docs/e2e-testing-strategy.md
+++ b/docs/e2e-testing-strategy.md
@@ -49,6 +49,16 @@ Obsidian-version compatibility is pinned in CI, not left to chance:
 `manifest.json`'s `minAppVersion` — see [Install and version
 modes](#install-and-version-modes) below.
 
+> **Temporarily pinned.** Everywhere this document says `latest` for the _app_
+> axis, the workflow and `wdio.conf.mts` currently say `1.13.7`. Obsidian 1.13.8
+> is an Android-only release — its `obsidian-versions.json` entry carries
+> `downloads: ["apk"]` and no installer bounds — so there is no asar to run and
+> setup fails with `No asar found for Obsidian version 1.13.8`. `latest` skips
+> the 1.14.0 beta but not an Android-only build, so it selects a version with no
+> desktop artifact at all. Restore `latest` once Obsidian ships a desktop
+> 1.13.9+, or once `wdio-obsidian-service` filters asar-less versions out of
+> `latest`.
+
 #### Install and version modes
 
 Obsidian has **two independent version axes**, and we configure both per capability

--- a/wdio.conf.mts
+++ b/wdio.conf.mts
@@ -8,9 +8,12 @@ import { parseObsidianVersions } from "wdio-obsidian-service";
 const SCREENSHOT_DIR = "./e2e/.reports/screenshots";
 
 // Version matrix is data-driven so CI jobs select it via OBSIDIAN_VERSIONS without
-// editing this file: PR gate -> "latest/latest"; nightly -> the floor + mismatch
+// editing this file: PR gate -> the pinned app version; nightly -> the floor + mismatch
 // combos (see docs/e2e-testing-strategy.md). `earliest` resolves manifest.minAppVersion.
-const versionSpec = env.OBSIDIAN_VERSIONS ?? "latest/latest";
+// Pinned rather than `latest/latest` for the same reason the CI matrix is: 1.13.8 is an
+// Android-only release with no asar, and `latest` selects it. See .github/workflows/e2e.yml
+// for the unpin condition; the two move together.
+const versionSpec = env.OBSIDIAN_VERSIONS ?? "1.13.7/1.13.7";
 const versions = await parseObsidianVersions(versionSpec);
 
 export const config: WebdriverIO.Config = {


### PR DESCRIPTION
Every e2e job on every branch has been failing since 1.13.8 shipped, `main` included:

```
SevereServiceError: Failed to download and setup Obsidian. Caused by:
Error: No asar found for Obsidian version 1.13.8
```

## Cause

**Obsidian 1.13.8 is an Android-only release.** From `wdio-obsidian-service`'s `obsidian-versions.json`:

| version | downloads | asar | installer bounds |
| --- | --- | --- | --- |
| 1.13.6 | asar, appImage, tar, dmg, exe, apk | yes | 1.5.8 – 1.13.6 |
| 1.13.7 | asar, appImage, tar, dmg, exe, apk | yes | 1.5.8 – 1.13.7 |
| **1.13.8** | **apk** | **no** | **none** |
| 1.14.0 | asar | yes | 1.5.8 – 1.13.7 |

`parseObsidianVersions("latest/latest")` resolves to `["1.13.8", "1.13.7"]` and then dies on the missing asar. `latest` correctly skips the 1.14.0 beta, but it does not skip an Android-only build — so it lands on a version with no desktop artifact at all. `wdio-obsidian-service` is already at 3.2.0, the newest published, so there is no version bump that fixes it.

## Change

Pin the **app** axis to 1.13.7, the last full desktop release, in both places that name it:

- `.github/workflows/e2e.yml` — the PR-gate combo and the nightly matrix's two `latest` app entries. The installer axis is untouched, so `earliest/earliest` and the mismatch combo still mean what they meant.
- `wdio.conf.mts` — the local-run default, which has the identical failure. Pinning only CI would leave every local `npm run e2e` broken.

`docs/e2e-testing-strategy.md` gets a note so the doc does not silently drift from the workflow.

All three combos resolve cleanly with the pin:

```
earliest/earliest -> [["1.8.7","1.5.8"]]
1.13.7/earliest   -> [["1.13.7","1.5.8"]]
1.13.7/1.13.7     -> [["1.13.7","1.13.7"]]
```

## Unpinning

Restore `latest` once either:

- Obsidian ships a desktop 1.13.9+, which moves `latest` past the Android-only entry, or
- `wdio-obsidian-service` filters asar-less versions out of `latest`.

The condition is written into the workflow comment, the `wdio.conf.mts` comment and the strategy doc, so whoever gets there first has it in front of them. No upstream issue exists for this yet; one is drafted to be filed against `jesse-r-s-hines/wdio-obsidian-service`.
