### PR TITLE
fix(templates): resolve journal variables in included sub-templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - Two new commands move between journals of different period lengths from the note you have open: **Zoom out** and **Zoom in**. From a daily note, zooming out opens that week's note; from there, the month's, and zooming in walks back down. Zooming stays among the journals on the shelf the open note's journal belongs to — so a work daily note zooms to the work monthly note rather than a personal one — and reaches every journal when that journal is on no shelf. A period length nothing in scope writes at is passed over, so a vault with only daily and monthly journals zooms straight between them, and a custom-interval journal takes its place by how long its interval runs: a two-week sprint sits between the weekly and the monthly journal. A journal whose timeline does not reach the date you are on is passed over the same way. Zooming in opens the first shorter period inside the current one — the 1st of the month, from a monthly note. The note is created if it does not exist yet, and where two journals in scope write the same length of period, you are asked which of them to open. Both commands stay out of the command palette on a note that belongs to no journal, and when nothing in scope is longer or shorter.
 
+### Bug Fixes
+
+- Journal variables now resolve in a sub-template Templater includes. A template calling `<% tp.file.include("[[Sub-Template]]") %>` had its own `{{date}}` and other variables filled in, but the included file's reached the note written out as `{{date}}` — Templater reads an included file straight off disk, past the point where the variables are filled in. An included file's variables are now filled in before Templater runs its commands, so it can use them inside a Templater command as well as in its text.
+
 ## [3.3.0] - 2026-09-06
 
 ### Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,42 @@ on it.
   Unit tests mirror the fake, so only an e2e that picks a _number_ property
   catches a registry rename.
 
+### Templater interop
+
+- Templater resolves `tp.file.include` by reading the sub-template **off disk**
+  and re-entering its own parser with it, so the `{{ }}` pass
+  `TemplateContentService` runs over a template body never reaches an included
+  file (#190). The seam is `parse_commands` on `plugin.templater.parser`, taking
+  the content and the functions object — the one method both the template
+  Templater was asked to run and every included file pass through, nested
+  includes included.
+  `TemplaterService` hooks it for the duration of an apply and renders each
+  nested body **before** Templater parses its commands. Rendering before rather
+  than post-processing the finished note is the whole point: it is what lets a
+  sub-template use a variable inside a `<% %>` command, and a second pass over
+  the output would also rewrite `{{ }}` that a command deliberately emitted. Do
+  not "simplify" the hook into that second pass.
+- Two properties of the hook are load-bearing and neither is visible at the call
+  site. It is **scoped** by `functionsObject.config.target_file.path`: Templater's
+  internal `config` module returns the running config verbatim, so `tp.config`
+  rides along with every parse, and without the check a parse the user or another
+  plugin starts during our `await` would get journal variables substituted into
+  it. And it is **refcounted** by target path, shared across concurrent applies —
+  a naive save-and-restore lets whichever apply finishes first uninstall the hook
+  out from under the others, which bulk add makes reachable.
+- `parse_commands` is a step deeper into Templater's internals than
+  `create_running_config` / `parse_template`, so it gets the same
+  capability-check-and-fall-back discipline: no `parser.parse_commands`, no hook,
+  behavior exactly as before. Both cached bundles carry it under that name
+  (`.obsidian-cache/obsidian-plugins/silentvoid13/Templater/<version>/main.js` —
+  minified, but the internal names survive, so grep settles a version question
+  directly). They differ only in how `generate_include` fetches the functions
+  object — `get_current_functions_object()` at 2.18.0, the
+  `current_functions_object` field at 2.22.1 — which is why the hook reads
+  neither. Only the real plugin exercises the re-entry: against
+  `__mocks__/obsidian.ts` there is no Templater, so this is an e2e-or-nothing
+  behavior, in `e2e/interop/templater.e2e.ts`.
+
 ### Settings and schema
 
 - A stored value that fails its schema on reload costs different amounts

--- a/e2e/fixtures/e2e-templater/.obsidian/plugins/journals/data.json
+++ b/e2e/fixtures/e2e-templater/.obsidian/plugins/journals/data.json
@@ -35,6 +35,23 @@
       },
       "numbering": { "enabled": false, "anchorDate": "", "allowBefore": false, "sources": [] }
     },
