### PR TITLE
fix(e2e): unpin the Obsidian app version back to latest

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,14 +30,7 @@ jobs:
         # which a manual dispatch can ask for too — a floor-only failure is otherwise
         # unverifiable until the next 07:00 UTC.
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        # The app version is pinned to 1.13.7 rather than `latest` because 1.13.8 is an
-        # Android-only release: its `obsidian-versions.json` entry carries `downloads: ["apk"]`
-        # and no installer bounds, so there is no asar to run and setup dies with
-        # "No asar found for Obsidian version 1.13.8". `latest` skips the 1.14.0 beta but not
-        # an Android-only build, so it lands on a version with no desktop artifact at all.
-        # Unpin — back to `latest` — once Obsidian ships a desktop 1.13.9+ (which moves
-        # `latest` past the Android-only entry) or wdio-obsidian-service filters these out.
-        obsidian: ${{ (github.event_name == 'schedule' || inputs.full_matrix) && fromJSON('["earliest/earliest", "1.13.7/earliest", "1.13.7/1.13.7"]') || fromJSON('["1.13.7/1.13.7"]') }}
+        obsidian: ${{ (github.event_name == 'schedule' || inputs.full_matrix) && fromJSON('["earliest/earliest", "latest/earliest", "latest/latest"]') || fromJSON('["latest/latest"]') }}
 
     runs-on: ${{ matrix.os }}
     permissions:

--- a/docs/e2e-testing-strategy.md
+++ b/docs/e2e-testing-strategy.md
@@ -49,16 +49,6 @@ Obsidian-version compatibility is pinned in CI, not left to chance:
 `manifest.json`'s `minAppVersion` — see [Install and version
 modes](#install-and-version-modes) below.
 
-> **Temporarily pinned.** Everywhere this document says `latest` for the _app_
-> axis, the workflow and `wdio.conf.mts` currently say `1.13.7`. Obsidian 1.13.8
-> is an Android-only release — its `obsidian-versions.json` entry carries
-> `downloads: ["apk"]` and no installer bounds — so there is no asar to run and
-> setup fails with `No asar found for Obsidian version 1.13.8`. `latest` skips
-> the 1.14.0 beta but not an Android-only build, so it selects a version with no
-> desktop artifact at all. Restore `latest` once Obsidian ships a desktop
-> 1.13.9+, or once `wdio-obsidian-service` filters asar-less versions out of
-> `latest`.
-
 #### Install and version modes
 
 Obsidian has **two independent version axes**, and we configure both per capability

--- a/e2e/journeys/notelets.e2e.ts
+++ b/e2e/journeys/notelets.e2e.ts
@@ -11,6 +11,7 @@ import {
   todayAnchor,
   waitForActiveNote,
   waitForActiveNoteIn,
+  waitForFrontmatter,
 } from "../support/vault.js";
 import { waitForState } from "../support/wait.js";
 
@@ -75,11 +76,17 @@ describe("notelets", () => {
 
       const path = await waitForActiveNoteIn("day/meetings");
       expect(path).toBe(`day/meetings/${today} Meeting 1.md`);
+      // The note becomes the active leaf before metadataCache has parsed it, so the counter has
+      // to be waited for; a bare read here returns undefined on whichever run loses that race.
+      await waitForFrontmatter(
+        path,
+        (frontmatter) => frontmatter["journal-notelet-index"] === 1,
+        "the first Meeting notelet never reached metadataCache carrying counter 1",
+      );
       const frontmatter = await frontmatterOf(path);
       expect(frontmatter?.journal).toBe("daily");
       expect(frontmatter?.["journal-date"]).toBe(today);
       expect(frontmatter?.["journal-notelet"]).toBe("Meeting");
-      expect(frontmatter?.["journal-notelet-index"]).toBe(1);
 
       // The whole point of a notelet: it sits beside the period note rather than standing in for
       // it. A create path that fell back to NoteCreationService would leave this note behind.
@@ -90,8 +97,11 @@ describe("notelets", () => {
       await runCommand("journals:create-meeting");
 
       await waitForActiveNote(`day/meetings/${today} Meeting 2.md`);
-      const frontmatter = await frontmatterOf(`day/meetings/${today} Meeting 2.md`);
-      expect(frontmatter?.["journal-notelet-index"]).toBe(2);
+      await waitForFrontmatter(
+        `day/meetings/${today} Meeting 2.md`,
+        (frontmatter) => frontmatter["journal-notelet-index"] === 2,
+        "the second Meeting notelet never reached metadataCache carrying counter 2",
+      );
       // The first one is still there under its own number — the second did not overwrite it.
       expect(await noteExists(`day/meetings/${today} Meeting 1.md`)).toBe(true);
     });
@@ -116,8 +126,12 @@ describe("notelets", () => {
         "the second Retro notelet never became the active note",
       );
       expect(await noteExists(`day/retros/${today} Retro.md`)).toBe(true);
+      await waitForFrontmatter(
+        second,
+        (frontmatter) => frontmatter["journal-notelet"] === "Retro",
+        "the suffixed Retro notelet never reached metadataCache",
+      );
       const frontmatter = await frontmatterOf(second);
-      expect(frontmatter?.["journal-notelet"]).toBe("Retro");
       expect(frontmatter?.["journal-date"]).toBe(today);
     });
   });

