### PR TITLE
ci: sweep dead Actions caches nightly, and ignore the worktree cache symlink

### DIFF
--- a/.github/workflows/cache-sweep.yml
+++ b/.github/workflows/cache-sweep.yml
@@ -22,12 +22,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v7
-        with:
-          node-version: "24.x"
-
-      # The script has no dependencies, so there is nothing to install — and nothing for this
-      # job to cache, which is the point of it.
+      # No setup-node: the script imports nothing, so it needs no install step and no pinned
+      # toolchain — the runner image's own Node is enough for `fetch` and top-level await.
+      # That also keeps one fewer third-party action in a job holding `actions: write`.
       - name: Prune dead Actions caches
         # `inputs.debug-only` is empty on a schedule, so the cron run deletes for real; a manual
         # dispatch defaults to the dry run. Safe against the `A && '' || B` trap documented in

--- a/.github/workflows/cache-sweep.yml
+++ b/.github/workflows/cache-sweep.yml
@@ -1,0 +1,38 @@
+name: Cache sweep
+
+on:
+  schedule:
+    # Daily, offset from the stale-issue sweep (03:00 UTC) and the nightly e2e run (07:00 UTC).
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+    inputs:
+      debug-only:
+        description: "Dry run: log what would be deleted without deleting it"
+        type: boolean
+        default: true
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24.x"
+
+      # The script has no dependencies, so there is nothing to install — and nothing for this
+      # job to cache, which is the point of it.
+      - name: Prune dead Actions caches
+        # `inputs.debug-only` is empty on a schedule, so the cron run deletes for real; a manual
+        # dispatch defaults to the dry run. Safe against the `A && '' || B` trap documented in
+        # e2e.yml because the middle operand here is a non-empty string.
+        run: node scripts/prune-actions-caches.mjs ${{ inputs.debug-only && '--dry-run' || '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,9 @@ test-vault/.obsidian/workspace-mobile.json
 test-vault/**/*.md
 
 # e2e (WebdriverIO + Obsidian)
-.obsidian-cache/
+# No trailing slash: in a git worktree the cache is usually a symlink to the main
+# checkout's copy, and a directory-only pattern leaves that symlink untracked.
+.obsidian-cache
 e2e/.reports/
 
 # Exclude sourcemaps

--- a/docs/e2e-testing-strategy.md
+++ b/docs/e2e-testing-strategy.md
@@ -74,6 +74,23 @@ Downloaded Obsidian versions are cached in `cacheDir` (e.g. `.obsidian-cache`).
 Cache it via `actions/cache` keyed on the version set, or every run re-downloads
 Obsidian.
 
+That cache competes for a budget. GitHub allows a repository 10 GB and evicts
+least-recently-used entries once it is full, and each e2e leg holds ~400 MB of
+Obsidian per version pair — so a dead entry is not free, it costs some _other_
+run its binaries. Two things keep it in bounds, because a cache is scoped to the
+ref that created it and `refs/pull/N/merge` outlives the head branch that
+`delete_branch_on_merge` removes: `cache-cleanup.yml` deletes a pull request's
+caches when it closes, and `cache-sweep.yml` runs
+`scripts/prune-actions-caches.mjs` nightly for whatever that missed — closed-PR
+entries, and anything unread for a fortnight, which is how a lockfile hash no
+branch resolves to any more finally goes. Run it by hand with `--dry-run` (or
+dispatch the workflow, which defaults to the dry run) to see what it would take.
+
+Changing the **key**, not the contents, is what actually orphans an entry: a run
+whose key already exists restores it and saves nothing, so it leaves no copy
+behind. The version unpin of 2026-09-08 moved every key from `1.13.7/*` to
+`latest/*` and left 2.4 GB stranded that way.
+
 ### WebdriverIO setup
 
 - **Testrunner mode** (`wdio.conf.ts` + `wdio run`), not standalone/programmatic —

--- a/scripts/prune-actions-caches.mjs
+++ b/scripts/prune-actions-caches.mjs
@@ -1,0 +1,118 @@
+// GitHub gives a repository 10 GB of Actions cache and evicts least-recently-used entries
+// once it is full — so an unreachable cache is not free, it costs some *other* run its
+// binaries. This repo fills that budget fast: every e2e leg caches ~400 MB of Obsidian, and
+// setup-node adds ~170 MB per lockfile hash per OS.
+//
+// Two kinds of entry are dead and this prunes them:
+//   CLOSED PR   — a cache is scoped to the ref that created it, and refs/pull/N/merge outlives
+//                 the head branch, so delete_branch_on_merge never reaches it. Only that PR's
+//                 own runs may read it, and it is closed. cache-cleanup.yml sweeps these when
+//                 the PR closes; this catches the ones it missed (a failed run, or a PR closed
+//                 before that workflow existed).
+//   UNREAD      — nothing has read it in STALE_DAYS. That is a lockfile hash no branch resolves
+//                 to any more, or a version combo the matrix stopped asking for. GitHub is
+//                 documented to evict at 7 days unread, but entries older than that have been
+//                 observed surviving, so this does not rely on it.
+//
+// Anything on an open pull request is left alone regardless of age.
+//
+// Usage: node scripts/prune-actions-caches.mjs [--dry-run]
+//   GH_TOKEN  a token with `actions: write` on the repo
+//   REPO      owner/name (defaults to this repo)
+
+const DRY_RUN = process.argv.includes("--dry-run");
+const REPO = process.env.REPO ?? "srg-kostyrko/obsidian-journal";
+const TOKEN = process.env.GH_TOKEN;
+const STALE_DAYS = Number(process.env.STALE_DAYS ?? 14);
+
+if (!TOKEN) {
+  console.error("GH_TOKEN is required (needs `actions: write`).");
+  process.exit(1);
+}
+
+async function api(path, init = {}) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    ...init,
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${TOKEN}`,
+      "x-github-api-version": "2022-11-28",
+      ...init.headers,
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`${init.method ?? "GET"} ${path} -> ${response.status} ${await response.text()}`);
+  }
+  return response.status === 204 ? undefined : response.json();
+}
+
+async function allCaches() {
+  const caches = [];
+  for (let page = 1; ; page++) {
+    const { actions_caches: batch } = await api(`/repos/${REPO}/actions/caches?per_page=100&page=${page}`);
+    if (batch.length === 0) return caches;
+    caches.push(...batch);
+  }
+}
+
+const prStates = new Map();
+async function pullRequestIsClosed(number) {
+  if (!prStates.has(number)) {
+    // A pull request can be missing entirely (deleted fork, transferred issue); treat an
+    // unreadable one as open so an unknown state never costs a live cache.
+    const state = await api(`/repos/${REPO}/pulls/${number}`)
+      .then((pr) => pr.state)
+      .catch(() => "open");
+    prStates.set(number, state);
+  }
+  return prStates.get(number) === "closed";
+}
+
+const gb = (bytes) => `${(bytes / 1e9).toFixed(2)} GB`;
+const daysSince = (iso) => (Date.now() - new Date(iso).getTime()) / 86_400_000;
+
+async function verdictFor(cache) {
+  const pull = /^refs\/pull\/(\d+)\//.exec(cache.ref);
+  if (pull) {
+    return (await pullRequestIsClosed(pull[1])) ? `pull request #${pull[1]} is closed` : undefined;
+  }
+  const unread = daysSince(cache.last_accessed_at);
+  return unread > STALE_DAYS ? `unread for ${Math.floor(unread)} days` : undefined;
+}
+
+const caches = await allCaches();
+const held = caches.reduce((sum, cache) => sum + cache.size_in_bytes, 0);
+console.log(`${caches.length} caches, ${gb(held)} held, pruning anything unread for ${STALE_DAYS}+ days.`);
+
+let reclaimed = 0;
+let failed = 0;
+for (const cache of caches) {
+  const reason = await verdictFor(cache);
+  if (!reason) continue;
+  const label = `${cache.key} (${cache.ref}, ${gb(cache.size_in_bytes)}) — ${reason}`;
+  if (DRY_RUN) {
+    console.log(`would delete ${label}`);
+    reclaimed += cache.size_in_bytes;
+    continue;
+  }
+  try {
+    await api(`/repos/${REPO}/actions/caches/${cache.id}`, { method: "DELETE" });
+    console.log(`deleted ${label}`);
+    reclaimed += cache.size_in_bytes;
+  } catch (error) {
+    // An entry can vanish between the listing and the delete — GitHub evicting it, or the
+    // per-PR workflow sweeping the same ref. Keep going; only a total failure is a real fault.
+    failed += 1;
+    console.log(`could not delete ${label}: ${error.message}`);
+  }
+}
+
+console.log(
+  DRY_RUN
+    ? `would reclaim ${gb(reclaimed)}, leaving ${gb(held - reclaimed)}.`
+    : `reclaimed ${gb(reclaimed)}, leaving ${gb(held - reclaimed)}.`,
+);
+if (failed > 0 && reclaimed === 0) {
+  console.error(`every delete failed (${failed}) — check that the token carries \`actions: write\`.`);
+  process.exit(1);
+}