+    "include": {
+      "name": "include",
+      "write": { "type": "day" },
+      "timeline": { "start": "", "end": { "kind": "never" } },
+      "dateFormat": "YYYY-MM-DD",
+      "nameTemplate": "{{date}}",
+      "folder": "include",
+      "templates": ["templates/include-parent.md"],
+      "frontmatter": {
+        "dateField": "journal-date",
+        "startDateField": "journal-start-date",
+        "endDateField": "journal-end-date",
+        "addStartDate": false,
+        "addEndDate": false
+      },
+      "numbering": { "enabled": false, "anchorDate": "", "allowBefore": false, "sources": [] }
+    },
     "cursor": {
       "name": "cursor",
       "write": { "type": "day" },
@@ -69,6 +86,15 @@
       "showInRibbon": false,
       "openMode": "active",
       "target": { "kind": "journal", "journalName": "compose" },
+      "type": "same",
+      "context": "today"
+    },
+    "open-include": {
+      "name": "Open include today",
+      "icon": "",
+      "showInRibbon": false,
+      "openMode": "active",
+      "target": { "kind": "journal", "journalName": "include" },
       "type": "same",
       "context": "today"
     },

--- a/e2e/fixtures/e2e-templater/templates/include-parent.md
+++ b/e2e/fixtures/e2e-templater/templates/include-parent.md
@@ -1,0 +1,1 @@
+parent {{journal_name}} / <% tp.file.include("[[include-sub]]") %>

--- a/e2e/fixtures/e2e-templater/templates/include-sub.md
+++ b/e2e/fixtures/e2e-templater/templates/include-sub.md
@@ -1,0 +1,1 @@
+sub {{journal_name}} <% "{{date}}" %>

--- a/e2e/interop/templater.e2e.ts
+++ b/e2e/interop/templater.e2e.ts
@@ -2,7 +2,7 @@ import { browser, expect } from "@wdio/globals";
 
 import { runCommand } from "../support/commands.js";
 import { cursorOf, editorValue, waitForCursorLine } from "../support/editor.js";
-import { contentOf, waitForActiveNoteIn, waitForContent } from "../support/vault.js";
+import { contentOf, todayAnchor, waitForActiveNoteIn, waitForContent } from "../support/vault.js";
 
 // Slice D — the Templater interop seam. The `e2e-templater` fixture commits day
 // journals whose templates carry Templater `<% %>` syntax; booting the real
