### PR TITLE
chore(deps): update vitest monorepo to v5

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -498,6 +498,15 @@ export default [
     },
   },
   {
+    // Benchmarks are `test()` bodies that register `bench()` registrations and never
+    // assert, and `bench.compare()` takes registrations rather than a title string.
+    files: ["**/*.bench.ts"],
+    rules: {
+      "vitest/expect-expect": "off",
+      "vitest/valid-title": "off",
+    },
+  },
+  {
     files: ["src/**/*.ts"],
     ignores: ["**/*.test.ts", "**/*.bench.ts", "src/i18n/paraglide/**"],
     rules: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@typescript-eslint/eslint-plugin": "^8.67.0",
         "@typescript-eslint/parser": "^8.67.0",
         "@vitejs/plugin-vue": "^6.0.8",
-        "@vitest/coverage-v8": "^4.1.10",
+        "@vitest/coverage-v8": "^5.0.0",
         "@vitest/eslint-plugin": "^1.6.27",
         "@vue/tsconfig": "^0.9.1",
         "@wdio/cli": "^9.30.1",
@@ -67,7 +67,7 @@
         "typescript-eslint": "^8.67.0",
         "vite": "^8.2.1",
         "vite-plugin-static-copy": "^4.1.1",
-        "vitest": "^4.1.10",
+        "vitest": "^5.0.0",
         "vue-tsc": "^3.3.9",
         "wdio-obsidian-reporter": "^3.1.3",
         "wdio-obsidian-service": "^3.1.3"
@@ -2819,13 +2819,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@standard-schema/spec": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@supercharge/promise-pool": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@supercharge/promise-pool/-/promise-pool-3.3.0.tgz",
@@ -3840,29 +3833,27 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.11.tgz",
-      "integrity": "sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-5.0.0.tgz",
+      "integrity": "sha512-toMg6PZGCIa/lQNCDoASrfb1ly4hsUKXFtFYC9kD4t78o5Y6LyNJU7AENt8eHPr3quYdxaxK7hj2mnbFfUk9NA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.11",
-        "ast-v8-to-istanbul": "^1.0.0",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.2",
-        "obug": "^2.1.1",
-        "std-env": "^4.0.0-rc.1",
-        "tinyrainbow": "^3.1.0"
+        "@vitest/istanbul-lib-coverage": "^1.0.0",
+        "@vitest/istanbul-lib-report": "^1.0.0",
+        "ast-v8-to-istanbul": "^1.0.5",
+        "magicast": "^0.5.4",
+        "obug": "^2.1.4",
+        "std-env": "^4.2.0",
+        "tinyrainbow": "^3.1.1"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.11",
-        "vitest": "4.1.11"
+        "@vitest/browser": "5.0.0",
+        "vitest": "5.0.0"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -3901,34 +3892,40 @@
         }
       }
     },
-    "node_modules/@vitest/expect": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
-      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+    "node_modules/@vitest/istanbul-lib-coverage": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vitest/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.1.tgz",
+      "integrity": "sha512-k3DJZ8LhMBK9NS4SclF1ASD3OgXEWDorbIcPTRDK0/Zae6fRvu+fJRxtFdLfHsa9Y24beCdPnoNZ4LviTNstfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@vitest/istanbul-lib-report": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vitest/istanbul-lib-report/-/istanbul-lib-report-1.0.1.tgz",
+      "integrity": "sha512-1EOLRfsTMnyAr3+kEAsP4o9dhaDlGPpD7H5iLBBeq//YpNB1VIahkPhB+eRp9N2Dkfw8oySROjE3yf9XDeaIkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.11",
-        "@vitest/utils": "4.1.11",
-        "chai": "^6.2.2",
-        "tinyrainbow": "^3.1.0"
+        "@vitest/istanbul-lib-coverage": "1.0.1"
       },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
-      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-5.0.0.tgz",
+      "integrity": "sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.11",
+        "@jridgewell/trace-mapping": "0.3.31",
+        "@vitest/spy": "5.0.0",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
+        "magic-string": "^1.2.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -3956,6 +3953,16 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/@vitest/mocker/node_modules/magic-string": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/@vitest/pretty-format": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
@@ -3968,27 +3975,6 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
-    },
-    "node_modules/@vitest/runner": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
-      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "4.1.11",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/runner/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@vitest/snapshot": {
       "version": "2.1.9",