### PR DESCRIPTION
The two loose ends from #362.

## `.gitignore` missed the worktree symlink

Line 34 read `.obsidian-cache/`, and a trailing slash matches directories only. In a git worktree the cache is usually a **symlink** to the main checkout's copy — that is what makes local e2e runnable from a worktree at all, since the launcher resolves `./.obsidian-cache` relative to the config's root dir and would otherwise re-download ~400 MB per worktree. The symlink therefore showed up as untracked, one `git add .` away from being committed. Dropping the slash matches both.

## Nightly sweep for what the per-PR cleanup cannot reach

#362 deletes a PR's caches when it closes. It cannot help with:

- a PR closed **before** that workflow existed, or one whose cleanup run failed;
- entries on `main` that nothing resolves to any more — a lockfile hash from a dependency bump three weeks ago, or a version combo the matrix stopped asking for.

`scripts/prune-actions-caches.mjs` deletes caches on **closed pull requests** and anything **unread for a fortnight** (`STALE_DAYS`, default 14). Caches on an open PR are left alone regardless of age, and a PR whose state cannot be read counts as open, so an unknown never costs a live cache.

Why it matters rather than being tidiness: GitHub allows 10 GB per repository and evicts least-recently-used entries once full, so a dead cache costs some *other* run its binaries. That already happened — `main` had lost `obsidian-cache-Windows-latest/latest`, so the Windows leg was re-downloading Obsidian while 5.5 GB of merged-PR caches sat unreachable.

GitHub is documented to evict entries unread for 7 days, but the merged-PR caches from 2026-08-27 were still present on 09-08, so this does not rely on that.

## Verification

Ran against this repo before pushing:

```
$ node scripts/prune-actions-caches.mjs --dry-run
19 caches, 4.62 GB held, pruning anything unread for 14+ days.
would reclaim 0.00 GB, leaving 4.62 GB.

$ STALE_DAYS=0 node scripts/prune-actions-caches.mjs --dry-run
would delete obsidian-cache-Windows-latest/latest (refs/heads/main, 0.33 GB) — unread for 0 days
… 18 selected …
would reclaim 4.28 GB, leaving 0.33 GB.
```

The 14-day run is the real no-op it should be today; forcing the threshold to zero exercises selection, age labels and sizing. A manual dispatch defaults to `--dry-run`; the cron deletes for real (`inputs.debug-only` is empty on a schedule).