@@ -49,6 +49,28 @@ describe("templater interop", () => {
     const content = await contentOf(path);
     expect(content).not.toContain("<%");
     expect(content).not.toContain("{{");
+  });
+
+  // Templater resolves `tp.file.include` by reading the sub-template off disk, past the engine
+  // pass that rendered the parent, so before the parser hook the sub-template's `{{ }}` reached
+  // the note verbatim (#190). Only the real plugin exercises that re-entry.
+  it("renders plugin variables in a sub-template Templater includes", async () => {
+    await runCommand("journals:open-include");
+
+    const path = await waitForActiveNoteIn("include");
+    await waitForContent(
+      path,
+      (content) => content.includes("sub include"),
+      "waited for the included sub-template to render its variables",
+    );
+
+    const content = await contentOf(path);
+    expect(content).toContain("parent include / sub include");
+    // The sub-template's date sits inside a Templater command, so it proves the variables were
+    // rendered before Templater parsed the include rather than after it ran.
+    expect(content).toContain(todayAnchor());
+    expect(content).not.toContain("{{");
+    expect(content).not.toContain("<%");
   });
 
   it("jumps the editor cursor to the Templater cursor marker", async () => {

--- a/src/infrastructure/host/internal/templater-plugin.ts
+++ b/src/infrastructure/host/internal/templater-plugin.ts
@@ -7,8 +7,20 @@ interface RunningConfig {
   active_file?: TFile | null;
 }
 
+export type ParseCommands = (content: string, functionsObject: unknown) => Promise<string>;
+
+/**
+ * The one method every template body passes through — the template Templater was asked to run
+ * and, on re-entry, each file `tp.file.include` pulls in. Optional because it is deeper into
+ * Templater's internals than the rest of this surface.
+ */
+export interface TemplaterParser {
+  parse_commands: ParseCommands;
+}
+
 export interface TemplaterPlugin extends Plugin {
   templater: {
+    parser?: TemplaterParser;
     create_running_config(templateFile: TFile | undefined, targetFile: TFile, runMode: number): RunningConfig;
     parse_template(config: RunningConfig, content: string): Promise<string>;
   };

--- a/src/infrastructure/host/internal/templater-service.test.ts
+++ b/src/infrastructure/host/internal/templater-service.test.ts
@@ -182,3 +182,164 @@ describe("TemplaterService.templatesFolder", () => {
     expect(build(fakeApp({ plugin })).templatesFolder()).toBeNull();
   });
 });
+
+// Templater resolves `tp.file.include` by reading the sub-template off disk and re-entering
+// its own parser with it, so the plugin's `{{ }}` pass — which ran over the parent's body
+// before Templater ever saw it — never reaches that content. The fake below mirrors that
+// re-entry through `plugin.templater.parser.parse_commands`, the seam the service hooks.
+function includingPlugin(includes: Record<string, string> = {}, gates: Record<string, Promise<void>> = {}) {
+  const plugin = {
+    templater: {
+      parser: {
+        parse_commands: async (content: string, functionsObject: unknown): Promise<string> => {
+          const match = /<% tp\.file\.include\("([^"]+)"\) %>/.exec(content);
+          if (match === null) return content;
+          const nested = await plugin.templater.parser.parse_commands(includes[match[1]] ?? "", functionsObject);
+          return content.replace(match[0], () => nested);
+        },
+      },
+      create_running_config: (template_file: TFile | undefined, target_file: TFile, run_mode: number) => ({
+        template_file,
+        target_file,
+        run_mode,
+      }),
+      parse_template: async (config: { target_file: TFile }, content: string): Promise<string> => {
+        await gates[config.target_file.path];
+        return plugin.templater.parser.parse_commands(content, { config });
+      },
+    },
+  };
+  return plugin;
+}
+
+describe("TemplaterService.apply nested content", () => {
+  const files = { "T.md": tfile("T.md"), "N.md": tfile("N.md") };
+  const body = '<% tp.file.include("Sub") %>';
+
+  it("renders a sub-template Templater includes through the nested renderer", async () => {
+    const service = build(fakeApp({ plugin: includingPlugin({ Sub: "sub says {{date}}" }), files }));
+
+    const result = await service.apply("T.md" as VaultPath, "N.md" as VaultPath, `intro ${body}`, (raw) =>
+      raw.replaceAll("{{date}}", "2026-05-19"),
+    );
+
+    expectOk(result);
+    expect(result.value).toBe("intro sub says 2026-05-19");
+  });
+
+  it("renders a sub-template's variables before Templater parses its commands", async () => {
+    const includes = { Sub: '<% "{{date}}" %>' };
+    const plugin = includingPlugin(includes);
+    // Stand in for Templater evaluating the command: by the time the parser sees it, the
+    // variable must already be gone, which a pass running after Templater cannot deliver.
+    const inner = plugin.templater.parser.parse_commands;
+    plugin.templater.parser.parse_commands = async (content: string, functionsObject: unknown): Promise<string> => {
+      const parsed = await inner(content, functionsObject);
+      return parsed.replace(/<% "([^"]*)" %>/, "$1");
+    };
+    const service = build(fakeApp({ plugin, files }));
+
+    const result = await service.apply("T.md" as VaultPath, "N.md" as VaultPath, body, (raw) =>
+      raw.replaceAll("{{date}}", "2026-05-19"),
+    );
+
+    expectOk(result);
+    expect(result.value).toBe("2026-05-19");
+  });
+
+  it("does not re-render the content it was handed", async () => {
+    const service = build(fakeApp({ plugin: includingPlugin({ Sub: "sub" }), files }));
+    const seen: string[] = [];
+
+    await service.apply("T.md" as VaultPath, "N.md" as VaultPath, `top {{date}} ${body}`, (raw) => {
+      seen.push(raw);
+      return raw;
+    });
+
+    expect(seen).toEqual(["sub"]);
+  });
+
+  it("leaves nested content untouched when no nested renderer is given", async () => {
+    const service = build(fakeApp({ plugin: includingPlugin({ Sub: "sub says {{date}}" }), files }));
+
+    const result = await service.apply("T.md" as VaultPath, "N.md" as VaultPath, body);
+
+    expectOk(result);
+    expect(result.value).toBe("sub says {{date}}");
+  });
+
+  it("leaves content Templater parses for another target untouched", async () => {
+    const plugin = includingPlugin({ Sub: "sub" });
+    const parse = plugin.templater.parse_template;
+    let alien = "";
+    plugin.templater.parse_template = async (config: { target_file: TFile }, content: string): Promise<string> => {
+      alien = await plugin.templater.parser.parse_commands("alien {{date}}", {
+        config: { target_file: tfile("Other.md") },
+      });
+      return parse(config, content);
+    };
+    const service = build(fakeApp({ plugin, files: { ...files, "Other.md": tfile("Other.md") } }));
+
+    await service.apply("T.md" as VaultPath, "N.md" as VaultPath, body, (raw) =>
+      raw.replaceAll("{{date}}", "2026-05-19"),
+    );
+
+    expect(alien).toBe("alien {{date}}");
+  });
+
+  it("renders each concurrent apply's includes with its own renderer", async () => {
+    const held = Promise.withResolvers<void>();
+    const plugin = includingPlugin({ Sub: "{{who}}" }, { "A.md": held.promise });
+    const service = build(
+      fakeApp({ plugin, files: { "T.md": tfile("T.md"), "A.md": tfile("A.md"), "B.md": tfile("B.md") } }),
+    );
+
+    const first = service.apply("T.md" as VaultPath, "A.md" as VaultPath, body, (raw) =>
+      raw.replaceAll("{{who}}", "first"),
+    );
+    const second = await service.apply("T.md" as VaultPath, "B.md" as VaultPath, body, (raw) =>
+      raw.replaceAll("{{who}}", "second"),
+    );
+    held.resolve();
+
+    expectOk(second);
+    expect(second.value).toBe("second");
+    const firstResult = await first;
+    expectOk(firstResult);
+    expect(firstResult.value).toBe("first");
+  });
+
+  it("keeps the nested content when the nested renderer throws", async () => {
+    const service = build(fakeApp({ plugin: includingPlugin({ Sub: "sub says {{date}}" }), files }));
+
+    const result = await service.apply("T.md" as VaultPath, "N.md" as VaultPath, body, () => {
+      throw new Error("boom");
+    });
+
+    expectOk(result);
+    expect(result.value).toBe("sub says {{date}}");
+  });
+
+  it("restores Templater's own parser once the template is applied", async () => {
+    const plugin = includingPlugin({ Sub: "sub" });
+    const original = plugin.templater.parser.parse_commands;
+    const service = build(fakeApp({ plugin, files }));
+
+    await service.apply("T.md" as VaultPath, "N.md" as VaultPath, body, (raw) => raw);
+
+    expect(plugin.templater.parser.parse_commands).toBe(original);
+  });
+
+  it("restores Templater's own parser when parsing throws", async () => {
+    const plugin = includingPlugin({ Sub: "sub" });
+    const original = plugin.templater.parser.parse_commands;
+    plugin.templater.parse_template = async (): Promise<string> => {
+      throw new Error("boom");
+    };
+    const service = build(fakeApp({ plugin, files }));
+
+    await service.apply("T.md" as VaultPath, "N.md" as VaultPath, body, (raw) => raw);
+
+    expect(plugin.templater.parser.parse_commands).toBe(original);
+  });
+});