@@ -4029,9 +4015,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
-      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-5.0.0.tgz",
+      "integrity": "sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -10184,13 +10170,6 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/html-escaper": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/htmlfy": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/htmlfy/-/htmlfy-0.8.1.tgz",
@@ -11124,45 +11103,6 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/istanbul-lib-coverage": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
-      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/istanbul-lib-report": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
-      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "istanbul-lib-coverage": "^3.0.0",
-        "make-dir": "^4.0.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-reports": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
-      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "html-escaper": "^2.0.0",
-        "istanbul-lib-report": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
@@ -12597,22 +12537,6 @@
       },
       "engines": {
         "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
-      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -15782,16 +15706,19 @@
       }
     },
     "node_modules/tinybench": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
-      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-6.1.4.tgz",
+      "integrity": "sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/tinyexec": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.1.tgz",
-      "integrity": "sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16489,38 +16416,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
-      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-5.0.0.tgz",
+      "integrity": "sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.11",
-        "@vitest/mocker": "4.1.11",
-        "@vitest/pretty-format": "4.1.11",
-        "@vitest/runner": "4.1.11",
-        "@vitest/snapshot": "4.1.11",
-        "@vitest/spy": "4.1.11",
-        "@vitest/utils": "4.1.11",
-        "es-module-lexer": "^2.0.0",
-        "expect-type": "^1.3.0",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^4.0.0-rc.1",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/mocker": "5.0.0",
+        "chai": "^6.2.2",
+        "es-module-lexer": "^2.3.2",
+        "expect-type": "^1.4.0",
+        "magic-string": "^1.2.3",
+        "obug": "^2.1.4",
+        "picomatch": "^4.0.7",
+        "std-env": "^4.2.0",
+        "tinybench": "6.1.4",
+        "tinyexec": "1.3.0",
+        "tinyglobby": "^0.2.17",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+        "node": "^22.12.0 || ^24.0.0 || >=26.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -16528,16 +16448,16 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.11",
-        "@vitest/browser-preview": "4.1.11",
-        "@vitest/browser-webdriverio": "4.1.11",
-        "@vitest/coverage-istanbul": "4.1.11",
-        "@vitest/coverage-v8": "4.1.11",
-        "@vitest/ui": "4.1.11",
+        "@types/node": "^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "5.0.0",
+        "@vitest/browser-preview": "5.0.0",
+        "@vitest/browser-webdriverio": "^5.0.0-beta.5 || >=5.0.0",
+        "@vitest/coverage-istanbul": "5.0.0",
+        "@vitest/coverage-v8": "5.0.0",
+        "@vitest/ui": "5.0.0",
         "happy-dom": "*",
         "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "vite": "^6.4.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -16578,28 +16498,15 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/@vitest/snapshot": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
