### PR TITLE
ci: pin GitHub Actions to digests through Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -56,6 +56,15 @@
       semanticCommitType: "chore",
       semanticCommitScope: "ci",
       schedule: ["before 06:00 on the first day of the month"],
+      // A tag is a mutable pointer: `@v7` resolves at run time to whatever the
+      // tag points at *now*, so whoever can move it changes the code CI runs
+      // with no diff in this repo to review. That is the shape the
+      // tj-actions/changed-files compromise took. A digest is content-addressed,
+      // so an upgrade becomes a reviewable bump on the schedule above instead.
+      // It earns its keep in release.yml and release-beta.yml, which run at
+      // `permissions: write-all` and build the artifact users install — an
+      // attested build is only as trustworthy as the attesting action.
+      pinDigests: true,
     },
     {
       // The typings and manifest.json's minAppVersion move independently, and


### PR DESCRIPTION
Follow-up to the security note Greptile raised on #363, done repo-wide rather than in one workflow.

## Why

A tag is a mutable pointer. `uses: actions/checkout@v7` resolves **at run time** to whatever that tag points at now, so anyone who can move it changes the code CI executes with no diff in this repo to review. That is the shape the tj-actions/changed-files compromise took in March 2025: tags across many versions were repointed at a malicious commit, and every consumer on a mutable tag dumped runner memory — secrets included — into build logs. Consumers pinned to digests were unaffected.

`pinDigests` makes Renovate rewrite each use to `actions/checkout@<sha> # v7.0.1` and keep the digest current on the monthly schedule the `github-actions` rule already carries. An upgrade becomes a reviewable bump instead of a silent substitution.

## Where the value actually is

Not in the workflow that prompted the comment. This repo has 13 action uses across 7 actions, and the ones that matter are in `release.yml` and `release-beta.yml`: they run at `permissions: write-all` and produce the artifact users install into their vaults. `actions/attest-build-provenance@v4` sits in that same job — an attested build is only as trustworthy as the attesting action.

## What it does not buy

Worth stating so the change isn't over-trusted:

- It does not stop a malicious *new release*. Renovate will open a bump PR and the exposure returns when it merges. Pinning converts "instant and invisible" into "on your schedule, with a diff" — which is only as strong as the attention those PRs get.
- It does not cover transitive risk: a composite action using its own mutable tags, or one fetching a script at run time.
- If GitHub's immutable releases are in force for a given action, part of this is already true without the pin.

Scoped to the `github-actions` rule rather than set globally, since npm already resolves through the lockfile.

## Verification

`renovate-config-validator .github/renovate.json5` → `Config validated successfully`. Renovate's next actions run opens the pinning PR across all seven actions; nothing in this PR changes a workflow.