--- a/src/infrastructure/host/internal/templater-service.ts
+++ b/src/infrastructure/host/internal/templater-service.ts
@@ -6,23 +6,53 @@ import { AsyncResult, InvariantError } from "@/infrastructure/result";
 
 import { InternalObsidianAppToken } from "./tokens";
 
-import type { TemplaterPlugin } from "./templater-plugin";
+import type { ParseCommands, TemplaterParser, TemplaterPlugin } from "./templater-plugin";
 import type { VaultPath } from "../types";
 
 const TEMPLATER_PLUGIN_ID = "templater-obsidian";
 const RUN_MODE_CREATE_NEW_FROM_TEMPLATE = 0;
 
+interface NestedRender {
+  /** Content already rendered by the caller; re-rendering it could substitute into a substitution. */
+  readonly topLevel: string;
+  readonly render: (raw: string) => string;
+}
+
+interface ParserHook {
+  readonly original: ParseCommands;
+  readonly byTarget: Map<string, NestedRender>;
+}
+
+// Keyed by the parser object so a Templater reload starts clean, and shared across concurrent
+// applies so the last one out is the one that restores the original.
+const parserHooks = new WeakMap<TemplaterParser, ParserHook>();
+
+function targetPathOf(functionsObject: unknown): string | null {
+  // Templater's "config" module hands the running config straight back as `tp.config`, so the
+  // functions object carries the file the parse is writing to.
+  const target = (functionsObject as { config?: { target_file?: { path?: unknown } } } | null)?.config?.target_file;
+  return typeof target?.path === "string" ? target.path : null;
+}
+
 export class TemplaterService {
   readonly #app = inject(InternalObsidianAppToken);
   readonly #logger = inject(LoggerFactoryToken).named("templater");
 
-  async #apply(templatePath: VaultPath, targetPath: VaultPath, content: string): Promise<string> {
+  async #apply(
+    templatePath: VaultPath,
+    targetPath: VaultPath,
+    content: string,
+    renderNested?: (raw: string) => string,
+  ): Promise<string> {
     if (!content.includes("<%") && !content.includes("%>")) return content;
     const plugin = this.#applyCapablePlugin();
     if (!plugin) return content;
     const templateFile = this.#app.vault.getAbstractFileByPath(templatePath);
     const targetFile = this.#app.vault.getAbstractFileByPath(targetPath);
     if (!(templateFile instanceof TFile) || !(targetFile instanceof TFile)) return content;
+    const release = renderNested
+      ? this.#hookNestedRender(plugin, targetPath, { topLevel: content, render: renderNested })
+      : undefined;
     try {
       const config = plugin.templater.create_running_config(
         templateFile,
@@ -33,6 +63,47 @@ export class TemplaterService {
     } catch (error) {
       this.#logger.debug("templater apply failed", { cause: String(error) });
       return content;
+    } finally {
+      release?.();
+    }
+  }
+
+  /**
+   * Renders `{{ }}` in every template body Templater pulls in below the one we handed it —
+   * `tp.file.include` reads its sub-template off disk, so nothing else reaches that content.
+   * Returns undefined when Templater exposes no parser to hook.
+   */
+  #hookNestedRender(plugin: TemplaterPlugin, targetPath: VaultPath, nested: NestedRender): (() => void) | undefined {
+    const parser = plugin.templater.parser;
+    if (!parser || typeof parser.parse_commands !== "function") return undefined;
+    const hook = parserHooks.get(parser) ?? this.#installParserHook(parser);
+    hook.byTarget.set(targetPath, nested);
+    return () => {
+      hook.byTarget.delete(targetPath);
+      if (hook.byTarget.size > 0) return;
+      parserHooks.delete(parser);
+      parser.parse_commands = hook.original;
+    };
+  }
+
+  #installParserHook(parser: TemplaterParser): ParserHook {
+    const hook: ParserHook = { original: parser.parse_commands, byTarget: new Map() };
+    parserHooks.set(parser, hook);
+    parser.parse_commands = async (raw: string, functionsObject: unknown): Promise<string> => {
+      const path = targetPathOf(functionsObject);
+      const entry = path === null ? undefined : hook.byTarget.get(path);
+      const rendered = entry && raw !== entry.topLevel ? this.#renderNested(entry.render, raw) : raw;
+      return hook.original.call(parser, rendered, functionsObject);
+    };
+    return hook;
+  }
+
+  #renderNested(render: (raw: string) => string, raw: string): string {
+    try {
+      return render(raw);
+    } catch (error) {
+      this.#logger.debug("nested template render failed", { cause: String(error) });
+      return raw;
     }
   }
 