-      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.11",
-        "@vitest/utils": "4.1.11",
-        "magic-string": "^0.30.21",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
-    },
-    "node_modules/vitest/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/vscode-languageserver-textdocument": {
       "version": "1.0.14",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:e2e:migration": "npm run build && wdio run ./wdio.conf.mts --suite migration",
     "test:e2e:interop": "npm run build && wdio run ./wdio.conf.mts --suite interop",
     "coverage": "vitest run --coverage",
-    "bench": "vitest bench",
+    "bench": "vitest bench --reporter=verbose",
     "check:types": "vue-tsc -b",
     "prepare": "husky",
     "postinstall": "patch-package"
@@ -66,7 +66,7 @@
     "@typescript-eslint/eslint-plugin": "^8.67.0",
     "@typescript-eslint/parser": "^8.67.0",
     "@vitejs/plugin-vue": "^6.0.8",
-    "@vitest/coverage-v8": "^4.1.10",
+    "@vitest/coverage-v8": "^5.0.0",
     "@vitest/eslint-plugin": "^1.6.27",
     "@vue/tsconfig": "^0.9.1",
     "@wdio/cli": "^9.30.1",
@@ -95,7 +95,7 @@
     "typescript-eslint": "^8.67.0",
     "vite": "^8.2.1",
     "vite-plugin-static-copy": "^4.1.1",
-    "vitest": "^4.1.10",
+    "vitest": "^5.0.0",
     "vue-tsc": "^3.3.9",
     "wdio-obsidian-reporter": "^3.1.3",
     "wdio-obsidian-service": "^3.1.3"

--- a/src/journals/journal-index.bench.ts
+++ b/src/journals/journal-index.bench.ts
@@ -1,4 +1,4 @@
-import { bench, describe } from "vitest";
+import { test } from "vitest";
 
 import type { AnchorString } from "@/calendar";
 import type { VaultPath } from "@/infrastructure/host";
@@ -19,108 +19,101 @@ function prepareTenYearsOfAnchors(): string[] {
   return dates;
 }
 
-describe.todo("JournalIndex - filling in", () => {
+function filledIndex(): JournalIndex {
+  const index = new JournalIndex();
+  for (const date of prepareTenYearsOfAnchors()) {
+    index.set(a(date), p("path/" + date));
+  }
+  return index;
+}
+
+test.todo("JournalIndex - filling in", async ({ bench }) => {
   const dates = prepareTenYearsOfAnchors();
 
-  bench("fill in journal - 1 year", () => {
-    const index = new JournalIndex();
-    for (const date of dates.slice(0, 365)) {
-      index.set(a(date), p("path/" + date));
-    }
-  });
-
-  bench("fill in journal - 10 years", () => {
-    const index = new JournalIndex();
-    for (const date of dates) {
-      index.set(a(date), p("path/" + date));
-    }
-  });
+  await bench.compare(
+    bench("fill in journal - 1 year", () => {
+      const index = new JournalIndex();
+      for (const date of dates.slice(0, 365)) {
+        index.set(a(date), p("path/" + date));
+      }
+    }),
+    bench("fill in journal - 10 years", () => {
+      const index = new JournalIndex();
+      for (const date of dates) {
+        index.set(a(date), p("path/" + date));
+      }
+    }),
+  );
 });
 
-describe("JournalIndex - find next", () => {
-  const index = new JournalIndex();
-  for (const date of prepareTenYearsOfAnchors()) {
-    index.set(a(date), p("path/" + date));
-  }
+test("JournalIndex - find next", async ({ bench }) => {
+  const index = filledIndex();
 
-  bench("find beginning", () => {
-    index.findNext(a("2022-02-01"));
-  });
-
-  bench("find middle", () => {
-    index.findNext(a("2027-05-01"));
-  });
-
-  bench("find end", () => {
-    index.findNext(a("2030-12-01"));
-  });
-
-  bench("find missing", () => {
-    index.findNext(a("2031-01-01"));
-  });
+  await bench.compare(
+    bench("find beginning", () => {
+      index.findNext(a("2022-02-01"));
+    }),
+    bench("find middle", () => {
+      index.findNext(a("2027-05-01"));
+    }),
+    bench("find end", () => {
+      index.findNext(a("2030-12-01"));
+    }),
+    bench("find missing", () => {
+      index.findNext(a("2031-01-01"));
+    }),
+  );
 });
 
-describe("JournalIndex - find previous", () => {
-  const index = new JournalIndex();
-  for (const date of prepareTenYearsOfAnchors()) {
-    index.set(a(date), p("path/" + date));
-  }
+test("JournalIndex - find previous", async ({ bench }) => {
+  const index = filledIndex();
 
-  bench("find beginning", () => {
-    index.findPrevious(a("2022-02-01"));
-  });
-
-  bench("find middle", () => {
-    index.findPrevious(a("2027-05-01"));
-  });
-
-  bench("find end", () => {
-    index.findPrevious(a("2030-12-01"));
-  });
-
-  bench("find missing", () => {
-    index.findPrevious(a("2031-01-01"));
-  });
+  await bench.compare(
+    bench("find beginning", () => {
+      index.findPrevious(a("2022-02-01"));
+    }),
+    bench("find middle", () => {
+      index.findPrevious(a("2027-05-01"));
+    }),
+    bench("find end", () => {
+      index.findPrevious(a("2030-12-01"));
+    }),
+    bench("find missing", () => {
+      index.findPrevious(a("2031-01-01"));
+    }),
+  );
 });
 
-describe("JournalIndex - find closest anchor", () => {
-  const index = new JournalIndex();
-  for (const date of prepareTenYearsOfAnchors()) {
-    index.set(a(date), p("path/" + date));
-  }
+test("JournalIndex - find closest anchor", async ({ bench }) => {
+  const index = filledIndex();
   index.delete(a("2022-03-01"));
   index.delete(a("2027-06-01"));
   index.delete(a("2030-11-01"));
 
-  bench("find closest beginning known", () => {
-    index.findClosestAnchor(a("2022-01-10"));
-  });
-
-  bench("find closest middle known", () => {
-    index.findClosestAnchor(a("2027-05-10"));
-  });
-
-  bench("find closest end known", () => {
-    index.findClosestAnchor(a("2030-12-10"));
-  });
-
-  bench("find closest beginning gap", () => {
-    index.findClosestAnchor(a("2022-03-01"));
-  });
-
-  bench("find closest middle gap", () => {
-    index.findClosestAnchor(a("2027-06-01"));
-  });
-
-  bench("find closest end gap", () => {
-    index.findClosestAnchor(a("2030-11-01"));
-  });
-
-  bench("find closest before known", () => {
-    index.findClosestAnchor(a("2021-12-01"));
-  });
-
-  bench("find closest after known", () => {
-    index.findClosestAnchor(a("2033-01-01"));
-  });
+  await bench.compare(
+    bench("find closest beginning known", () => {
+      index.findClosestAnchor(a("2022-01-10"));
+    }),
+    bench("find closest middle known", () => {
+      index.findClosestAnchor(a("2027-05-10"));
+    }),
+    bench("find closest end known", () => {
+      index.findClosestAnchor(a("2030-12-10"));
+    }),
+    bench("find closest beginning gap", () => {
+      index.findClosestAnchor(a("2022-03-01"));
+    }),
+    bench("find closest middle gap", () => {
+      index.findClosestAnchor(a("2027-06-01"));
+    }),
+    bench("find closest end gap", () => {
+      index.findClosestAnchor(a("2030-11-01"));
+    }),
+    bench("find closest before known", () => {
+      index.findClosestAnchor(a("2021-12-01"));
+    }),
+    bench("find closest after known", () => {
+      index.findClosestAnchor(a("2033-01-01"));
+    }),
+  );
 });


### PR DESCRIPTION
Supersedes #335, which fails `check:types` because vitest 5 removes the top-level `bench` export.

## Why #335 is red

`check:types` is step 3 of 8 in `checks.yml`, so its failure hid the rest of the job. Running the full chain against #335's head locally: `coverage` passes (all tests, thresholds met), and `check:lint` fails with 18 `no-unsafe-call` errors — all in the same file, all downstream of the unresolved import. One root cause, one file.

```
src/journals/journal-index.bench.ts(1,10): error TS2724:
  '"vitest"' has no exported member named 'bench'. Did you mean 'Bench'?
```

## What changed

Vitest 5 rewrote the benchmark API ([vitest-dev/vitest#10113](https://github.com/vitest-dev/vitest/pull/10113)). `bench` is no longer a top-level export — it is a fixture on the test context, available only in files matching `benchmark.include`. `src/journals/journal-index.bench.ts` is the only consumer. Each `describe` group becomes one `test()` registering its benchmarks through `bench.compare()`; the `.todo` group becomes `test.todo`. The `vitest bench` subcommand and the `**/*.{bench,benchmark}.*` include pattern are unchanged.

Two follow-on adjustments the port forces:

- **`eslint.config.mjs`** — `@vitest/eslint-plugin`'s recommended rules read the new shape as ordinary tests: bodies that never `expect()`, and a `bench.compare()` whose first argument is a registration rather than a title string. 11 errors without an override. `vitest/expect-expect` and `vitest/valid-title` are off for `*.bench.ts` only. This is a rule change riding along with a dep bump — worth a look rather than a skim.
- **`npm run bench`** — under vitest 5's default reporter the command completes and prints nothing but a pass count; the hz tables are gone. `--reporter=verbose` restores them. This regression was masked by the type error and would not have surfaced until someone wanted benchmark numbers.

## Why one PR and not two

The halves are inseparable. The new file does not compile against vitest 4 (`Property 'bench' does not exist on type 'TestContext'`, verified), and the old file does not compile against vitest 5.

This branches from current `main` (52822b1f) rather than cherry-picking #335, whose head predates #334, #336 and #337 — #336 was lock-file maintenance, so the lockfile is regenerated here rather than carried over.

## Verification

All eight `checks.yml` steps run locally against this branch: `compile:i18n`, `check:i18n`, `check:types`, `coverage` (457 files, 5327 tests, thresholds met), `check:lint`, `build:api`, the `packages/api/index.d.ts` diff gate, and `check:api` — all pass. `npm run bench` runs and reports (3 passed, 1 todo, tables printed).

No `CHANGELOG.md` entry: the `[Unreleased]` sections are `### Features` and `### Bug Fixes`, both written for the person using the plugin, and nothing here reaches them.

Note: vitest 5 emits a new advisory warning during the benchmark run — *"accessed module export getters too many times"*, pointing at `Option` from `src/infrastructure/result/`. It is about benchmark measurement accuracy, not a failure, and is left alone here.