### PR TITLE
ci(e2e): shard the PR matrix so the gate is not one serial suite per host

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,6 +31,16 @@ jobs:
         # unverifiable until the next 07:00 UTC.
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         obsidian: ${{ (github.event_name == 'schedule' || inputs.full_matrix) && fromJSON('["earliest/earliest", "latest/earliest", "latest/latest"]') || fromJSON('["latest/latest"]') }}
+        # Only the PR + merge path is sharded, because only there does wall clock buy anything:
+        # the suite is dominated by Obsidian process lifecycle rather than by assertions (test
+        # bodies are 38% of the Linux run and 25% of the Windows one — 71 sessions plus ~100
+        # reloadObsidian boots), so it splits across runners almost linearly. `--shard c/t` slices
+        # the spec list *after* suite filtering, contiguously and by file count, not by duration;
+        # measured against the run of 2026-09-08 the two halves come out 387s/440s on Windows, the
+        # leg that sets the gate. Nightly stays on one shard: it already fans out over the version
+        # axis, its wall clock is nobody's feedback loop, and 3 versions x 3 OS x 2 shards would
+        # queue against the concurrent-job limit.
+        shard: ${{ (github.event_name == 'schedule' || inputs.full_matrix) && fromJSON('["1/1"]') || fromJSON('["1/2", "2/2"]') }}
 
     runs-on: ${{ matrix.os }}
     permissions:
@@ -63,24 +73,29 @@ jobs:
           path: .obsidian-cache
           key: obsidian-cache-${{ runner.os }}-${{ env.OBSIDIAN_VERSIONS }}
           restore-keys: obsidian-cache-${{ runner.os }}-
+          # Deliberately not keyed by shard: both shards want the same binaries. On a cold
+          # cache they race to save it and the loser logs "another job may be creating this
+          # cache" — noise, not failure, and cheaper than storing the same asar twice.
 
       - name: Build plugin
         run: npm run build
 
       - name: Run e2e (Linux)
         if: runner.os == 'Linux'
-        run: xvfb-run -a npx wdio run ./wdio.conf.mts ${{ env.WDIO_SUITES }}
+        run: xvfb-run -a npx wdio run ./wdio.conf.mts ${{ env.WDIO_SUITES }} --shard ${{ matrix.shard }}
 
       - name: Run e2e (Windows/macOS)
         if: runner.os != 'Linux'
-        run: npx wdio run ./wdio.conf.mts ${{ env.WDIO_SUITES }}
+        run: npx wdio run ./wdio.conf.mts ${{ env.WDIO_SUITES }} --shard ${{ matrix.shard }}
 
       - name: Publish e2e results
         if: always()
         uses: mikepenz/action-junit-report@v6
         with:
           report_paths: e2e/.reports/e2e-junit-*.xml
-          check_name: e2e results (${{ matrix.os }}, ${{ matrix.obsidian }})
+          # The shard belongs in the name: two legs of the same OS and version publish
+          # separate checks, and a shared name would leave one silently overwriting the other.
+          check_name: e2e results (${{ matrix.os }}, ${{ matrix.obsidian }}, shard ${{ matrix.shard }})
           # Tolerate a suite that crashed before emitting XML; the run step
           # already failed the job in that case.
           require_tests: false

--- a/docs/e2e-testing-strategy.md
+++ b/docs/e2e-testing-strategy.md
@@ -285,9 +285,25 @@ Three deliberate clocks:
 | Local on-demand     | `npm run test:e2e`                                                  | A dev runs it when touching the integration seam. Never automatic. |
 | CI                  | `pull_request` + `push` to `main` (full suite) + nightly `schedule` | Separate job, **not** wired into `checks.yml`.                     |
 
-The whole stable suite runs on **every PR and every merge to `main`** — it finishes
-in well under a minute, so there is no longer a reason to split a thin smoke gate
-from a fuller nightly pass. Both run `latest/latest` on Linux for a fast signal.
+The whole stable suite runs on **every PR and every merge to `main`**, on all three
+hosts, so there is no longer a reason to split a thin smoke gate from a fuller
+nightly pass.
+
+#### Sharding
+
+The PR legs are **split in two by `--shard`**, so each runs half the spec files.
+What makes that worth doing is where the time actually goes: measured on the run of
+2026-09-08, test bodies were 38% of the Linux suite step and 25% of the Windows one.
+The rest is Obsidian process lifecycle — 71 sessions, one per spec file, plus the
+~100 `reloadObsidian` boots the specs ask for — which is work that splits across
+runners almost linearly. Windows sets the gate at roughly twice Linux's wall clock
+for identical work, so it is the leg the split is aimed at.
+
+`--shard current/total` slices the spec list **after** suite filtering, contiguously
+and by file count rather than by duration, so the halves are only as balanced as the
+file order happens to make them (387s/440s on Windows for the run above). Nightly
+stays unsharded: it already fans out over the version axis, and its wall clock is
+nobody's feedback loop.
 
 The nightly run is specifically the defense against **Obsidian** shipping a
 breaking change under us — it can go red with zero code change. It is also the only


### PR DESCRIPTION
The e2e gate takes ~17.5 minutes, set by the Windows leg. Almost none of that is assertions.

## Where the time goes

Measured from main's green run [34256649131](https://github.com/srg-kostyrko/obsidian-journal/actions/runs/34256649131) — job steps, the wdio log, and the per-test junit artifacts:

| | ubuntu | windows |
|---|---|---|
| job total | 521s | 1055s |
| setup (checkout, node, `npm ci`, cache, build) | 29s | 104s |
| suite step | 486s | 943s |
| — test bodies (junit, 379 cases) | 187s | 237s |
| — hooks, mostly `reloadObsidian` | 101s | 335s |
| — per-spec session start/stop | 102s | 255s |
| — launcher setup + gaps between specs | ~95s | ~116s |
| **test bodies as a share of the step** | **38%** | **25%** |

71 spec files means 71 Obsidian sessions, plus the ~100 `reloadObsidian` boots the specs ask for (six files reload in `beforeEach`). That is process lifecycle, and it splits across runners almost linearly.

## The change

A `shard` axis on the PR + merge legs — two shards per host — passed through as `--shard current/total`. Expected gate: ~10 minutes instead of ~17.5.

- **Nightly stays on one shard.** It already fans out over the version axis, its wall clock is nobody's feedback loop, and 3 versions x 3 hosts x 2 shards would queue against the concurrent-job limit.
- **`e2e-gate` needs no change** — it gates on `needs.e2e.result`, not on leg names, which is exactly what that job exists for.
- **The junit `check_name` gains the shard**, or two legs of the same OS and version publish checks under one name and one overwrites the other.
- **The binary cache key deliberately does not gain it** — both shards want the same asar; on a cold cache they race to save it and the loser logs a warning, which is cheaper than storing it twice.

## Verification

Ran the real config through wdio's `ConfigParser` with the suite list CI passes: unsharded 71 specs, `1/2` 36, `2/2` 35, union covers all 71, overlap 0.

Balance is by file count, not duration — wdio slices contiguously — so the halves are only as even as the file order makes them. On the measured run that is 387s/440s of Windows spec time, which is good enough; it is not guaranteed to stay that way as specs are added.

This PR's own run is the end-to-end proof: six e2e legs instead of three, all green, in noticeably less wall clock.