@@ -79,8 +150,13 @@ export class TemplaterService {
     return typeof folder === "string" ? folder : null;
   }
 
-  apply(templatePath: VaultPath, targetPath: VaultPath, content: string): AsyncResult<string, never> {
-    return AsyncResult.fromPromise(this.#apply(templatePath, targetPath, content), () => {
+  apply(
+    templatePath: VaultPath,
+    targetPath: VaultPath,
+    content: string,
+    renderNested?: (raw: string) => string,
+  ): AsyncResult<string, never> {
+    return AsyncResult.fromPromise(this.#apply(templatePath, targetPath, content, renderNested), () => {
       throw new InvariantError("unreachable: #apply never rejects");
     });
   }

--- a/src/infrastructure/host/testing.ts
+++ b/src/infrastructure/host/testing.ts
@@ -403,9 +403,12 @@ export class FakePluginData implements Pick<
   }
 }
 
+/** `renderNested` stands in for Templater re-entering the parser with a `tp.file.include` body. */
+type TemplaterTransform = (content: string, renderNested?: (raw: string) => string) => string;
+
 export class FakeTemplaterService implements Pick<TemplaterService, "apply" | "cursorJump" | "isSupported"> {
   #supported = false;
-  #transform: (content: string) => string = (content) => content;
+  #transform: TemplaterTransform = (content) => content;
   readonly applyCalls: { templatePath: VaultPath; targetPath: VaultPath; content: string }[] = [];
   readonly cursorJumps: VaultPath[] = [];
 
@@ -413,13 +416,18 @@ export class FakeTemplaterService implements Pick<TemplaterService, "apply" | "c
     this.#supported = value;
   }
 