--- a/wdio.conf.mts
+++ b/wdio.conf.mts
@@ -8,12 +8,9 @@ import { parseObsidianVersions } from "wdio-obsidian-service";
 const SCREENSHOT_DIR = "./e2e/.reports/screenshots";
 
 // Version matrix is data-driven so CI jobs select it via OBSIDIAN_VERSIONS without
-// editing this file: PR gate -> the pinned app version; nightly -> the floor + mismatch
+// editing this file: PR gate -> "latest/latest"; nightly -> the floor + mismatch
 // combos (see docs/e2e-testing-strategy.md). `earliest` resolves manifest.minAppVersion.
-// Pinned rather than `latest/latest` for the same reason the CI matrix is: 1.13.8 is an
-// Android-only release with no asar, and `latest` selects it. See .github/workflows/e2e.yml
-// for the unpin condition; the two move together.
-const versionSpec = env.OBSIDIAN_VERSIONS ?? "1.13.7/1.13.7";
+const versionSpec = env.OBSIDIAN_VERSIONS ?? "latest/latest";
 const versions = await parseObsidianVersions(versionSpec);
 
 export const config: WebdriverIO.Config = {


### PR DESCRIPTION
Two commits, both about keeping the e2e gate meaningful.

## 1. Unpin the Obsidian app version

Reverts the 1.13.7 pin from c23fd5d8 — CI matrix, `wdio.conf.mts`'s local default, and the "Temporarily pinned" note in `docs/e2e-testing-strategy.md` all go back to `latest`.

**Why it is safe now.** Upstream [wdio-obsidian-service#83](https://github.com/jesse-r-s-hines/wdio-obsidian-service/issues/83) is closed: the maintainer removed the mobile-only 1.13.8 entry from `obsidian-versions.json` and updated the workflow that generates it to omit such releases, plus a check so a future Android-only build cannot break test runs the same way.

That file is fetched from the repo at run time and re-cached every 30 minutes, so the fix applies without a package bump (`wdio-obsidian-service` stays at the already-installed 3.2.0) and a restored `.obsidian-cache` cannot serve stale metadata.

Verified against the installed launcher: `parseObsidianVersions("latest/latest")` resolves to `[["1.13.7", "1.13.7"]]` — the exact version the pin was holding, so this PR's e2e run exercises the same binary CI has been running, and the matrix tracks new desktop releases again from here.

## 2. Fix a metadataCache race in the notelet creation specs

The first run of this PR went red on ubuntu only, at `notelets.e2e.ts:94`, `Expected: 2, Received: undefined`. Not caused by the unpin: that job's banner reads `Running: obsidian v1.13.7 (installer: v1.13.7, platform: linux)`, and main's own run on the same binary passed the same spec.

The three creation specs read `frontmatterOf` straight after an active-note wait, but `waitForActiveNote` polls the workspace's active path only — it says nothing about `metadataCache`. `frontmatterOf` is a single `getFileCache` read, so it returns `undefined` whenever the parse has not landed yet, and the assertion fails instead of retrying. The other two reads carried the same latent race and merely won it.

Each spec now waits on the key it discriminates by, then reads once and asserts the rest, matching `week-preset.e2e.ts`. The wait carries a timeout message, so a notelet that genuinely never gets its counter still fails rather than being papered over. Every other `frontmatterOf` call site in the suite is already behind a wait or is a deliberate `toBeNull` negative.