### PR TITLE
feat(api): the notelets public API

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -20,6 +20,7 @@ words:
   - macrotask
   - multitext
   - nanoevents
+  - nanoids
   - offref
   - paraglide
   - parameterless

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -101,8 +101,11 @@ const meetings = await journals.noteletsFor("Work Weekly", "today", { type: "Mee
 // Create one, without stealing the user's pane.
 const notelet = await journals.createNotelet("Work Weekly", "today", "Meeting");
 
-// Show it, reusing a pane that already holds it in the focused window.
-await journals.openNotelet(notelet, { openMode: "tab" });
+// Show it. The default mode reuses a pane that already holds the note, in the focused window.
+await journals.openNotelet(notelet);
+
+// An explicit mode is a request for a new pane, and never reuses.
+await journals.openNotelet(notelet, { openMode: "split" });
 
 // Which notelet is this file, if any? journalOf stays period-note only.
 const held = await journals.noteletOf(this.app.workspace.getActiveFile());

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -71,7 +71,7 @@ interface JournalsApi {
 ```ts
 // Which journals exist, and what cadence do they write?
 const dailies = await journals.listJournals({ writeType: "day" });
-//  [{ name: "Work Daily", shelf: "Work", write: { type: "day" } }, …]
+//  [{ name: "Work Daily", shelf: "Work", write: { type: "day" }, notelets: [] }, …]
 
 // Does today's note exist, and where would it go?
 const [today] = await journals.notesFor("Work Daily", "today");
@@ -210,6 +210,9 @@ period note and any number of notelets.
 - **`createNotelet` always creates.** There is no ensure semantics: several notelets per period is
   the point, so calling it twice gives two notes.
 - **`createNotelet` does not open** unless you pass `openMode`.
+- **Results are grouped by journal, not globally sorted.** `noteletsFor` builds one listing per
+  matching journal, so a multi-journal selector's results appear in the order journals were
+  matched; the type/counter/filename ordering applies only within each journal's group.
 
 ## Errors
 

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -47,9 +47,22 @@ interface JournalsApi {
 
   notesFor(selector: JournalSelector, date: DateInput): Promise<readonly JournalNote[]>;
   journalOf(file: TFile): Promise<ExistingJournalNote | null>;
+  noteletOf(file: TFile): Promise<NoteletNote | null>;
+  noteletsFor(
+    selector: JournalSelector,
+    date: DateInput,
+    options?: { readonly type?: string },
+  ): Promise<readonly NoteletNote[]>;
 
   ensureNote(selector: JournalSelector, date: DateInput, options?: EnsureNoteOptions): Promise<EnsureResult>;
   openNote(selector: JournalSelector, date: DateInput, options?: OpenNoteOptions): Promise<EnsureResult>;
+  createNotelet(
+    selector: JournalSelector,
+    date: DateInput,
+    type: string,
+    options?: CreateNoteletOptions,
+  ): Promise<NoteletNote>;
+  openNotelet(notelet: NoteletNote, options?: OpenNoteletOptions): Promise<void>;
 
   on<K extends keyof JournalsApiEvents>(event: K, handler: JournalsApiEvents[K]): () => void;
 }
@@ -76,6 +89,23 @@ if (current) console.log(current.journal, current.date);
 const off = journals.on("noteAdded", ({ journal, date, path }) => {
   /* … */
 });
+
+// What notelet types does this journal offer?
+const [journal] = await journals.listJournals("Work Weekly");
+//  { name, shelf, write, notelets: ["1o1", "Meeting"] }
+
+// What notelets sit on this week?
+const meetings = await journals.noteletsFor("Work Weekly", "today", { type: "Meeting" });
+//  [{ journal, type, date, displayDate, endDate, path, file, counter }, …]
+
+// Create one, without stealing the user's pane.
+const notelet = await journals.createNotelet("Work Weekly", "today", "Meeting");
+
+// Show it, reusing a pane that already holds it in the focused window.
+await journals.openNotelet(notelet, { openMode: "tab" });
+
+// Which notelet is this file, if any? journalOf stays period-note only.
+const held = await journals.noteletOf(this.app.workspace.getActiveFile());
 ```
 
 ## Selectors
@@ -156,23 +186,46 @@ configuration.
 `endDate` names a day, not an instant. A containment test needs
 `d >= note.date && d <= note.endDate` on date strings, not a timestamp compare.
 
+## Notelets
+
+A notelet is an extra note attached to a period, of a type the journal defines. A period has one
+period note and any number of notelets.
+
+- **`journalOf` never returns a notelet, and `noteAdded`/`noteRemoved` never carry one.**
+  Answering "what journal thing is this file?" is two calls. This is deliberate: a consumer
+  written before notelets existed must keep receiving exactly what it receives today.
+- **`path` and `file` are non-nullable on `NoteletNote`**, unlike `JournalNote`'s. A notelet's
+  path is not a function of its identity — the counter, the prompt answers and the auto-suffix
+  all feed it — so there is no "where it would go". It exists, or there is nothing to describe.
+- **`date`, `displayDate` and `endDate` are the period's**, derived from the anchor. A notelet
+  stores none of them. Correlate a notelet to its period note on `date`.
+- **Types are named, not identified.** `JournalInfo.notelets` lists the names `noteletsFor` and
+  `createNotelet` take. A rename breaks a hardcoded name exactly as it breaks a hardcoded journal
+  name — see [Renames](#renames).
+- **`options.type` is matched per journal.** Two journals may each own a type called "1o1", so a
+  selector spanning both returns notelets from each.
+- **`createNotelet` always creates.** There is no ensure semantics: several notelets per period is
+  the point, so calling it twice gives two notes.
+- **`createNotelet` does not open** unless you pass `openMode`.
+
 ## Errors
 
 Failures reject with an error carrying a stable string `code`. Absence is not a
 failure — no note for a period is `file: null`.
 
-| code                  | meaning                                                                   |
-| --------------------- | ------------------------------------------------------------------------- |
-| `journal-not-found`   | no journal by that name — usually a stale stored reference                |
-| `no-matching-journal` | the selector matched no journal                                           |
-| `invalid-date`        | the `DateInput` could not be read                                         |
-| `unmappable-date`     | the journal's configuration cannot place that date in a period            |
-| `outside-timeline`    | the period falls outside the journal's timeline, and no note exists there |
-| `creation-failed`     | the note could not be created or written                                  |
-| `open-failed`         | the note could not be opened                                              |
-| `aborted`             | the user dismissed the confirmation prompt or the journal picker          |
-| `prompts-required`    | the journal has creation prompts and `prompt: false` was passed           |
-| `plugin-unloaded`     | Journals was unloaded while the call was in flight                        |
+| code                     | meaning                                                                   |
+| ------------------------ | ------------------------------------------------------------------------- |
+| `journal-not-found`      | no journal by that name — usually a stale stored reference                |
+| `no-matching-journal`    | the selector matched no journal                                           |
+| `invalid-date`           | the `DateInput` could not be read                                         |
+| `unmappable-date`        | the journal's configuration cannot place that date in a period            |
+| `outside-timeline`       | the period falls outside the journal's timeline, and no note exists there |
+| `notelet-type-not-found` | the journal owns no notelet type by that name                             |
+| `creation-failed`        | the note could not be created or written                                  |
+| `open-failed`            | the note could not be opened                                              |
+| `aborted`                | the user dismissed the confirmation prompt or the journal picker          |
+| `prompts-required`       | the journal has creation prompts and `prompt: false` was passed           |
+| `plugin-unloaded`        | Journals was unloaded while the call was in flight                        |
 
 ```ts
 try {
@@ -220,8 +273,9 @@ this.register(
 `on` returns its unsubscribe function, so it hands straight to `this.register`.
 
 Available events: `journalCreated`, `journalRenamed`, `journalDeleted`,
-`noteAdded`, `noteRemoved`. Note events carry `path` rather than a `TFile`,
-because on removal the file is already gone.
+`noteAdded`, `noteRemoved`, `noteletAdded`, `noteletRemoved`. Note and notelet
+events carry `path` rather than a `TFile`, because on removal the file is
+already gone.
 
 ## `path` is for display, not for writing
 

--- a/packages/api/index.d.ts
+++ b/packages/api/index.d.ts
@@ -141,6 +141,11 @@ export interface JournalsApi {
   notesFor(selector: JournalSelector, date: DateInput): Promise<readonly JournalNote[]>;
   journalOf(file: TFile): Promise<ExistingJournalNote | null>;
   noteletOf(file: TFile): Promise<NoteletNote | null>;
+  noteletsFor(
+    selector: JournalSelector,
+    date: DateInput,
+    options?: { readonly type?: string },
+  ): Promise<readonly NoteletNote[]>;
 
   ensureNote(selector: JournalSelector, date: DateInput, options?: EnsureNoteOptions): Promise<EnsureResult>;
   openNote(selector: JournalSelector, date: DateInput, options?: OpenNoteOptions): Promise<EnsureResult>;

--- a/packages/api/index.d.ts
+++ b/packages/api/index.d.ts
@@ -38,6 +38,8 @@ export interface JournalInfo {
   readonly name: string;
   readonly shelf: string | null;
   readonly write: JournalWrite;
+  /** The journal's notelet type names, sorted. Empty when the journal defines none. */
+  readonly notelets: readonly string[];
 }
 
 /** The journal's note for a period — on disk, or where it would go. */

--- a/packages/api/index.d.ts
+++ b/packages/api/index.d.ts
@@ -112,6 +112,10 @@ export interface CreateNoteletOptions {
   readonly openMode?: "active" | "tab" | "split" | "window";
 }
 
+export interface OpenNoteletOptions {
+  readonly openMode?: "active" | "tab" | "split" | "window";
+}
+
 /** Open on purpose: new codes are an additive change, so always handle the default case. */
 export type JournalsApiErrorCode =
   | "journal-not-found"
@@ -160,6 +164,7 @@ export interface JournalsApi {
     type: string,
     options?: CreateNoteletOptions,
   ): Promise<NoteletNote>;
+  openNotelet(notelet: NoteletNote, options?: OpenNoteletOptions): Promise<void>;
 
   ensureNote(selector: JournalSelector, date: DateInput, options?: EnsureNoteOptions): Promise<EnsureResult>;
   openNote(selector: JournalSelector, date: DateInput, options?: OpenNoteOptions): Promise<EnsureResult>;

--- a/packages/api/index.d.ts
+++ b/packages/api/index.d.ts
@@ -142,6 +142,8 @@ export interface JournalsApiEvents {
   journalDeleted: (event: { journal: string }) => void;
   noteAdded: (event: { journal: string; date: string; path: string }) => void;
   noteRemoved: (event: { journal: string; date: string; path: string }) => void;
+  noteletAdded: (event: { journal: string; date: string; type: string; path: string }) => void;
+  noteletRemoved: (event: { journal: string; date: string; type: string; path: string }) => void;
 }
 
 export interface JournalsApi {

--- a/packages/api/index.d.ts
+++ b/packages/api/index.d.ts
@@ -105,6 +105,13 @@ export interface EnsureResult {
   readonly created: boolean;
 }
 
+export interface CreateNoteletOptions {
+  /** Ask the type's creation prompts. Defaults to true. */
+  readonly prompt?: boolean;
+  /** Omit to create without opening; pass a mode to create and show. */
+  readonly openMode?: "active" | "tab" | "split" | "window";
+}
+
 /** Open on purpose: new codes are an additive change, so always handle the default case. */
 export type JournalsApiErrorCode =
   | "journal-not-found"
@@ -112,6 +119,7 @@ export type JournalsApiErrorCode =
   | "invalid-date"
   | "unmappable-date"
   | "outside-timeline"
+  | "notelet-type-not-found"
   | "creation-failed"
   | "prompts-required"
   | "open-failed"
@@ -146,6 +154,12 @@ export interface JournalsApi {
     date: DateInput,
     options?: { readonly type?: string },
   ): Promise<readonly NoteletNote[]>;
+  createNotelet(
+    selector: JournalSelector,
+    date: DateInput,
+    type: string,
+    options?: CreateNoteletOptions,
+  ): Promise<NoteletNote>;
 
   ensureNote(selector: JournalSelector, date: DateInput, options?: EnsureNoteOptions): Promise<EnsureResult>;
   openNote(selector: JournalSelector, date: DateInput, options?: OpenNoteOptions): Promise<EnsureResult>;

--- a/packages/api/index.d.ts
+++ b/packages/api/index.d.ts
@@ -67,6 +67,22 @@ export interface ExistingJournalNote extends JournalNote {
   readonly file: TFile;
 }
 
+/** A notelet attached to a journal period. Always exists on disk. */
+export interface NoteletNote {
+  readonly journal: string;
+  /** The type's name, as stored in the note's frontmatter. */
+  readonly type: string;
+  /** "YYYY-MM-DD" — the period's first day. Correlates with JournalNote.date. */
+  readonly date: string;
+  /** The period's, derived from the anchor — a notelet stores neither this nor endDate. */
+  readonly displayDate: string;
+  readonly endDate: string;
+  readonly path: string;
+  readonly file: TFile;
+  /** The assigned counter, when the type has one. Orders siblings within a period. */
+  readonly counter: number | null;
+}
+
 export interface EnsureNoteOptions {
   /** Show the journal's creation-confirmation prompt. Defaults to the journal's own setting. */
   readonly confirm?: boolean;
@@ -124,6 +140,7 @@ export interface JournalsApi {
 
   notesFor(selector: JournalSelector, date: DateInput): Promise<readonly JournalNote[]>;
   journalOf(file: TFile): Promise<ExistingJournalNote | null>;
+  noteletOf(file: TFile): Promise<NoteletNote | null>;
 
   ensureNote(selector: JournalSelector, date: DateInput, options?: EnsureNoteOptions): Promise<EnsureResult>;
   openNote(selector: JournalSelector, date: DateInput, options?: OpenNoteOptions): Promise<EnsureResult>;

--- a/scripts/check-api-package.mjs
+++ b/scripts/check-api-package.mjs
@@ -38,7 +38,7 @@ if (undeclared.length > 0) {
 writeFileSync(
   join(scratch, "consumer.ts"),
   `import { getJournalsApi } from "obsidian-journals-api";
-import type { JournalNote, JournalsApiErrorCode } from "obsidian-journals-api";
+import type { JournalNote, JournalsApiErrorCode, NoteletNote } from "obsidian-journals-api";
 import type { App, TFile } from "obsidian";
 
 export async function capture(app: App): Promise<TFile | null> {
@@ -50,13 +50,26 @@ export async function capture(app: App): Promise<TFile | null> {
   const off = journals.on("journalRenamed", ({ from, to }) => void [from, to]);
   off();
 
+  const types: readonly string[] = dailies[0]?.notelets ?? [];
+  const meetings: readonly NoteletNote[] = await journals.noteletsFor("Daily", "today", {
+    type: types[0] ?? "Meeting",
+  });
+  const offNotelets = journals.on("noteletAdded", ({ journal, date, type, path }) =>
+    void [journal, date, type, path],
+  );
+  offNotelets();
+  if (meetings[0]) await journals.openNotelet(meetings[0], { openMode: "tab" });
+
   try {
     const { note, created } = await journals.ensureNote(dailies[0]?.name ?? "Daily", "+1w", { confirm: false });
+    const notelet: NoteletNote = await journals.createNotelet("Daily", "today", "Meeting", { prompt: false });
+    const held: NoteletNote | null = await journals.noteletOf(notelet.file);
+    void [notes, held?.counter, notelet.displayDate];
     return created ? note.file : null;
   } catch (error) {
     const code = (error as { code: JournalsApiErrorCode }).code;
     // The union is open, so a default branch must always compile.
-    return code === "aborted" ? null : null;
+    return code === "notelet-type-not-found" ? null : null;
   }
 }
 `,

--- a/scripts/check-api-package.mjs
+++ b/scripts/check-api-package.mjs
@@ -58,6 +58,10 @@ export async function capture(app: App): Promise<TFile | null> {
     void [journal, date, type, path],
   );
   offNotelets();
+  const offNoteletsRemoved = journals.on("noteletRemoved", ({ journal, date, type, path }) =>
+    void [journal, date, type, path],
+  );
+  offNoteletsRemoved();
   if (meetings[0]) await journals.openNotelet(meetings[0], { openMode: "tab" });
 
   try {

--- a/src/api/convert.test.ts
+++ b/src/api/convert.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { customJournal, fixedJournal } from "@/journals/testing";
+import type { TypeId } from "@/journals/notelets/config";
+import { buildNoteletType, customJournal, fixedJournal } from "@/journals/testing";
 
 import { normalizeSelector, toCalendarDate, toJournalInfo } from "./convert";
 
@@ -56,6 +57,7 @@ describe("toJournalInfo", () => {
       name: "daily",
       shelf: null,
       write: { type: "day" },
+      notelets: [],
     });
   });
 
@@ -64,6 +66,22 @@ describe("toJournalInfo", () => {
       name: "sprint",
       shelf: "Work",
       write: { type: "custom", every: "week", duration: 3 },
+      notelets: [],
     });
+  });
+
+  it("lists notelet type names in sorted order, not record order", () => {
+    const config = fixedJournal(
+      "daily",
+      { type: "day" },
+      {
+        notelets: {
+          nt_second: buildNoteletType({ id: "nt_second" as TypeId, name: "Meeting" }),
+          nt_first: buildNoteletType({ id: "nt_first" as TypeId, name: "1o1" }),
+        },
+      },
+    );
+
+    expect(toJournalInfo("daily", config, "").notelets).toEqual(["1o1", "Meeting"]);
   });
 });

--- a/src/api/convert.ts
+++ b/src/api/convert.ts
@@ -39,5 +39,10 @@ export function toJournalInfo(name: string, config: JournalConfig, shelf: string
   const write: JournalWrite = match(config.write)
     .with({ type: "custom" }, ({ every, duration }) => ({ type: "custom" as const, every, duration }))
     .otherwise(({ type }) => ({ type }));
-  return { name, shelf: shelf === "" ? null : shelf, write };
+  // Sorted rather than record order: the keys are nanoids, so record order is creation order and
+  // an unrelated edit would reshuffle a caller's list.
+  const notelets = Object.values(config.notelets)
+    .map((type) => type.name)
+    .toSorted((a, b) => a.localeCompare(b));
+  return { name, shelf: shelf === "" ? null : shelf, write, notelets };
 }

--- a/src/api/journals-api.test.ts
+++ b/src/api/journals-api.test.ts
@@ -11,9 +11,10 @@ import { CycleService } from "@/journals/cycle";
 import { EnsureJournalEntryFlow, OpenJournalEntryFlow } from "@/journals/flows";
 import { JournalsIndex } from "@/journals/journals-index";
 import { journalsCoreModule } from "@/journals/module";
+import type { TypeId } from "@/journals/notelets/config";
 import type { Prompt, PromptAnswer } from "@/journals/prompts/config";
 import { JournalsRepository } from "@/journals/repository";
-import { fixedJournal } from "@/journals/testing";
+import { buildNoteletType, fixedJournal } from "@/journals/testing";
 import { VaultSubscriptionService } from "@/journals/vault-subscription";
 import type { ShelfConfig } from "@/shelves/config";
 import { shelvesCoreModule } from "@/shelves/module";
@@ -93,6 +94,22 @@ describe("JournalsApiService reads", () => {
     const { api } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
 
     expect(await api.journalInfo("nope")).toBeNull();
+  });
+
+  it("reports a journal's notelet type names through journalInfo", async () => {
+    const { api } = await buildApi({
+      daily: fixedJournal(
+        "daily",
+        { type: "day" },
+        {
+          notelets: { nt_meeting: buildNoteletType({ id: "nt_meeting" as TypeId, name: "Meeting" }) },
+        },
+      ),
+    });
+
+    const info = await api.journalInfo("daily");
+
+    expect(info?.notelets).toEqual(["Meeting"]);
   });
 
   it("reports a period with no note as file null and a predicted path", async () => {

--- a/src/api/journals-api.test.ts
+++ b/src/api/journals-api.test.ts
@@ -6,6 +6,7 @@ import { NotesService, WorkspaceOpenError, WorkspaceService } from "@/infrastruc
 import type { VaultPath } from "@/infrastructure/host";
 import { NoteFileService } from "@/infrastructure/host/internal/note-file-service";
 import { AsyncResult, Option } from "@/infrastructure/result";
+import { CreateNoteletFlow } from "@/journals";
 import type { JournalConfig } from "@/journals/config";
 import { CycleService } from "@/journals/cycle";
 import { EnsureJournalEntryFlow, OpenJournalEntryFlow } from "@/journals/flows";
@@ -26,6 +27,7 @@ import { JournalsApiService } from "./journals-api";
 import { apiModule } from "./module";
 
 const meeting = buildNoteletType({ id: "nt_meeting" as TypeId, name: "Meeting" });
+const mood: Prompt = { variable: "mood", question: "Mood?", type: "text", frontmatterKey: "mood", required: false };
 
 interface BuildOptions {
   /** Shelves to seed, keyed the same as their own name. Default: none. */
@@ -711,9 +713,137 @@ describe("JournalsApiService writes", () => {
   });
 });
 
-describe("JournalsApiService creation prompts", () => {
-  const mood: Prompt = { variable: "mood", question: "Mood?", type: "text", frontmatterKey: "mood", required: false };
+describe("JournalsApiService notelet creation", () => {
+  it("creates a notelet through the flow and reports it", async () => {
+    const { api, flows } = await buildApi({
+      weekly: fixedJournal("weekly", { type: "week" }, { notelets: { nt_meeting: meeting } }),
+    });
 
+    const note = await api.createNotelet("weekly", "2026-08-19", "Meeting");
+
+    expect(note).toMatchObject({ journal: "weekly", type: "Meeting", date: "2026-08-17", counter: 1 });
+    expect(note.file).not.toBeNull();
+    expect(flows).toHaveBeenLastCalledWith(CreateNoteletFlow, expect.anything(), expect.anything());
+  });
+
+  it("does not open the notelet unless a mode is asked for", async () => {
+    const { api, harness } = await buildApi({
+      weekly: fixedJournal("weekly", { type: "week" }, { notelets: { nt_meeting: meeting } }),
+    });
+    const open = vi.spyOn(harness.resolve(WorkspaceService), "openNote");
+
+    await api.createNotelet("weekly", "2026-08-19", "Meeting");
+
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("opens the notelet in the mode it was given", async () => {
+    const { api, harness } = await buildApi({
+      weekly: fixedJournal("weekly", { type: "week" }, { notelets: { nt_meeting: meeting } }),
+    });
+    const open = vi.spyOn(harness.resolve(WorkspaceService), "openNote");
+
+    await api.createNotelet("weekly", "2026-08-19", "Meeting", { openMode: "split" });
+
+    expect(open).toHaveBeenCalledWith(expect.any(String), "split");
+  });
+
+  it("creates a second notelet rather than handing back the first", async () => {
+    const { api } = await buildApi({
+      weekly: fixedJournal("weekly", { type: "week" }, { notelets: { nt_meeting: meeting } }),
+    });
+
+    const first = await api.createNotelet("weekly", "2026-08-19", "Meeting");
+    const second = await api.createNotelet("weekly", "2026-08-19", "Meeting");
+
+    expect(second.path).not.toBe(first.path);
+  });
+
+  it("fails with notelet-type-not-found for a name the journal does not own", async () => {
+    const { api } = await buildApi({
+      weekly: fixedJournal("weekly", { type: "week" }, { notelets: { nt_meeting: meeting } }),
+    });
+
+    await expect(api.createNotelet("weekly", "2026-08-19", "Nope")).rejects.toMatchObject({
+      code: "notelet-type-not-found",
+      journal: "weekly",
+    });
+  });
+
+  it("fails with journal-not-found for a journal that does not exist", async () => {
+    const { api } = await buildApi({ weekly: fixedJournal("weekly", { type: "week" }) });
+
+    await expect(api.createNotelet("nope", "2026-08-19", "Meeting")).rejects.toMatchObject({
+      code: "journal-not-found",
+    });
+  });
+
+  it("fails with outside-timeline for a date the journal's timeline excludes", async () => {
+    const { api } = await buildApi({
+      past: fixedJournal(
+        "past",
+        { type: "week" },
+        {
+          notelets: { nt_meeting: meeting },
+          timeline: {
+            start: "2020-01-01" as AnchorString,
+            end: { kind: "date", date: "2020-12-31" as AnchorString },
+          },
+        },
+      ),
+    });
+
+    await expect(api.createNotelet("past", "2026-08-19", "Meeting")).rejects.toMatchObject({
+      code: "outside-timeline",
+    });
+  });
+
+  it("asks the type's prompts by default", async () => {
+    const { api, harness } = await buildApi({
+      weekly: fixedJournal(
+        "weekly",
+        { type: "week" },
+        {
+          notelets: {
+            nt_meeting: buildNoteletType({ id: "nt_meeting" as TypeId, name: "Meeting", prompts: [mood] }),
+          },
+        },
+      ),
+    });
+
+    const pending = api.createNotelet("weekly", "2026-08-19", "Meeting");
+    await vi.waitFor(() => expect(harness.modals.opens).toHaveLength(1));
+    harness.modals.lastOpen<unknown, Record<string, PromptAnswer>>().submit({ mood: "good" });
+
+    await expect(pending).resolves.toMatchObject({ type: "Meeting" });
+  });
+
+  it("fails with prompts-required when prompt:false and an answer reaches the note name", async () => {
+    const { api, harness } = await buildApi({
+      weekly: fixedJournal(
+        "weekly",
+        { type: "week" },
+        {
+          notelets: {
+            nt_meeting: buildNoteletType({
+              id: "nt_meeting" as TypeId,
+              name: "Meeting",
+              prompts: [mood],
+              nameTemplate: "{{journal_name}} {{mood}}",
+            }),
+          },
+        },
+      ),
+    });
+
+    await expect(api.createNotelet("weekly", "2026-08-19", "Meeting", { prompt: false })).rejects.toMatchObject({
+      code: "prompts-required",
+    });
+    expect(harness.modals.opens).toHaveLength(0);
+  });
+});
+
+describe("JournalsApiService creation prompts", () => {
   it("asks by default on a prompting journal", async () => {
     const { api, harness } = await buildApi({
       daily: fixedJournal("daily", { type: "day" }, { prompts: [mood] }),

--- a/src/api/journals-api.test.ts
+++ b/src/api/journals-api.test.ts
@@ -314,6 +314,187 @@ describe("JournalsApiService notelet reads", () => {
 
     expect(await api.journalOf({ path: "Journal/Meeting 1.md" })).toBeNull();
   });
+
+  it("returns a period's notelets ordered by type, then counter", async () => {
+    const { api, harness, index } = await buildApi({
+      weekly: fixedJournal(
+        "weekly",
+        { type: "week" },
+        {
+          notelets: {
+            nt_meeting: meeting,
+            nt_review: buildNoteletType({ id: "nt_review" as TypeId, name: "Review" }),
+          },
+        },
+      ),
+    });
+    const anchor = "2026-08-17" as AnchorString;
+    await seedNotelet(harness, index, {
+      journalName: "weekly",
+      anchor,
+      path: "Journal/Review.md" as VaultPath,
+      typeName: "Review",
+      typeId: "nt_review" as TypeId,
+      counter: 1,
+    });
+    await seedNotelet(harness, index, {
+      journalName: "weekly",
+      anchor,
+      path: "Journal/Meeting 2.md" as VaultPath,
+      typeName: "Meeting",
+      typeId: "nt_meeting" as TypeId,
+      counter: 2,
+    });
+    await seedNotelet(harness, index, {
+      journalName: "weekly",
+      anchor,
+      path: "Journal/Meeting 1.md" as VaultPath,
+      typeName: "Meeting",
+      typeId: "nt_meeting" as TypeId,
+      counter: 1,
+    });
+
+    const found = await api.noteletsFor("weekly", "2026-08-19");
+
+    expect(found.map((note) => note.path)).toEqual([
+      "Journal/Meeting 1.md",
+      "Journal/Meeting 2.md",
+      "Journal/Review.md",
+    ]);
+  });
+
+  it("finds a notelet from any day inside its period", async () => {
+    const { api, harness, index } = await buildApi({
+      weekly: fixedJournal("weekly", { type: "week" }, { notelets: { nt_meeting: meeting } }),
+    });
+    await seedNotelet(harness, index, {
+      journalName: "weekly",
+      anchor: "2026-08-17" as AnchorString,
+      path: "Journal/Meeting 1.md" as VaultPath,
+      typeName: "Meeting",
+      typeId: "nt_meeting" as TypeId,
+      counter: 1,
+    });
+
+    const found = await api.noteletsFor("weekly", "2026-08-21");
+
+    expect(found).toHaveLength(1);
+    expect(found.at(0)?.date).toBe("2026-08-17");
+  });
+
+  it("fans across every journal the selector matches", async () => {
+    const { api, harness, index } = await buildApi({
+      work: fixedJournal("work", { type: "day" }, { notelets: { nt_meeting: meeting } }),
+      home: fixedJournal("home", { type: "day" }, { notelets: { nt_meeting: meeting } }),
+    });
+    const anchor = "2026-08-18" as AnchorString;
+    await seedNotelet(harness, index, {
+      journalName: "work",
+      anchor,
+      path: "Work/Meeting 1.md" as VaultPath,
+      typeName: "Meeting",
+      typeId: "nt_meeting" as TypeId,
+      counter: 1,
+    });
+    await seedNotelet(harness, index, {
+      journalName: "home",
+      anchor,
+      path: "Home/Meeting 1.md" as VaultPath,
+      typeName: "Meeting",
+      typeId: "nt_meeting" as TypeId,
+      counter: 1,
+    });
+
+    const found = await api.noteletsFor({ writeType: "day" }, "2026-08-18");
+
+    expect(found.map((note) => note.journal).toSorted()).toEqual(["home", "work"]);
+  });
+
+  it("narrows to one type by name, per journal", async () => {
+    const { api, harness, index } = await buildApi({
+      weekly: fixedJournal(
+        "weekly",
+        { type: "week" },
+        {
+          notelets: {
+            nt_meeting: meeting,
+            nt_review: buildNoteletType({ id: "nt_review" as TypeId, name: "Review" }),
+          },
+        },
+      ),
+    });
+    const anchor = "2026-08-17" as AnchorString;
+    await seedNotelet(harness, index, {
+      journalName: "weekly",
+      anchor,
+      path: "Journal/Meeting 1.md" as VaultPath,
+      typeName: "Meeting",
+      typeId: "nt_meeting" as TypeId,
+      counter: 1,
+    });
+    await seedNotelet(harness, index, {
+      journalName: "weekly",
+      anchor,
+      path: "Journal/Review.md" as VaultPath,
+      typeName: "Review",
+      typeId: "nt_review" as TypeId,
+      counter: 1,
+    });
+
+    const found = await api.noteletsFor("weekly", "2026-08-19", { type: "Meeting" });
+
+    expect(found.map((note) => note.path)).toEqual(["Journal/Meeting 1.md"]);
+  });
+
+  it("matches an orphaned notelet by the type name it still carries", async () => {
+    const { api, harness, index } = await buildApi({ weekly: fixedJournal("weekly", { type: "week" }) });
+    await seedNotelet(harness, index, {
+      journalName: "weekly",
+      anchor: "2026-08-17" as AnchorString,
+      path: "Journal/Orphan.md" as VaultPath,
+      typeName: "Retired",
+      typeId: null,
+    });
+
+    const found = await api.noteletsFor("weekly", "2026-08-19", { type: "Retired" });
+
+    expect(found.map((note) => note.type)).toEqual(["Retired"]);
+  });
+
+  it("returns empty for a type name the journal does not know, rather than failing", async () => {
+    const { api, harness, index } = await buildApi({
+      weekly: fixedJournal("weekly", { type: "week" }, { notelets: { nt_meeting: meeting } }),
+    });
+    await seedNotelet(harness, index, {
+      journalName: "weekly",
+      anchor: "2026-08-17" as AnchorString,
+      path: "Journal/Meeting 1.md" as VaultPath,
+      typeName: "Meeting",
+      typeId: "nt_meeting" as TypeId,
+      counter: 1,
+    });
+
+    await expect(api.noteletsFor("weekly", "2026-08-19", { type: "Nope" })).resolves.toEqual([]);
+  });
+
+  // Forced with a spy, not a fixture: CycleService.anchorOf (cycle.ts:123) walks a custom cycle
+  // forward from its anchor and always answers Some, so no real config reaches this branch. The
+  // suite's existing unmappable-date case records the same finding and uses the same shape. The
+  // mock must persist rather than be *Once* — the fan-out calls anchorOf once per selected journal.
+  it("omits a journal whose cycle cannot place the date instead of failing the fan-out", async () => {
+    const { api, harness } = await buildApi({
+      weekly: fixedJournal("weekly", { type: "week" }, { notelets: { nt_meeting: meeting } }),
+    });
+    vi.spyOn(harness.resolve(CycleService), "anchorOf").mockReturnValue(Option.none());
+
+    await expect(api.noteletsFor("weekly", "2026-08-19")).resolves.toEqual([]);
+  });
+
+  it("rejects a date it cannot read with invalid-date", async () => {
+    const { api } = await buildApi({ weekly: fixedJournal("weekly", { type: "week" }) });
+
+    await expect(api.noteletsFor("weekly", "whenever")).rejects.toMatchObject({ code: "invalid-date" });
+  });
 });
 
 describe("JournalsApiService writes", () => {
@@ -708,5 +889,16 @@ describe("JournalsApiService unloading", () => {
     await api[Symbol.asyncDispose]();
 
     await expect(api.notesFor("daily", "2026-08-18")).rejects.toMatchObject({ code: "plugin-unloaded" });
+  });
+
+  it("rejects notelet calls made after disposal", async () => {
+    const { api } = await buildApi({ weekly: fixedJournal("weekly", { type: "week" }) });
+
+    await api[Symbol.asyncDispose]();
+
+    await expect(api.noteletsFor("weekly", "2026-08-18")).rejects.toMatchObject({ code: "plugin-unloaded" });
+    await expect(api.noteletOf({ path: "Journal/Meeting 1.md" })).rejects.toMatchObject({
+      code: "plugin-unloaded",
+    });
   });
 });

--- a/src/api/journals-api.test.ts
+++ b/src/api/journals-api.test.ts
@@ -26,6 +26,8 @@ import { testContainer } from "@/testing";
 import { JournalsApiService } from "./journals-api";
 import { apiModule } from "./module";
 
+import type { NoteletNote } from "./public-api";
+
 const meeting = buildNoteletType({ id: "nt_meeting" as TypeId, name: "Meeting" });
 const mood: Prompt = { variable: "mood", question: "Mood?", type: "text", frontmatterKey: "mood", required: false };
 
@@ -871,6 +873,55 @@ describe("JournalsApiService notelet creation", () => {
       code: "prompts-required",
     });
     expect(harness.modals.opens).toHaveLength(0);
+  });
+});
+
+async function createdNotelet(): Promise<{
+  api: JournalsApiService;
+  harness: Awaited<ReturnType<typeof buildApi>>["harness"];
+  note: NoteletNote;
+}> {
+  const { api, harness } = await buildApi({
+    weekly: fixedJournal("weekly", { type: "week" }, { notelets: { nt_meeting: meeting } }),
+  });
+  const note = await api.createNotelet("weekly", "2026-08-19", "Meeting");
+  return { api, harness, note };
+}
+
+describe("JournalsApiService notelet opening", () => {
+  it("opens through the workspace, in the active pane by default", async () => {
+    const { api, harness, note } = await createdNotelet();
+    const open = vi.spyOn(harness.resolve(WorkspaceService), "openNote");
+
+    await api.openNotelet(note);
+
+    expect(open).toHaveBeenCalledWith(note.path, "active");
+  });
+
+  it("honors the requested mode", async () => {
+    const { api, harness, note } = await createdNotelet();
+    const open = vi.spyOn(harness.resolve(WorkspaceService), "openNote");
+
+    await api.openNotelet(note, { openMode: "window" });
+
+    expect(open).toHaveBeenCalledWith(note.path, "window");
+  });
+
+  it("fails with open-failed when the file is gone", async () => {
+    const { api, harness, note } = await createdNotelet();
+    vi.spyOn(harness.resolve(WorkspaceService), "openNote").mockReturnValueOnce(
+      AsyncResult.err(new WorkspaceOpenError(note.path as VaultPath, new Error("not a file"))),
+    );
+
+    await expect(api.openNotelet(note)).rejects.toMatchObject({ code: "open-failed", journal: "weekly" });
+  });
+
+  it("refuses after the plugin is unloaded", async () => {
+    const { api, note } = await createdNotelet();
+
+    await api[Symbol.asyncDispose]();
+
+    await expect(api.openNotelet(note)).rejects.toMatchObject({ code: "plugin-unloaded" });
   });
 });
 

--- a/src/api/journals-api.test.ts
+++ b/src/api/journals-api.test.ts
@@ -481,6 +481,23 @@ describe("JournalsApiService notelet reads", () => {
     await expect(api.noteletsFor("weekly", "2026-08-19", { type: "Nope" })).resolves.toEqual([]);
   });
 
+  it("omits a notelet whose file the vault cannot resolve", async () => {
+    const { api, index } = await buildApi({
+      weekly: fixedJournal("weekly", { type: "week" }, { notelets: { nt_meeting: meeting } }),
+    });
+    index.register({
+      kind: "notelet",
+      journalName: "weekly",
+      anchor: "2026-08-17" as AnchorString,
+      path: "Journal/Meeting 1.md" as VaultPath,
+      typeName: "Meeting",
+      typeId: "nt_meeting" as TypeId,
+      counter: 1,
+    });
+
+    await expect(api.noteletsFor("weekly", "2026-08-19")).resolves.toEqual([]);
+  });
+
   // Forced with a spy, not a fixture: CycleService.anchorOf (cycle.ts:123) walks a custom cycle
   // forward from its anchor and always answers Some, so no real config reaches this branch. The
   // suite's existing unmappable-date case records the same finding and uses the same shape. The
@@ -750,7 +767,7 @@ describe("JournalsApiService notelet creation", () => {
     expect(open).toHaveBeenCalledWith(expect.any(String), "split");
   });
 
-  it("does not collapse two concurrent creations into one", async () => {
+  it("invokes the creation flow once per call rather than deduping", async () => {
     const { api, flows } = await buildApi({
       weekly: fixedJournal("weekly", { type: "week" }, { notelets: { nt_meeting: meeting } }),
     });
@@ -873,6 +890,30 @@ describe("JournalsApiService notelet creation", () => {
       code: "prompts-required",
     });
     expect(harness.modals.opens).toHaveLength(0);
+  });
+
+  it("fails with notelet-type-not-found when the type is deleted while the prompt modal is open", async () => {
+    const { api, harness, repo } = await buildApi({
+      weekly: fixedJournal(
+        "weekly",
+        { type: "week" },
+        {
+          notelets: {
+            nt_meeting: buildNoteletType({ id: "nt_meeting" as TypeId, name: "Meeting", prompts: [mood] }),
+          },
+        },
+      ),
+    });
+
+    const pending = api.createNotelet("weekly", "2026-08-19", "Meeting");
+    await vi.waitFor(() => expect(harness.modals.opens).toHaveLength(1));
+    repo.deleteNoteletType("weekly", "nt_meeting" as TypeId);
+    harness.modals.lastOpen<unknown, Record<string, PromptAnswer>>().submit({ mood: "good" });
+
+    await expect(pending).rejects.toMatchObject({
+      code: "notelet-type-not-found",
+      message: "Notelet type not found in weekly: nt_meeting",
+    });
   });
 });
 
@@ -1171,6 +1212,50 @@ describe("JournalsApiService events", () => {
 
     expect(seen).toEqual([]);
   });
+
+  it("keeps note and notelet add/remove events each to their own kind", async () => {
+    const { api, index } = await buildApi({
+      weekly: fixedJournal("weekly", { type: "week" }, { notelets: { nt_meeting: meeting } }),
+    });
+    const notesAdded: string[] = [];
+    const notesRemoved: string[] = [];
+    const noteletsAdded: string[] = [];
+    const noteletsRemoved: string[] = [];
+    api.on("noteAdded", (event) => {
+      notesAdded.push(event.path);
+    });
+    api.on("noteRemoved", (event) => {
+      notesRemoved.push(event.path);
+    });
+    api.on("noteletAdded", (event) => {
+      noteletsAdded.push(event.path);
+    });
+    api.on("noteletRemoved", (event) => {
+      noteletsRemoved.push(event.path);
+    });
+
+    index.register({
+      journalName: "weekly",
+      anchor: "2026-08-17" as AnchorString,
+      path: "Journal/2026-08-17.md" as VaultPath,
+    });
+    index.register({
+      kind: "notelet",
+      journalName: "weekly",
+      anchor: "2026-08-17" as AnchorString,
+      path: "Journal/Meeting 1.md" as VaultPath,
+      typeName: "Meeting",
+      typeId: "nt_meeting" as TypeId,
+      counter: 1,
+    });
+    index.unregister("Journal/2026-08-17.md" as VaultPath);
+    index.unregister("Journal/Meeting 1.md" as VaultPath);
+
+    expect(notesAdded).toEqual(["Journal/2026-08-17.md"]);
+    expect(notesRemoved).toEqual(["Journal/2026-08-17.md"]);
+    expect(noteletsAdded).toEqual(["Journal/Meeting 1.md"]);
+    expect(noteletsRemoved).toEqual(["Journal/Meeting 1.md"]);
+  });
 });
 
 describe("JournalsApiService unloading", () => {
@@ -1197,6 +1282,9 @@ describe("JournalsApiService unloading", () => {
     await api[Symbol.asyncDispose]();
 
     await expect(api.noteletsFor("weekly", "2026-08-18")).rejects.toMatchObject({ code: "plugin-unloaded" });
+    await expect(api.createNotelet("weekly", "2026-08-18", "Meeting")).rejects.toMatchObject({
+      code: "plugin-unloaded",
+    });
     await expect(api.noteletOf({ path: "Journal/Meeting 1.md" })).rejects.toMatchObject({
       code: "plugin-unloaded",
     });

--- a/src/api/journals-api.test.ts
+++ b/src/api/journals-api.test.ts
@@ -1083,6 +1083,94 @@ describe("JournalsApiService events", () => {
 
     expect(calls).toBe(0);
   });
+
+  it("reports an added notelet with its type", async () => {
+    const { api, index } = await buildApi({
+      weekly: fixedJournal(
+        "weekly",
+        { type: "week" },
+        {
+          notelets: { nt_meeting: buildNoteletType({ id: "nt_meeting" as TypeId, name: "Meeting" }) },
+        },
+      ),
+    });
+    const seen: { journal: string; date: string; type: string; path: string }[] = [];
+    api.on("noteletAdded", (event) => {
+      seen.push(event);
+    });
+
+    index.register({
+      kind: "notelet",
+      journalName: "weekly",
+      anchor: "2026-08-17" as AnchorString,
+      path: "Journal/Meeting 1.md" as VaultPath,
+      typeName: "Meeting",
+      typeId: "nt_meeting" as TypeId,
+      counter: 1,
+    });
+
+    expect(seen).toEqual([{ journal: "weekly", date: "2026-08-17", type: "Meeting", path: "Journal/Meeting 1.md" }]);
+  });
+
+  it("reports a removed notelet", async () => {
+    const { api, index } = await buildApi({ weekly: fixedJournal("weekly", { type: "week" }) });
+    index.register({
+      kind: "notelet",
+      journalName: "weekly",
+      anchor: "2026-08-17" as AnchorString,
+      path: "Journal/Meeting 1.md" as VaultPath,
+      typeName: "Meeting",
+      typeId: "nt_meeting" as TypeId,
+    });
+    const seen: { journal: string; type: string }[] = [];
+    api.on("noteletRemoved", (event) => {
+      seen.push({ journal: event.journal, type: event.type });
+    });
+
+    index.unregister("Journal/Meeting 1.md" as VaultPath);
+
+    expect(seen).toEqual([{ journal: "weekly", type: "Meeting" }]);
+  });
+
+  it("does not deliver a notelet to noteAdded", async () => {
+    const { api, index } = await buildApi({ weekly: fixedJournal("weekly", { type: "week" }) });
+    const periodNotes: string[] = [];
+    const notelets: string[] = [];
+    api.on("noteAdded", (event) => {
+      periodNotes.push(event.path);
+    });
+    api.on("noteletAdded", (event) => {
+      notelets.push(event.path);
+    });
+
+    index.register({
+      kind: "notelet",
+      journalName: "weekly",
+      anchor: "2026-08-17" as AnchorString,
+      path: "Journal/Meeting 1.md" as VaultPath,
+      typeName: "Meeting",
+      typeId: "nt_meeting" as TypeId,
+    });
+
+    expect(notelets).toEqual(["Journal/Meeting 1.md"]);
+    expect(periodNotes).toEqual([]);
+  });
+
+  it("does not deliver a period note to noteletAdded", async () => {
+    const { api, index } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    const seen: string[] = [];
+    api.on("noteletAdded", (event) => {
+      seen.push(event.path);
+    });
+
+    index.register({
+      journalName: "daily",
+      anchor: "2026-08-18" as AnchorString,
+      path: "Journal/2026-08-18.md" as VaultPath,
+    });
+
+    expect(seen).toEqual([]);
+  });
 });
 
 describe("JournalsApiService unloading", () => {

--- a/src/api/journals-api.test.ts
+++ b/src/api/journals-api.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { AnchorString } from "@/calendar";
 import { Flows } from "@/infrastructure/flows";
-import { WorkspaceOpenError, WorkspaceService } from "@/infrastructure/host";
+import { NotesService, WorkspaceOpenError, WorkspaceService } from "@/infrastructure/host";
 import type { VaultPath } from "@/infrastructure/host";
 import { NoteFileService } from "@/infrastructure/host/internal/note-file-service";
 import { AsyncResult, Option } from "@/infrastructure/result";
@@ -15,6 +15,7 @@ import type { TypeId } from "@/journals/notelets/config";
 import type { Prompt, PromptAnswer } from "@/journals/prompts/config";
 import { JournalsRepository } from "@/journals/repository";
 import { buildNoteletType, fixedJournal } from "@/journals/testing";
+import type { NoteletEntry } from "@/journals/types";
 import { VaultSubscriptionService } from "@/journals/vault-subscription";
 import type { ShelfConfig } from "@/shelves/config";
 import { shelvesCoreModule } from "@/shelves/module";
@@ -23,6 +24,8 @@ import { testContainer } from "@/testing";
 
 import { JournalsApiService } from "./journals-api";
 import { apiModule } from "./module";
+
+const meeting = buildNoteletType({ id: "nt_meeting" as TypeId, name: "Meeting" });
 
 interface BuildOptions {
   /** Shelves to seed, keyed the same as their own name. Default: none. */
@@ -206,6 +209,110 @@ describe("JournalsApiService reads", () => {
     const { api } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
 
     expect(await api.journalOf({ path: "Random/note.md" })).toBeNull();
+  });
+});
+
+async function seedNotelet(
+  harness: Awaited<ReturnType<typeof buildApi>>["harness"],
+  index: JournalsIndex,
+  entry: Omit<NoteletEntry, "kind">,
+): Promise<void> {
+  const created = await harness.resolve(NotesService).create(entry.path, "");
+  expect(created.isOk()).toBe(true);
+  index.register({ kind: "notelet", ...entry });
+}
+
+describe("JournalsApiService notelet reads", () => {
+  it("reads a notelet off the file it was handed", async () => {
+    const { api, harness, index } = await buildApi({
+      weekly: fixedJournal("weekly", { type: "week" }, { notelets: { nt_meeting: meeting } }),
+    });
+    await seedNotelet(harness, index, {
+      journalName: "weekly",
+      anchor: "2026-08-17" as AnchorString,
+      path: "Journal/Meeting 1.md" as VaultPath,
+      typeName: "Meeting",
+      typeId: "nt_meeting" as TypeId,
+      counter: 1,
+    });
+    const file = { path: "Journal/Meeting 1.md" } as never;
+
+    const note = await api.noteletOf(file);
+
+    expect(note).toMatchObject({
+      journal: "weekly",
+      type: "Meeting",
+      date: "2026-08-17",
+      endDate: "2026-08-23",
+      path: "Journal/Meeting 1.md",
+      counter: 1,
+    });
+    expect(note?.file).toBe(file);
+  });
+
+  it("reports a null counter for a notelet that has none", async () => {
+    const { api, harness, index } = await buildApi({
+      weekly: fixedJournal("weekly", { type: "week" }, { notelets: { nt_meeting: meeting } }),
+    });
+    await seedNotelet(harness, index, {
+      journalName: "weekly",
+      anchor: "2026-08-17" as AnchorString,
+      path: "Journal/Meeting.md" as VaultPath,
+      typeName: "Meeting",
+      typeId: "nt_meeting" as TypeId,
+    });
+
+    const note = await api.noteletOf({ path: "Journal/Meeting.md" });
+
+    expect(note?.counter).toBeNull();
+  });
+
+  it("reports the stored type name for a notelet whose type was deleted in keep mode", async () => {
+    const { api, harness, index } = await buildApi({ weekly: fixedJournal("weekly", { type: "week" }) });
+    await seedNotelet(harness, index, {
+      journalName: "weekly",
+      anchor: "2026-08-17" as AnchorString,
+      path: "Journal/Orphan.md" as VaultPath,
+      typeName: "Retired",
+      typeId: null,
+    });
+
+    const note = await api.noteletOf({ path: "Journal/Orphan.md" });
+
+    expect(note?.type).toBe("Retired");
+  });
+
+  it("returns null from noteletOf for a period note", async () => {
+    const { api, index } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+    index.register({
+      journalName: "daily",
+      anchor: "2026-08-18" as AnchorString,
+      path: "Journal/2026-08-18.md" as VaultPath,
+    });
+
+    expect(await api.noteletOf({ path: "Journal/2026-08-18.md" })).toBeNull();
+  });
+
+  it("returns null from noteletOf for an unconnected note", async () => {
+    const { api } = await buildApi({ daily: fixedJournal("daily", { type: "day" }) });
+
+    expect(await api.noteletOf({ path: "Random/note.md" })).toBeNull();
+  });
+
+  it("leaves journalOf answering null for a notelet", async () => {
+    const { api, harness, index } = await buildApi({
+      weekly: fixedJournal("weekly", { type: "week" }, { notelets: { nt_meeting: meeting } }),
+    });
+    await seedNotelet(harness, index, {
+      journalName: "weekly",
+      anchor: "2026-08-17" as AnchorString,
+      path: "Journal/Meeting 1.md" as VaultPath,
+      typeName: "Meeting",
+      typeId: "nt_meeting" as TypeId,
+      counter: 1,
+    });
+
+    expect(await api.journalOf({ path: "Journal/Meeting 1.md" })).toBeNull();
   });
 });
 

--- a/src/api/journals-api.test.ts
+++ b/src/api/journals-api.test.ts
@@ -748,19 +748,22 @@ describe("JournalsApiService notelet creation", () => {
     expect(open).toHaveBeenCalledWith(expect.any(String), "split");
   });
 
-  it("creates a second notelet rather than handing back the first", async () => {
-    const { api } = await buildApi({
+  it("does not collapse two concurrent creations into one", async () => {
+    const { api, flows } = await buildApi({
       weekly: fixedJournal("weekly", { type: "week" }, { notelets: { nt_meeting: meeting } }),
     });
 
-    const first = await api.createNotelet("weekly", "2026-08-19", "Meeting");
-    const second = await api.createNotelet("weekly", "2026-08-19", "Meeting");
+    await Promise.allSettled([
+      api.createNotelet("weekly", "2026-08-19", "Meeting"),
+      api.createNotelet("weekly", "2026-08-19", "Meeting"),
+    ]);
 
-    expect(second.path).not.toBe(first.path);
+    const invocations = flows.mock.calls.filter(([flow]) => flow === CreateNoteletFlow);
+    expect(invocations).toHaveLength(2);
   });
 
   it("fails with notelet-type-not-found for a name the journal does not own", async () => {
-    const { api } = await buildApi({
+    const { api, flows } = await buildApi({
       weekly: fixedJournal("weekly", { type: "week" }, { notelets: { nt_meeting: meeting } }),
     });
 
@@ -768,6 +771,7 @@ describe("JournalsApiService notelet creation", () => {
       code: "notelet-type-not-found",
       journal: "weekly",
     });
+    expect(flows).not.toHaveBeenCalledWith(CreateNoteletFlow, expect.anything(), expect.anything());
   });
 
   it("fails with journal-not-found for a journal that does not exist", async () => {
@@ -796,6 +800,33 @@ describe("JournalsApiService notelet creation", () => {
     await expect(api.createNotelet("past", "2026-08-19", "Meeting")).rejects.toMatchObject({
       code: "outside-timeline",
     });
+  });
+
+  it("refuses before the flow when a period note exists outside the timeline", async () => {
+    const { api, index, harness, flows } = await buildApi({
+      past: fixedJournal(
+        "past",
+        { type: "week" },
+        {
+          notelets: { nt_meeting: meeting },
+          timeline: {
+            start: "2020-01-01" as AnchorString,
+            end: { kind: "date", date: "2020-12-31" as AnchorString },
+          },
+        },
+      ),
+    });
+    harness.host.putFile("Past/2026-08-17.md", "existing");
+    index.register({
+      journalName: "past",
+      anchor: "2026-08-17" as AnchorString,
+      path: "Past/2026-08-17.md" as VaultPath,
+    });
+
+    await expect(api.createNotelet("past", "2026-08-19", "Meeting")).rejects.toMatchObject({
+      code: "outside-timeline",
+    });
+    expect(flows).not.toHaveBeenCalledWith(CreateNoteletFlow, expect.anything(), expect.anything());
   });
 
   it("asks the type's prompts by default", async () => {

--- a/src/api/journals-api.ts
+++ b/src/api/journals-api.ts
@@ -17,6 +17,7 @@ import { JournalsRepository } from "@/journals/repository";
 import { TimelineService } from "@/journals/timeline";
 import { JournalsEventsToken } from "@/journals/tokens";
 import { isNotelet, periodEntryOf } from "@/journals/types";
+import type { NoteletEntry } from "@/journals/types";
 import { ShelvesService } from "@/shelves/service";
 
 import { normalizeSelector, toCalendarDate, toJournalInfo } from "./convert";
@@ -32,8 +33,10 @@ import type {
   JournalSelector,
   JournalsApi,
   JournalsApiEvents,
+  NoteletNote,
   OpenNoteOptions,
 } from "./public-api";
+import type { TFile } from "obsidian";
 
 const API_VERSION = 1;
 
@@ -122,10 +125,30 @@ export class JournalsApiService implements JournalsApi {
     return this.#noteAtAnchor(name, anchorOption.value);
   }
 
-  #noteAtAnchor(name: string, anchor: AnchorString): JournalNote | null {
+  #periodDates(name: string, anchor: AnchorString): { displayDate: string; endDate: string } | null {
     const display = this.#cycle.representativeOf(name, anchor);
     const end = this.#cycle.endOf(name, anchor);
     if (display.isNone() || end.isNone()) return null;
+    return { displayDate: display.value.toAnchor(), endDate: end.value.toAnchor() };
+  }
+
+  #noteletFrom(entry: NoteletEntry, file: TFile): NoteletNote | null {
+    const dates = this.#periodDates(entry.journalName, entry.anchor);
+    if (dates === null) return null;
+    return {
+      journal: entry.journalName,
+      type: entry.typeName,
+      date: entry.anchor,
+      ...dates,
+      path: entry.path,
+      file,
+      counter: entry.counter ?? null,
+    };
+  }
+
+  #noteAtAnchor(name: string, anchor: AnchorString): JournalNote | null {
+    const dates = this.#periodDates(name, anchor);
+    if (dates === null) return null;
 
     const entry = this.#index.entryByAnchor(name, anchor);
     const existingPath = entry.isSome() ? entry.value.path : null;
@@ -133,8 +156,7 @@ export class JournalsApiService implements JournalsApi {
     return {
       journal: name,
       date: anchor,
-      displayDate: display.value.toAnchor(),
-      endDate: end.value.toAnchor(),
+      ...dates,
       path: this.#pathOf(name, anchor, existingPath),
       file: existingPath === null ? null : this.#files.resolve(existingPath),
     };
@@ -189,20 +211,12 @@ export class JournalsApiService implements JournalsApi {
   // learns about a new note once Obsidian re-parses its frontmatter, so a lookup here
   // reports `file: null` for the note we just created.
   #existing(name: string, anchor: AnchorString, path: string): ExistingJournalNote {
-    const display = this.#cycle.representativeOf(name, anchor);
-    const end = this.#cycle.endOf(name, anchor);
+    const dates = this.#periodDates(name, anchor);
     const file = this.#files.resolve(path);
-    if (display.isNone() || end.isNone() || file === null) {
+    if (dates === null || file === null) {
       throw new ApiError("creation-failed", `The note for ${name} could not be read back`, name);
     }
-    return {
-      journal: name,
-      date: anchor,
-      displayDate: display.value.toAnchor(),
-      endDate: end.value.toAnchor(),
-      path,
-      file,
-    };
+    return { journal: name, date: anchor, ...dates, path, file };
   }
 
   // Between the existence check and the write, NoteCreationService may await a confirmation
@@ -302,6 +316,15 @@ export class JournalsApiService implements JournalsApi {
     // We were handed the file; re-resolving entry.path would add a null branch that
     // conflates "not a journal note" with a resolution hiccup.
     return { ...note, path: entry.value.path, file: file as ExistingJournalNote["file"] };
+  }
+
+  async noteletOf(file: { path: string }): Promise<NoteletNote | null> {
+    await this.#readyForNotes();
+    const entry = this.#index.entryByPath(file.path as VaultPath);
+    if (entry.isNone() || !isNotelet(entry.value)) return null;
+    // We were handed the file, so it stands in for a resolve that could only fail spuriously —
+    // the same reason journalOf reuses it.
+    return this.#noteletFrom(entry.value, file as NoteletNote["file"]);
   }
 
   on<K extends keyof JournalsApiEvents>(event: K, handler: JournalsApiEvents[K]): () => void {

--- a/src/api/journals-api.ts
+++ b/src/api/journals-api.ts
@@ -292,9 +292,15 @@ export class JournalsApiService implements JournalsApi {
   }
 
   // Its own wrapper rather than a widened #toApiError: mapping OutOfTimelineError there would
-  // change what ensureNote and openNote answer today. Both branches are unreachable in a single
-  // uninterrupted call — #resolveOne's "timeline" eligibility and the type-name guard above both
-  // refuse first — and stay as the point-of-write defense for a config edited mid-flight.
+  // change what ensureNote and openNote answer today. The two branches differ in reachability.
+  // NoteletTypeNotFoundError is reachable: createNotelet's own type-name guard (below) checks
+  // before every await, but FrontmatterService.writeMutator re-resolves the type from the live
+  // config after the prompt modal, so a type deleted while that modal is open lands here — tested
+  // by "fails with notelet-type-not-found when the type is deleted while the prompt modal is
+  // open". OutOfTimelineError stays unreachable today: its only producers are #resolveOne's
+  // "timeline" eligibility (refuses before this point) and note-path.ts's linkTargetForDate, which
+  // is not on the creation path. The arm is kept anyway so relaxing #eligibleForNotelet later
+  // cannot silently downgrade it to creation-failed.
   #toNoteletApiError(cause: unknown, journal: string): ApiError {
     if (cause instanceof OutOfTimelineError) {
       return new ApiError("outside-timeline", cause.message, journal);

--- a/src/api/journals-api.ts
+++ b/src/api/journals-api.ts
@@ -11,6 +11,7 @@ import { EnsureJournalEntryFlow, JournalDateResolver, OpenJournalEntryFlow } fro
 import type { ApplicableJournal } from "@/journals/flows";
 import { FrontmatterService } from "@/journals/frontmatter";
 import { JournalsIndex } from "@/journals/journals-index";
+import { buildNoteletListing } from "@/journals/notelets/listing";
 import { NotePathService } from "@/journals/notes/note-path";
 import { PromptsUnansweredError } from "@/journals/prompts/errors";
 import { JournalsRepository } from "@/journals/repository";
@@ -325,6 +326,39 @@ export class JournalsApiService implements JournalsApi {
     // We were handed the file, so it stands in for a resolve that could only fail spuriously —
     // the same reason journalOf reuses it.
     return this.#noteletFrom(entry.value, file as NoteletNote["file"]);
+  }
+
+  async noteletsFor(
+    selector: JournalSelector,
+    date: DateInput,
+    options?: { readonly type?: string },
+  ): Promise<readonly NoteletNote[]> {
+    await this.#readyForNotes();
+    const calendarDate = this.#date(date);
+    // A journal that cannot place this date is omitted rather than failing the fan-out, matching
+    // notesFor.
+    return this.#select(selector).flatMap((name) => {
+      const anchor = this.#cycle.anchorOf(name, calendarDate);
+      if (anchor.isNone()) return [];
+      const listing = buildNoteletListing(
+        { journals: this.#journals, index: this.#index, cycle: this.#cycle },
+        { kind: "period", journalName: name, anchor: anchor.value },
+      );
+      return (
+        listing.periods
+          .flatMap((period) => period.types)
+          // Filtered by stored name, not by resolved id: a type deleted in "keep" mode leaves its
+          // notes carrying a name the config no longer holds, and the name is what a caller has.
+          .filter((group) => options?.type === undefined || group.typeName === options.type)
+          .flatMap((group) => group.notelets)
+          .flatMap((entry) => {
+            const file = this.#files.resolve(entry.path);
+            if (file === null) return [];
+            const note = this.#noteletFrom(entry, file);
+            return note === null ? [] : [note];
+          })
+      );
+    });
   }
 
   on<K extends keyof JournalsApiEvents>(event: K, handler: JournalsApiEvents[K]): () => void {

--- a/src/api/journals-api.ts
+++ b/src/api/journals-api.ts
@@ -286,13 +286,9 @@ export class JournalsApiService implements JournalsApi {
   }
 
   // Its own wrapper rather than a widened #toApiError: mapping OutOfTimelineError there would
-  // change what ensureNote and openNote answer today, which is exactly the behavior change this
-  // slice may not make.
-  // The OutOfTimelineError branch is currently unreachable through createNotelet: #resolveOne's
-  // "timeline" eligibility already excludes an out-of-range anchor before the flow is invoked, so
-  // NoteletCreationService's own timeline check can never fire for a call that reaches this far.
-  // It stays for the same reason CreateNoteletFlow's error union carries OutOfTimelineError at
-  // all — a defensive check at the point of write, not one this class can currently observe.
+  // change what ensureNote and openNote answer today. Both branches are unreachable in a single
+  // uninterrupted call — #resolveOne's "timeline" eligibility and the type-name guard above both
+  // refuse first — and stay as the point-of-write defense for a config edited mid-flight.
   #toNoteletApiError(cause: unknown, journal: string): ApiError {
     if (cause instanceof OutOfTimelineError) {
       return new ApiError("outside-timeline", cause.message, journal);

--- a/src/api/journals-api.ts
+++ b/src/api/journals-api.ts
@@ -6,11 +6,15 @@ import { Flows, UserAborted } from "@/infrastructure/flows";
 import { WorkspaceOpenError } from "@/infrastructure/host";
 import type { VaultPath } from "@/infrastructure/host";
 import { NoteFileService } from "@/infrastructure/host/internal/note-file-service";
+import { Option } from "@/infrastructure/result";
 import { CycleService } from "@/journals/cycle";
+import { NoteletTypeNotFoundError, OutOfTimelineError } from "@/journals/errors";
 import { EnsureJournalEntryFlow, JournalDateResolver, OpenJournalEntryFlow } from "@/journals/flows";
 import type { ApplicableJournal } from "@/journals/flows";
 import { FrontmatterService } from "@/journals/frontmatter";
 import { JournalsIndex } from "@/journals/journals-index";
+import { noteletTypeByName } from "@/journals/notelets/config";
+import { CreateNoteletFlow } from "@/journals/notelets/flows/create-notelet.flow";
 import { buildNoteletListing } from "@/journals/notelets/listing";
 import { NotePathService } from "@/journals/notes/note-path";
 import { PromptsUnansweredError } from "@/journals/prompts/errors";
@@ -25,6 +29,7 @@ import { normalizeSelector, toCalendarDate, toJournalInfo } from "./convert";
 import { ApiError } from "./errors";
 
 import type {
+  CreateNoteletOptions,
   DateInput,
   EnsureNoteOptions,
   EnsureResult,
@@ -177,7 +182,22 @@ export class JournalsApiService implements JournalsApi {
     });
   }
 
-  async #resolveOne(selector: JournalSelector, date: DateInput): Promise<ApplicableJournal> {
+  // Notelet creation always requires the timeline, so a journal that could only fail must not
+  // reach the picker. The period rule ("a note exists OR in timeline") exists so `ensure` cannot
+  // refuse a note the API just reported; there is no equivalent here.
+  #eligibleForNotelet(names: readonly string[], date: CalendarDate): ApplicableJournal[] {
+    return names.flatMap((name) => {
+      const resolved = this.#cycle.anchorOf(name, date);
+      if (resolved.isNone()) return [];
+      return this.#timeline.contains(name, resolved.value) ? [{ name, anchor: resolved.value }] : [];
+    });
+  }
+
+  async #resolveOne(
+    selector: JournalSelector,
+    date: DateInput,
+    eligibility: "existing-or-timeline" | "timeline" = "existing-or-timeline",
+  ): Promise<ApplicableJournal> {
     const calendarDate = this.#date(date);
     const names = this.#select(selector);
     if (names.length === 0) {
@@ -188,7 +208,8 @@ export class JournalsApiService implements JournalsApi {
       throw new ApiError("no-matching-journal", "No journal matches that selector");
     }
 
-    const eligible = this.#eligible(names, calendarDate);
+    const eligible =
+      eligibility === "timeline" ? this.#eligibleForNotelet(names, calendarDate) : this.#eligible(names, calendarDate);
     if (eligible.length === 0) {
       // "No period for that date" means the journal is misconfigured for this input;
       // "a period, out of range" is a different answer callers act on differently.
@@ -220,6 +241,23 @@ export class JournalsApiService implements JournalsApi {
     return { journal: name, date: anchor, ...dates, path, file };
   }
 
+  // Built from the write's own result, never re-read through the index — a notelet the index has
+  // not re-parsed yet reports as missing.
+  #createdNotelet(
+    name: string,
+    anchor: AnchorString,
+    typeName: string,
+    path: string,
+    counter: number | null,
+  ): NoteletNote {
+    const dates = this.#periodDates(name, anchor);
+    const file = this.#files.resolve(path);
+    if (dates === null || file === null) {
+      throw new ApiError("creation-failed", `The notelet for ${name} could not be read back`, name);
+    }
+    return { journal: name, type: typeName, date: anchor, ...dates, path, file, counter };
+  }
+
   // Between the existence check and the write, NoteCreationService may await a confirmation
   // modal — seconds wide. Two callers ensuring the same period would otherwise get two
   // prompts and one NoteAlreadyExistsError.
@@ -236,7 +274,7 @@ export class JournalsApiService implements JournalsApi {
     return options?.confirm === undefined ? undefined : !options.confirm;
   }
 
-  #unattended(options: EnsureNoteOptions | undefined): boolean | undefined {
+  #unattended(options: { readonly prompt?: boolean } | undefined): boolean | undefined {
     return options?.prompt === false;
   }
 
@@ -245,6 +283,24 @@ export class JournalsApiService implements JournalsApi {
     if (cause instanceof WorkspaceOpenError) return new ApiError("open-failed", cause.message, journal);
     if (cause instanceof PromptsUnansweredError) return new ApiError("prompts-required", cause.message, journal);
     return new ApiError("creation-failed", cause instanceof Error ? cause.message : String(cause), journal);
+  }
+
+  // Its own wrapper rather than a widened #toApiError: mapping OutOfTimelineError there would
+  // change what ensureNote and openNote answer today, which is exactly the behavior change this
+  // slice may not make.
+  // The OutOfTimelineError branch is currently unreachable through createNotelet: #resolveOne's
+  // "timeline" eligibility already excludes an out-of-range anchor before the flow is invoked, so
+  // NoteletCreationService's own timeline check can never fire for a call that reaches this far.
+  // It stays for the same reason CreateNoteletFlow's error union carries OutOfTimelineError at
+  // all — a defensive check at the point of write, not one this class can currently observe.
+  #toNoteletApiError(cause: unknown, journal: string): ApiError {
+    if (cause instanceof OutOfTimelineError) {
+      return new ApiError("outside-timeline", cause.message, journal);
+    }
+    if (cause instanceof NoteletTypeNotFoundError) {
+      return new ApiError("notelet-type-not-found", cause.message, journal);
+    }
+    return this.#toApiError(cause, journal);
   }
 
   async listJournals(selector?: JournalSelector): Promise<readonly JournalInfo[]> {
@@ -306,6 +362,37 @@ export class JournalsApiService implements JournalsApi {
       if (result.isErr()) throw this.#toApiError(result.error, name);
       return { note: this.#existing(name, anchor, result.value.path), created: result.value.created };
     });
+  }
+
+  async createNotelet(
+    selector: JournalSelector,
+    date: DateInput,
+    type: string,
+    options?: CreateNoteletOptions,
+  ): Promise<NoteletNote> {
+    await this.#readyForNotes();
+    const { name, anchor } = await this.#resolveOne(selector, date, "timeline");
+    const config = this.#journals.get(name);
+    const found = config.isNone() ? Option.none() : noteletTypeByName(config.value, type);
+    if (found.isNone()) {
+      throw new ApiError("notelet-type-not-found", `Journal ${name} has no notelet type named ${type}`, name);
+    }
+    const [typeId, noteletType] = found.value;
+    // No #dedupe: notelet creation is never idempotent, so two concurrent calls must produce two
+    // notelets rather than collapsing onto one.
+    const result = await this.#flows.invoke(
+      CreateNoteletFlow,
+      {
+        journalName: name,
+        typeId,
+        anchor,
+        openMode: options?.openMode ?? null,
+        unattended: this.#unattended(options),
+      },
+      { notify: false, context: { via: "api" } },
+    );
+    if (result.isErr()) throw this.#toNoteletApiError(result.error, name);
+    return this.#createdNotelet(name, anchor, noteletType.name, result.value.path, result.value.counter ?? null);
   }
 
   async journalOf(file: { path: string }): Promise<ExistingJournalNote | null> {

--- a/src/api/journals-api.ts
+++ b/src/api/journals-api.ts
@@ -3,7 +3,7 @@ import { match } from "ts-pattern";
 import type { CalendarDate, AnchorString } from "@/calendar";
 import { inject } from "@/infrastructure/di";
 import { Flows, UserAborted } from "@/infrastructure/flows";
-import { WorkspaceOpenError } from "@/infrastructure/host";
+import { WorkspaceOpenError, WorkspaceService } from "@/infrastructure/host";
 import type { VaultPath } from "@/infrastructure/host";
 import { NoteFileService } from "@/infrastructure/host/internal/note-file-service";
 import { Option } from "@/infrastructure/result";
@@ -40,6 +40,7 @@ import type {
   JournalsApi,
   JournalsApiEvents,
   NoteletNote,
+  OpenNoteletOptions,
   OpenNoteOptions,
 } from "./public-api";
 import type { TFile } from "obsidian";
@@ -64,6 +65,7 @@ export class JournalsApiService implements JournalsApi {
   readonly #files = inject(NoteFileService);
   readonly #resolver = inject(JournalDateResolver);
   readonly #flows = inject(Flows);
+  readonly #workspace = inject(WorkspaceService);
   readonly #inFlight = new Map<string, Promise<EnsureResult>>();
   readonly #unloaded: Promise<never>;
   #rejectUnloaded: ((reason: unknown) => void) | undefined;
@@ -80,15 +82,19 @@ export class JournalsApiService implements JournalsApi {
     void this.#unloaded.catch(() => null);
   }
 
+  #assertLoaded(): void {
+    if (this.#disposed) throw new ApiError("plugin-unloaded", "Journals has been unloaded");
+  }
+
   // listJournals/journalInfo read the settings-backed repository, which is populated before
   // `api` is even assigned; only the index reads wait, because the index is filled by a
   // whole-vault walk that takes seconds and answers "no note" for real notes until it lands.
   async #readyForNotes(): Promise<void> {
-    if (this.#disposed) throw new ApiError("plugin-unloaded", "Journals has been unloaded");
+    this.#assertLoaded();
     // whenReady never settles if readiness never arrives, so a consumer awaiting a call
     // when the user disables Journals would hang forever inside their own plugin.
     await Promise.race([this.#index.whenReady(), this.#unloaded]);
-    if (this.#disposed) throw new ApiError("plugin-unloaded", "Journals has been unloaded");
+    this.#assertLoaded();
   }
 
   #date(input: DateInput): CalendarDate {
@@ -389,6 +395,14 @@ export class JournalsApiService implements JournalsApi {
     );
     if (result.isErr()) throw this.#toNoteletApiError(result.error, name);
     return this.#createdNotelet(name, anchor, noteletType.name, result.value.path, result.value.counter ?? null);
+  }
+
+  async openNotelet(notelet: NoteletNote, options?: OpenNoteletOptions): Promise<void> {
+    // The caller already holds the notelet, so nothing here reads the index — waiting on the
+    // whole-vault walk would stall an open for no answer it needs.
+    this.#assertLoaded();
+    const result = await this.#workspace.openNote(notelet.path as VaultPath, options?.openMode ?? "active");
+    if (result.isErr()) throw new ApiError("open-failed", result.error.message, notelet.journal);
   }
 
   async journalOf(file: { path: string }): Promise<ExistingJournalNote | null> {

--- a/src/api/journals-api.ts
+++ b/src/api/journals-api.ts
@@ -498,6 +498,28 @@ export class JournalsApiService implements JournalsApi {
           });
         }),
       )
+      .with("noteletAdded", () =>
+        this.#index.events.on("entryChanged", ({ entry, kind }) => {
+          if (kind !== "added" || !isNotelet(entry)) return;
+          (handler as JournalsApiEvents["noteletAdded"])({
+            journal: entry.journalName,
+            date: entry.anchor,
+            type: entry.typeName,
+            path: entry.path,
+          });
+        }),
+      )
+      .with("noteletRemoved", () =>
+        this.#index.events.on("entryChanged", ({ entry, kind }) => {
+          if (kind !== "removed" || !isNotelet(entry)) return;
+          (handler as JournalsApiEvents["noteletRemoved"])({
+            journal: entry.journalName,
+            date: entry.anchor,
+            type: entry.typeName,
+            path: entry.path,
+          });
+        }),
+      )
       .exhaustive();
   }
 

--- a/src/api/public-api.ts
+++ b/src/api/public-api.ts
@@ -109,6 +109,10 @@ export interface CreateNoteletOptions {
   readonly openMode?: "active" | "tab" | "split" | "window";
 }
 
+export interface OpenNoteletOptions {
+  readonly openMode?: "active" | "tab" | "split" | "window";
+}
+
 /** Open on purpose: new codes are an additive change, so always handle the default case. */
 export type JournalsApiErrorCode =
   | "journal-not-found"
@@ -157,6 +161,7 @@ export interface JournalsApi {
     type: string,
     options?: CreateNoteletOptions,
   ): Promise<NoteletNote>;
+  openNotelet(notelet: NoteletNote, options?: OpenNoteletOptions): Promise<void>;
 
   ensureNote(selector: JournalSelector, date: DateInput, options?: EnsureNoteOptions): Promise<EnsureResult>;
   openNote(selector: JournalSelector, date: DateInput, options?: OpenNoteOptions): Promise<EnsureResult>;

--- a/src/api/public-api.ts
+++ b/src/api/public-api.ts
@@ -102,6 +102,13 @@ export interface EnsureResult {
   readonly created: boolean;
 }
 
+export interface CreateNoteletOptions {
+  /** Ask the type's creation prompts. Defaults to true. */
+  readonly prompt?: boolean;
+  /** Omit to create without opening; pass a mode to create and show. */
+  readonly openMode?: "active" | "tab" | "split" | "window";
+}
+
 /** Open on purpose: new codes are an additive change, so always handle the default case. */
 export type JournalsApiErrorCode =
   | "journal-not-found"
@@ -109,6 +116,7 @@ export type JournalsApiErrorCode =
   | "invalid-date"
   | "unmappable-date"
   | "outside-timeline"
+  | "notelet-type-not-found"
   | "creation-failed"
   | "prompts-required"
   | "open-failed"
@@ -143,6 +151,12 @@ export interface JournalsApi {
     date: DateInput,
     options?: { readonly type?: string },
   ): Promise<readonly NoteletNote[]>;
+  createNotelet(
+    selector: JournalSelector,
+    date: DateInput,
+    type: string,
+    options?: CreateNoteletOptions,
+  ): Promise<NoteletNote>;
 
   ensureNote(selector: JournalSelector, date: DateInput, options?: EnsureNoteOptions): Promise<EnsureResult>;
   openNote(selector: JournalSelector, date: DateInput, options?: OpenNoteOptions): Promise<EnsureResult>;

--- a/src/api/public-api.ts
+++ b/src/api/public-api.ts
@@ -139,6 +139,8 @@ export interface JournalsApiEvents {
   journalDeleted: (event: { journal: string }) => void;
   noteAdded: (event: { journal: string; date: string; path: string }) => void;
   noteRemoved: (event: { journal: string; date: string; path: string }) => void;
+  noteletAdded: (event: { journal: string; date: string; type: string; path: string }) => void;
+  noteletRemoved: (event: { journal: string; date: string; type: string; path: string }) => void;
 }
 
 export interface JournalsApi {

--- a/src/api/public-api.ts
+++ b/src/api/public-api.ts
@@ -138,6 +138,11 @@ export interface JournalsApi {
   notesFor(selector: JournalSelector, date: DateInput): Promise<readonly JournalNote[]>;
   journalOf(file: TFile): Promise<ExistingJournalNote | null>;
   noteletOf(file: TFile): Promise<NoteletNote | null>;
+  noteletsFor(
+    selector: JournalSelector,
+    date: DateInput,
+    options?: { readonly type?: string },
+  ): Promise<readonly NoteletNote[]>;
 
   ensureNote(selector: JournalSelector, date: DateInput, options?: EnsureNoteOptions): Promise<EnsureResult>;
   openNote(selector: JournalSelector, date: DateInput, options?: OpenNoteOptions): Promise<EnsureResult>;

--- a/src/api/public-api.ts
+++ b/src/api/public-api.ts
@@ -35,6 +35,8 @@ export interface JournalInfo {
   readonly name: string;
   readonly shelf: string | null;
   readonly write: JournalWrite;
+  /** The journal's notelet type names, sorted. Empty when the journal defines none. */
+  readonly notelets: readonly string[];
 }
 
 /** The journal's note for a period — on disk, or where it would go. */

--- a/src/api/public-api.ts
+++ b/src/api/public-api.ts
@@ -64,6 +64,22 @@ export interface ExistingJournalNote extends JournalNote {
   readonly file: TFile;
 }
 
+/** A notelet attached to a journal period. Always exists on disk. */
+export interface NoteletNote {
+  readonly journal: string;
+  /** The type's name, as stored in the note's frontmatter. */
+  readonly type: string;
+  /** "YYYY-MM-DD" — the period's first day. Correlates with JournalNote.date. */
+  readonly date: string;
+  /** The period's, derived from the anchor — a notelet stores neither this nor endDate. */
+  readonly displayDate: string;
+  readonly endDate: string;
+  readonly path: string;
+  readonly file: TFile;
+  /** The assigned counter, when the type has one. Orders siblings within a period. */
+  readonly counter: number | null;
+}
+
 export interface EnsureNoteOptions {
   /** Show the journal's creation-confirmation prompt. Defaults to the journal's own setting. */
   readonly confirm?: boolean;
@@ -121,6 +137,7 @@ export interface JournalsApi {
 
   notesFor(selector: JournalSelector, date: DateInput): Promise<readonly JournalNote[]>;
   journalOf(file: TFile): Promise<ExistingJournalNote | null>;
+  noteletOf(file: TFile): Promise<NoteletNote | null>;
 
   ensureNote(selector: JournalSelector, date: DateInput, options?: EnsureNoteOptions): Promise<EnsureResult>;
   openNote(selector: JournalSelector, date: DateInput, options?: OpenNoteOptions): Promise<EnsureResult>;

--- a/src/journals/notelets/flows/create-notelet.flow.test.ts
+++ b/src/journals/notelets/flows/create-notelet.flow.test.ts
@@ -62,6 +62,49 @@ describe("CreateNoteletFlow", () => {
     expect(openSpy).toHaveBeenCalledWith("Standup 1.md", "split");
   });
 
+  it("creates without opening when openMode is null", async () => {
+    const harness = await testContainer({
+      modules: [journalsCoreModule],
+      data: seed,
+      initialize: [VaultSubscriptionService],
+    });
+    const open = vi.spyOn(harness.resolve(WorkspaceService), "openNote");
+
+    const result = await harness
+      .resolve(Flows)
+      .invoke(CreateNoteletFlow, { journalName: "Work", typeId: TYPE, anchor: ANCHOR, openMode: null });
+
+    expect(result.isOk()).toBe(true);
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("opens in the active pane when openMode is omitted", async () => {
+    const harness = await testContainer({
+      modules: [journalsCoreModule],
+      data: seed,
+      initialize: [VaultSubscriptionService],
+    });
+    const open = vi.spyOn(harness.resolve(WorkspaceService), "openNote");
+
+    await harness.resolve(Flows).invoke(CreateNoteletFlow, { journalName: "Work", typeId: TYPE, anchor: ANCHOR });
+
+    expect(open).toHaveBeenCalledWith(expect.any(String), "active");
+  });
+
+  it("passes the assigned counter back to its caller", async () => {
+    const harness = await testContainer({
+      modules: [journalsCoreModule],
+      data: seed,
+      initialize: [VaultSubscriptionService],
+    });
+
+    const result = await harness
+      .resolve(Flows)
+      .invoke(CreateNoteletFlow, { journalName: "Work", typeId: TYPE, anchor: ANCHOR, openMode: null });
+
+    expect(result.isOk() && result.value).toMatchObject({ counter: 1 });
+  });
+
   it("opens nothing when creation is refused", async () => {
     const harness = await testContainer({
       modules: [journalsCoreModule],

--- a/src/journals/notelets/flows/create-notelet.flow.test.ts
+++ b/src/journals/notelets/flows/create-notelet.flow.test.ts
@@ -76,6 +76,7 @@ describe("CreateNoteletFlow", () => {
 
     expect(result.isOk()).toBe(true);
     expect(open).not.toHaveBeenCalled();
+    expect(harness.templater.cursorJumps).toEqual([]);
   });
 
   it("opens in the active pane when openMode is omitted", async () => {

--- a/src/journals/notelets/flows/create-notelet.flow.ts
+++ b/src/journals/notelets/flows/create-notelet.flow.ts
@@ -15,29 +15,35 @@ export interface CreateNoteletParameters {
   journalName: string;
   typeId: TypeId;
   anchor: AnchorString;
-  openMode?: OpenMode;
+  /** Omitted opens in the active pane; `null` creates without opening at all. */
+  openMode?: OpenMode | null;
   unattended?: boolean;
 }
 
 export class CreateNoteletFlow implements Flow<
   CreateNoteletParameters,
-  { path: VaultPath },
+  { path: VaultPath; counter?: number },
   NoteletCreationError | WorkspaceOpenError
 > {
   readonly #creation = inject(NoteletCreationService);
   readonly #workspace = inject(WorkspaceService);
   readonly #templater = inject(TemplaterService);
 
-  execute(p: CreateNoteletParameters): AsyncResult<{ path: VaultPath }, NoteletCreationError | WorkspaceOpenError> {
+  execute(
+    p: CreateNoteletParameters,
+  ): AsyncResult<{ path: VaultPath; counter?: number }, NoteletCreationError | WorkspaceOpenError> {
     return attempt.in(this, async function* (this: CreateNoteletFlow) {
-      const { path } = yield* this.#creation.createNotelet(p.journalName, p.typeId, p.anchor, {
+      const { path, counter } = yield* this.#creation.createNotelet(p.journalName, p.typeId, p.anchor, {
         unattended: p.unattended,
       });
-      yield* this.#workspace.openNote(path, p.openMode ?? "active");
-      // A notelet is always newly created, so the cursor jump is unconditional where the period
-      // flow has to ask whether it created anything.
-      yield* this.#templater.cursorJump(path);
-      return { path };
+      if (p.openMode !== null) {
+        yield* this.#workspace.openNote(path, p.openMode ?? "active");
+        // A notelet is always newly created, so the cursor jump is unconditional where the period
+        // flow has to ask whether it created anything. It needs an open editor, so it moves with
+        // the open.
+        yield* this.#templater.cursorJump(path);
+      }
+      return { path, ...(counter !== undefined && { counter }) };
     });
   }
 }

--- a/src/journals/notelets/notelet-creation.test.ts
+++ b/src/journals/notelets/notelet-creation.test.ts
@@ -163,6 +163,24 @@ describe("NoteletCreationService", () => {
     expect(harness.host.files.get(created.value.path)?.frontmatter).not.toHaveProperty("journal-notelet-index");
   });
 
+  it("reports the counter it assigned", async () => {
+    const harness = await boot(workWith());
+
+    const created = await harness.resolve(NoteletCreationService).createNotelet("Work", TYPE, ANCHOR);
+
+    expectOk(created);
+    expect(created.value).toMatchObject({ counter: 1 });
+  });
+
+  it("reports no counter when the type has none", async () => {
+    const harness = await boot(workWith({ counter: { enabled: false, frontmatterKey: "journal-notelet-index" } }));
+
+    const created = await harness.resolve(NoteletCreationService).createNotelet("Work", TYPE, ANCHOR);
+
+    expectOk(created);
+    expect(created.value.counter).toBeUndefined();
+  });
+
   it("refuses unattended creation when a question reaches the note name", async () => {
     const harness = await boot(
       workWith({

--- a/src/journals/notelets/notelet-creation.ts
+++ b/src/journals/notelets/notelet-creation.ts
@@ -75,7 +75,7 @@ export class NoteletCreationService {
     typeId: TypeId,
     anchor: AnchorString,
     options?: CreateNoteletOptions,
-  ): AsyncResult<{ path: VaultPath }, NoteletCreationError> {
+  ): AsyncResult<{ path: VaultPath; counter?: number }, NoteletCreationError> {
     return attempt.in(this, async function* (this: NoteletCreationService) {
       const config = yield* this.#journals.require(journalName);
       const type = config.notelets[typeId];
@@ -138,7 +138,7 @@ export class NoteletCreationService {
         yield* this.#notes.write(path, content).tapErr(() => this.#guard.release(path));
       }
       yield* this.#notes.updateFrontmatter(path, mutator).tapErr(() => this.#guard.release(path));
-      return { path };
+      return { path, ...(counter !== undefined && { counter }) };
     });
   }
 


### PR DESCRIPTION
Slice 8 of the notelets feature: the public API other plugins call to discover, read, create and open notelets.

## The surface

- `JournalInfo.notelets: readonly string[]` — the journal's notelet type names, sorted.
- `NoteletNote` — `journal`, `type`, `date`, `displayDate`, `endDate`, `path`, `file`, `counter`.
- `noteletOf(file)`, `noteletsFor(selector, date, options?)`, `createNotelet(selector, date, type, options?)`, `openNotelet(notelet, options?)`.
- The `notelet-type-not-found` error code, and the `noteletAdded` / `noteletRemoved` events.
- `docs/plugin-api.md` documents all of it; `scripts/check-api-package.mjs`'s compiled consumer now names every new type, so `check:api` proves the published declaration is usable from TypeScript.

`apiVersion` stays **1** — every addition is a new method, a new readonly field on a returned object, a new event name or a new error code, all additive by the doc's own table.

## Additive in behaviour, not only in shape

`journalOf` is untouched and still returns `null` for a notelet, `JournalNote` gains no field, and `noteAdded` / `noteRemoved` stay period-note only. Answering "what journal thing is this file?" is deliberately two calls, so a consumer written before notelets existed keeps receiving exactly what it receives today. `#toApiError` was deliberately **not** widened for the same reason — mapping `OutOfTimelineError` there would change what `ensureNote` and `openNote` answer, so notelet creation gets its own `#toNoteletApiError` wrapper.

## Decisions worth reviewing

- **`createNotelet` does not open unless given `openMode`.** The spec never said what an omitted `openMode` means; opening is opt-in, matching `ensureNote`/`openNote` where it is always explicit. That drove the one production change outside `src/api/`: `CreateNoteletFlow.openMode` is now tri-state — `undefined` opens in the active pane (what all four existing callers rely on), `null` creates without opening. Same `undefined`/`null` convention `JournalSelector.shelf` already uses.
- **`noteletsFor`'s type filter matches the *stored* type name, not a resolved id**, so a type deleted in "keep" mode stays reachable by the name its notes carry. An unknown name returns `[]` rather than throwing.
- **Creation eligibility is timeline containment only**, not `ensureNote`'s looser "a note exists OR the date is in timeline" — a journal that could only fail must never reach the journal picker.
- **`openNotelet` reuses a pane only in the default `"active"` mode**; an explicit tab/split/window is a request for a new pane. Documented both ways.
- **No package version bump.** `packages/api/package.json` stays at `1.0.0`. Per `docs/releasing.md`'s "API package release" section the bump happens at release time, from the maintainer's machine, immediately before `npm publish` — an npm version cannot be reused once published, so it is not worth spending until a green tag build has proven the surface ships.
- No `CHANGELOG.md` entry — that is written once, on the `feat/notelets` → `main` PR, where it should also note that **adding methods breaks a test double written as `implements JournalsApi`**.

## Known and deliberately deferred

Two **concurrent** `createNotelet` calls on one anchor produce one notelet and one `creation-failed`: `availablePathFor` resolves both to the same free path and the second `vault.create` rejects. This is pre-existing in `NoteletCreationService` and not API-specific — on a prompt-less type a double-click on the create button races identically in the shipped UI today. It is loud and lossless, and the fix belongs in `NoteletPathService`, not here.

Still no e2e for any notelet surface, now across all eight slices. Slice 9 owns it.

## Test plan

- [x] `npm test` — 454 test files / 5272 tests passing (from 5229 on `feat/notelets`)
- [x] `npm run check:types` — clean
- [x] `npm run check:lint` — 0 errors, 12 pre-existing warnings in untouched files (unchanged)
- [x] `npm run check:api` — passes; verified live by breaking the generated `index.d.ts` and confirming the consumer check fails, then restoring via `npm run build:api`
- [x] `npm run check:i18n` — clean (no keys added; API error text is untranslated developer text)
- [x] `npm run build` — clean

Every test on this branch was verified by mutation — break the line it claims to cover, watch it go red. That found and closed nine tests that could not fail, including four event guards where a broken `kind` check would have fired on every note rename.
