### PR TITLE
ci: delete a pull request's Actions caches when it closes

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -41,7 +41,22 @@ jobs:
             echo "No caches scoped to $REF."
             exit 0
           fi
+          # Attempt every id even when one fails. A DELETE can legitimately 404 — GitHub may have
+          # evicted the entry between the listing and the delete, and a close/reopen/close leaves
+          # two runs sweeping the same ref — and under `set -e` that would abort the loop, leaving
+          # the rest of the caches behind and the run red for reaching the desired state early.
+          # Failing every id is a different thing (a token without `actions: write`, say), and
+          # that one should be loud rather than swallowed, so it is the only case that exits 1.
+          failed=0
+          total=0
           for id in $ids; do
-            gh api -X DELETE "/repos/$REPO/actions/caches/$id" --silent
-            echo "deleted cache $id ($REF)"
+            total=$((total + 1))
+            if gh api -X DELETE "/repos/$REPO/actions/caches/$id" --silent; then
+              echo "deleted cache $id ($REF)"
+            else
+              failed=$((failed + 1))
+              echo "could not delete cache $id ($REF) — already gone?"
+            fi
           done
+          echo "$((total - failed)) of $total caches deleted for $REF."
+          [ "$failed" -lt "$total" ] || exit 1

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,47 @@
+name: Cache cleanup
+
+on:
+  # `pull_request_target`, not `pull_request`: deleting a cache needs `actions: write`, and a
+  # fork's `pull_request` token is read-only, so fork PRs — the ones whose leftovers nobody is
+  # watching — could never clean up after themselves. The hazard that trigger is known for is
+  # running PR-authored code with a writable token; this job checks nothing out and runs none.
+  pull_request_target:
+    types: [closed]
+  # For sweeping a PR whose closure predates this workflow, or one whose run failed.
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "Pull request number whose caches should be deleted"
+        type: string
+        required: true
+
+permissions:
+  actions: write
+
+jobs:
+  caches:
+    runs-on: ubuntu-latest
+
+    steps:
+      # A cache is scoped to the ref that created it, and a PR's `refs/pull/N/merge` outlives
+      # its head branch — `delete_branch_on_merge` does not reach it. Left alone the entries are
+      # unreachable forever: only that PR's own runs may read them, and it is closed. They are
+      # not small either, because every e2e leg caches ~400 MB of Obsidian binaries, so a single
+      # PR leaves over a gigabyte behind and the repo drifts into cache eviction — which then
+      # costs *other* runs a cold download of the binaries.
+      - name: Delete the caches scoped to this pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          REF: refs/pull/${{ github.event.pull_request.number || inputs.pr }}/merge
+        run: |
+          set -euo pipefail
+          ids=$(gh api -X GET "/repos/$REPO/actions/caches" -f ref="$REF" -F per_page=100 --jq '.actions_caches[].id')
+          if [ -z "$ids" ]; then
+            echo "No caches scoped to $REF."
+            exit 0
+          fi
+          for id in $ids; do
+            gh api -X DELETE "/repos/$REPO/actions/caches/$id" --silent
+            echo "deleted cache $id ($REF)"
+          done


### PR DESCRIPTION
## The problem, measured

`delete_branch_on_merge` is already on and does delete the branch — but a cache is scoped to the ref that **created** it, and a PR's `refs/pull/N/merge` outlives its head branch. The entries survive, readable by nobody: only that PR's own runs may read a PR-scoped cache, and it is closed.

Every e2e leg caches ~400 MB of Obsidian binaries, so one PR leaves over a gigabyte behind. Today's snapshot before cleanup:

```
3.95GB  17 entries  refs/heads/main          ← the only ones a future run can use
1.21GB   3 entries  refs/pull/359/merge      ← merged, branch deleted, cache still here
1.21GB   3 entries  refs/pull/361/merge
1.03GB   6 entries  refs/pull/336/merge
0.85GB   5 entries  refs/pull/334/merge
0.69GB   4 entries  refs/pull/335/merge
0.52GB   3 entries  refs/pull/338/merge
```

5.5 GB of that 9.45 GB was unreachable, against a **10 GB per-repo limit** — so the repo sat over the limit and GitHub evicted least-recently-used entries. That is not free: `obsidian-cache-Windows-latest/latest` had been evicted from `main`, so the Windows leg was re-downloading ~333 MB of Obsidian rather than restoring it. Cleared by hand today (now 4.28 GB, all on `main`); this workflow keeps it from coming back.

## The change

One job, triggered on PR close, deleting every cache scoped to that PR's ref.

- **`pull_request_target`, not `pull_request`** — deleting a cache needs `actions: write`, and a fork's `pull_request` token is read-only, so fork PRs could never clean up after themselves. That trigger's known hazard is running PR-authored code with a writable token; this job checks nothing out and runs none.
- **`workflow_dispatch` with a `pr` input** for a PR closed before this existed, or one whose run failed.

## Verification

The API call the job makes, run against this repo: `ref=refs/heads/main` returns 18 cache ids, `ref=refs/pull/360/merge` (open, no caches) returns 0 and takes the no-op path. The end-to-end proof is this PR's own merge — it should delete the caches its e2e legs just created.