-  setTransform(transform: (content: string) => string): void {
+  setTransform(transform: TemplaterTransform): void {
     this.#transform = transform;
   }
 
-  apply(templatePath: VaultPath, targetPath: VaultPath, content: string): AsyncResult<string, never> {
+  apply(
+    templatePath: VaultPath,
+    targetPath: VaultPath,
+    content: string,
+    renderNested?: (raw: string) => string,
+  ): AsyncResult<string, never> {
     this.applyCalls.push({ templatePath, targetPath, content });
-    return AsyncResult.ok(this.#transform(content));
+    return AsyncResult.ok(this.#transform(content, renderNested));
   }
 
   cursorJump(path: VaultPath): AsyncResult<void, never> {

--- a/src/journals/notes/template-content.test.ts
+++ b/src/journals/notes/template-content.test.ts
@@ -196,6 +196,23 @@ describe("TemplateContentService.renderFor — Templater", () => {
       expect(result.value).toBe("# 2026-05-19 [templated]");
     });
 
+    // Templater reads a `tp.file.include` sub-template off disk, past the engine pass that
+    // rendered the parent. The renderer handed down carries the parent's own bindings, so the
+    // sub-template resolves the journal's date rather than the template file's own name.
+    it("hands Templater a renderer that resolves the note's variables in included content", async () => {
+      harness.host.putFile("Templates/daily.md", "body");
+      harness.templater.setTransform(
+        (content, renderNested) => `${content} ${renderNested?.("sub {{date}}") ?? "no renderer"}`,
+      );
+
+      const result = await harness
+        .resolve(TemplateContentService)
+        .renderFor("daily", meta, "2026-05-19", "2026-05-19.md" as VaultPath);
+
+      expectOk(result);
+      expect(result.value).toBe("body sub 2026-05-19");
+    });
+
     it("passes the winning template path and target path to Templater", async () => {
       harness.host.putFile("Templates/daily.md", "body");
 

--- a/src/journals/notes/template-content.ts
+++ b/src/journals/notes/template-content.ts
@@ -38,7 +38,11 @@ export class TemplateContentService {
           // content wins the slot.
           if (readResult.value === "") continue;
           const rendered = this.#engine.renderString(readResult.value, context);
-          const applied = await this.#templater.apply(renderedPath, targetPath, rendered);
+          // Templater pulls a `tp.file.include` sub-template straight off disk, so the same
+          // context has to travel with it or the sub-template keeps its variables literal.
+          const applied = await this.#templater.apply(renderedPath, targetPath, rendered, (raw) =>
+            this.#engine.renderString(raw, context),
+          );
           return applied.match({ ok: (content) => content, err: () => rendered });
         }
         return "";


### PR DESCRIPTION
Closes #190.

## The bug

`TemplateContentService` renders `{{ }}` over a template body and hands the result to Templater. Templater resolves `tp.file.include` by reading the sub-template **off disk** and re-entering its own parser with it, so that content never passed through the engine and its variables reached the note verbatim.

## The fix

`plugin.templater.parser.parse_commands(content, functionsObject)` is the one method both the template Templater was asked to run and every included file pass through — same name and shape in 2.18.0 and 2.22.1, which differ only in how `generate_include` fetches the functions object. `TemplaterService.apply` takes an optional `renderNested` callback and hooks that method for the duration of a parse, rendering each nested body before Templater parses its commands.

Rendering *before* the parse rather than post-processing the output is what lets a sub-template use a variable **inside** a Templater command (`<% "{{date}}" %>`), which a second pass over the finished note cannot do — and a second pass would also rewrite `{{ }}` that a Templater command deliberately emitted.

Two guards:

- **Scope.** Templater's internal `config` module returns the running config verbatim, so the functions object always carries `config.target_file`. The hook only renders for the target the apply is writing to; a parse the user or another plugin starts meanwhile is untouched.
- **Refcount.** The hook is shared and keyed by target path, so concurrent applies each keep their own renderer and the last one out restores the original method.

The top-level body is skipped (the caller already rendered it), a throwing renderer falls back to the raw content, and if Templater exposes no `parser.parse_commands` no hook is installed and behaviour is exactly as before — the same capability-check-and-fall-back discipline the rest of this service already applies to Templater's internals.

## Tests

- `templater-service.test.ts` — nine cases against a fake plugin that mirrors Templater's re-entry through `parser.parse_commands`: the include renders, it renders *before* commands are parsed, the top-level body is not re-rendered, another target is untouched, concurrent applies keep their own renderers, a throwing renderer is absorbed, and the original method is restored on both the success and throw paths.
- `template-content.test.ts` — the renderer handed down carries the note's own bindings.
- `e2e/interop/templater.e2e.ts` — a new `include` journal in the `e2e-templater` fixture whose template includes a sub-template holding both a bare `{{journal_name}}` and a `{{date}}` inside a Templater command. Verified red on this branch with only the production files reverted (that one test failed, the other three passed), green with them restored.

`check:types`, `check:lint` (0 errors), 5337 unit tests and the interop e2e suite all pass.