### PR TITLE
fix(nav): name the nav block's mode setting after the arrows it controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 
 - Journal variables now resolve in a sub-template Templater includes. A template calling `<% tp.file.include("[[Sub-Template]]") %>` had its own `{{date}}` and other variables filled in, but the included file's reached the note written out as `{{date}}` — Templater reads an included file straight off disk, past the point where the variables are filled in. An included file's variables are now filled in before Templater runs its commands, so it can use them inside a Templater command as well as in its text.
+- A journal's navigation block could already skip over the periods you have no note for — jumping straight from one existing note to the next, however far apart they are — but the setting that turns this on was called **Mode**, with the choices **Create new note** and **Open existing note**, which read as descriptions of what clicking the block does rather than of what the arrows step over. The setting is now **Previous and next arrows**, its choices are **Step to the adjacent period** and **Jump to the nearest existing note**, and it explains both. Clicking a segment creates that segment's note whichever you pick; the manual previously described this setting as controlling segment clicks, which it never did.
 
 ## [3.3.0] - 2026-09-06
 

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ replaced "row".
 
 **Settings**:
 
-- Mode: create a new note when a segment is clicked, or only open notes that already exist
+- Previous and next arrows: step to the adjacent period, creating that note if it's missing, or jump to the nearest period that already has a note, skipping the gaps and never creating. Clicking a segment always creates its note either way
 - Show previous and next periods: with it off, the block draws only the current period and its previous/next arrows, which still open those notes. A single note can override this either way with the block's `adjacent` option.
 - Whole block decoration: decorate the block as a whole from the current journal's rules
 

--- a/messages/de.json
+++ b/messages/de.json
@@ -196,14 +196,15 @@
     }
   ],
   "nav_block_section_title": "Navigationsblock",
-  "nav_block_section_mode_label": "Modus",
-  "nav_block_section_mode_option": [
+  "nav_block_section_arrows_label": "Navigationspfeile",
+  "nav_block_section_arrows_description": "Beim Wechseln geht es immer einen Zeitraum weiter, und die Notiz wird erstellt, falls sie fehlt. Beim Springen werden Zeiträume ohne Notiz übersprungen, und es wird nie eine erstellt. Ein Klick auf ein Segment erstellt dessen Notiz immer, unabhängig von dieser Einstellung.",
+  "nav_block_section_arrows_option": [
     {
       "declarations": ["input kind"],
       "selectors": ["kind"],
       "match": {
-        "kind=create": "Neue Notiz erstellen",
-        "kind=existing": "Vorhandene Notiz öffnen"
+        "kind=create": "Zum benachbarten Zeitraum wechseln",
+        "kind=existing": "Zur nächstgelegenen vorhandenen Notiz springen"
       }
     }
   ],

--- a/messages/en.json
+++ b/messages/en.json
@@ -132,14 +132,15 @@
   "code_blocks_timeline_navigation_range": "{from} – {to}",
 
   "nav_block_section_title": "Navigation block",
-  "nav_block_section_mode_label": "Mode",
-  "nav_block_section_mode_option": [
+  "nav_block_section_arrows_label": "Previous and next arrows",
+  "nav_block_section_arrows_description": "Stepping always moves one period, creating that note if it's missing. Jumping skips periods that have no note, and never creates one. Clicking a segment always creates its note, whichever you choose.",
+  "nav_block_section_arrows_option": [
     {
       "declarations": ["input kind"],
       "selectors": ["kind"],
       "match": {
-        "kind=create": "Create new note",
-        "kind=existing": "Open existing note"
+        "kind=create": "Step to the adjacent period",
+        "kind=existing": "Jump to the nearest existing note"
       }
     }
   ],

--- a/messages/es.json
+++ b/messages/es.json
@@ -196,14 +196,15 @@
     }
   ],
   "nav_block_section_title": "Bloque de navegación",
-  "nav_block_section_mode_label": "Modo",
-  "nav_block_section_mode_option": [
+  "nav_block_section_arrows_label": "Flechas de anterior y siguiente",
+  "nav_block_section_arrows_description": "Ir al periodo adyacente siempre avanza un periodo y crea esa nota si falta. Saltar omite los periodos sin nota y nunca crea ninguna. Hacer clic en un segmento siempre crea su nota, elijas lo que elijas.",
+  "nav_block_section_arrows_option": [
     {
       "declarations": ["input kind"],
       "selectors": ["kind"],
       "match": {
-        "kind=create": "Crear nueva nota",
-        "kind=existing": "Abrir nota existente"
+        "kind=create": "Ir al periodo adyacente",
+        "kind=existing": "Saltar a la nota existente más cercana"
       }
     }
   ],

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -196,14 +196,15 @@
     }
   ],
   "nav_block_section_title": "Bloc de navigation",
-  "nav_block_section_mode_label": "Mode",
-  "nav_block_section_mode_option": [
+  "nav_block_section_arrows_label": "Flèches précédent et suivant",
+  "nav_block_section_arrows_description": "Aller à la période adjacente avance toujours d'une période et crée la note si elle manque. Sauter ignore les périodes sans note et n'en crée jamais. Cliquer sur un segment crée toujours sa note, quel que soit ce choix.",
+  "nav_block_section_arrows_option": [
     {
       "declarations": ["input kind"],
       "selectors": ["kind"],
       "match": {
-        "kind=create": "Créer une nouvelle note",
-        "kind=existing": "Ouvrir la note existante"
+        "kind=create": "Aller à la période adjacente",
+        "kind=existing": "Aller à la note existante la plus proche"
       }
     }
   ],

--- a/messages/it.json
+++ b/messages/it.json
@@ -196,14 +196,15 @@
     }
   ],
   "nav_block_section_title": "Blocco di navigazione",
-  "nav_block_section_mode_label": "Modalità",
-  "nav_block_section_mode_option": [
+  "nav_block_section_arrows_label": "Frecce precedente e successivo",
+  "nav_block_section_arrows_description": "Andare al periodo adiacente avanza sempre di un periodo e crea quella nota se manca. Saltare ignora i periodi senza nota e non ne crea mai una. Fare clic su un segmento crea sempre la sua nota, qualunque sia questa scelta.",
+  "nav_block_section_arrows_option": [
     {
       "declarations": ["input kind"],
       "selectors": ["kind"],
       "match": {
-        "kind=create": "Crea una nuova nota",
-        "kind=existing": "Apri una nota esistente"
+        "kind=create": "Vai al periodo adiacente",
+        "kind=existing": "Vai alla nota esistente più vicina"
       }
     }
   ],

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -185,14 +185,15 @@
     }
   ],
   "nav_block_section_title": "ナビゲーションブロック",
-  "nav_block_section_mode_label": "モード",
-  "nav_block_section_mode_option": [
+  "nav_block_section_arrows_label": "前後の矢印",
+  "nav_block_section_arrows_description": "隣の期間に移動する場合は常に 1 期間ずつ進み、ノートがなければ作成します。移動する場合はノートのない期間を飛ばし、ノートを作成することはありません。セグメントをクリックした場合は、この設定にかかわらず常にノートが作成されます。",
+  "nav_block_section_arrows_option": [
     {
       "declarations": ["input kind"],
       "selectors": ["kind"],
       "match": {
-        "kind=create": "新しいノートを作成する",
-        "kind=existing": "既存のノートを開く"
+        "kind=create": "隣の期間に移動する",
+        "kind=existing": "最も近い既存のノートに移動する"
       }
     }
   ],

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -196,14 +196,15 @@
     }
   ],
   "nav_block_section_title": "탐색 블록",
-  "nav_block_section_mode_label": "모드",
-  "nav_block_section_mode_option": [
+  "nav_block_section_arrows_label": "이전 및 다음 화살표",
+  "nav_block_section_arrows_description": "인접한 기간으로 이동하면 항상 한 기간씩 움직이며 노트가 없으면 만듭니다. 기존 노트로 이동하면 노트가 없는 기간을 건너뛰고 노트를 만들지 않습니다. 세그먼트를 클릭하면 이 설정과 상관없이 항상 노트를 만듭니다.",
+  "nav_block_section_arrows_option": [
     {
       "declarations": ["input kind"],
       "selectors": ["kind"],
       "match": {
-        "kind=create": "새 노트 만들기",
-        "kind=existing": "기존 노트 열기"
+        "kind=create": "인접한 기간으로 이동",
+        "kind=existing": "가장 가까운 기존 노트로 이동"
       }
     }
   ],

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -196,14 +196,15 @@
     }
   ],
   "nav_block_section_title": "Bloco de navegação",
-  "nav_block_section_mode_label": "Modo",
-  "nav_block_section_mode_option": [
+  "nav_block_section_arrows_label": "Setas de anterior e próximo",
+  "nav_block_section_arrows_description": "Ir para o período adjacente avança sempre um período e cria essa nota se ela faltar. Saltar ignora os períodos sem nota e nunca cria nenhuma. Clicar num segmento cria sempre a sua nota, seja qual for esta escolha.",
+  "nav_block_section_arrows_option": [
     {
       "declarations": ["input kind"],
       "selectors": ["kind"],
       "match": {
-        "kind=create": "Criar nova nota",
-        "kind=existing": "Abrir nota existente"
+        "kind=create": "Ir para o período adjacente",
+        "kind=existing": "Ir para a nota existente mais próxima"
       }
     }
   ],

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -198,14 +198,15 @@
     }
   ],
   "nav_block_section_title": "Блок навигации",
-  "nav_block_section_mode_label": "Режим",
-  "nav_block_section_mode_option": [
+  "nav_block_section_arrows_label": "Стрелки навигации",
+  "nav_block_section_arrows_description": "Переход к соседнему периоду всегда сдвигает на один период и создаёт заметку, если её нет. Переход к ближайшей существующей заметке пропускает периоды без заметок и никогда ничего не создаёт. Щелчок по сегменту всегда создаёт его заметку, независимо от этой настройки.",
+  "nav_block_section_arrows_option": [
     {
       "declarations": ["input kind"],
       "selectors": ["kind"],
       "match": {
-        "kind=create": "Создать новую заметку",
-        "kind=existing": "Открыть существующую заметку"
+        "kind=create": "Переходить к соседнему периоду",
+        "kind=existing": "Переходить к ближайшей существующей заметке"
       }
     }
   ],

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -185,14 +185,15 @@
     }
   ],
   "nav_block_section_title": "Блок навігації",
-  "nav_block_section_mode_label": "Режим",
-  "nav_block_section_mode_option": [
+  "nav_block_section_arrows_label": "Стрілки навігації",
+  "nav_block_section_arrows_description": "Перехід до сусіднього періоду завжди зсуває на один період і створює нотатку, якщо її немає. Перехід до найближчої наявної нотатки пропускає періоди без нотаток і ніколи нічого не створює. Клацання на сегменті завжди створює його нотатку, незалежно від цього налаштування.",
+  "nav_block_section_arrows_option": [
     {
       "declarations": ["input kind"],
       "selectors": ["kind"],
       "match": {
-        "kind=create": "Створити нову нотатку",
-        "kind=existing": "Відкрити наявну нотатку"
+        "kind=create": "Переходити до сусіднього періоду",
+        "kind=existing": "Переходити до найближчої наявної нотатки"
       }
     }
   ],

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -185,14 +185,15 @@
     }
   ],
   "nav_block_section_title": "导航块",
-  "nav_block_section_mode_label": "模式",
-  "nav_block_section_mode_option": [
+  "nav_block_section_arrows_label": "上一个和下一个箭头",
+  "nav_block_section_arrows_description": "跳转到相邻时段总是移动一个时段，笔记不存在时会创建。跳转到最近的现有笔记会跳过没有笔记的时段，并且从不创建笔记。点击段落时始终会创建其笔记，与此设置无关。",
+  "nav_block_section_arrows_option": [
     {
       "declarations": ["input kind"],
       "selectors": ["kind"],
       "match": {
-        "kind=create": "创建新笔记",
-        "kind=existing": "打开现有笔记"
+        "kind=create": "跳转到相邻时段",
+        "kind=existing": "跳转到最近的现有笔记"
       }
     }
   ],

--- a/src/code-blocks/nav/settings/ui/NavBlockLinesEditor.test.ts
+++ b/src/code-blocks/nav/settings/ui/NavBlockLinesEditor.test.ts
@@ -34,13 +34,40 @@ async function mount(lines: NavBlockSegment[][], decorateWholeBlock = false) {
   return { harness, flows };
 }
 
+async function mountNavigation() {
+  const harness = await testContainer({
+    modules: [journalsCoreModule, shelvesCoreModule],
+    data: { journals: { daily: journalWithIntervalLines([[sampleSegment]]) } },
+  });
+  vi.spyOn(harness.resolve(Flows), "invoke").mockReturnValue({} as never);
+  harness.render(NavBlockLinesEditor, {
+    props: { journalName: "daily", field: "navBlock", title: TITLE, icon: "list", navigation: true },
+  });
+  await userEvent.click(screen.getByText(TITLE));
+  return harness;
+}
+
 const sampleSegment = buildNavSegment({ template: "static text" });
 
 describe("NavBlockLinesEditor", () => {
-  it("hides the mode dropdown when mode is not enabled", async () => {
+  it("hides the arrow-behavior dropdown on a block that has no previous and next arrows", async () => {
     await mount([[sampleSegment]]);
     await userEvent.click(screen.getByText(TITLE));
-    expect(screen.queryByText(m.nav_block_section_mode_label())).toBeNull();
+    expect(screen.queryByText(m.nav_block_section_arrows_label())).toBeNull();
+  });
+
+  it("offers both arrow behaviors on the navigation block", async () => {
+    await mountNavigation();
+    expect(screen.getByText(m.nav_block_section_arrows_label())).toBeTruthy();
+    expect(screen.getByRole("option", { name: m.nav_block_section_arrows_option({ kind: "create" }) })).toBeTruthy();
+    expect(screen.getByRole("option", { name: m.nav_block_section_arrows_option({ kind: "existing" }) })).toBeTruthy();
+  });
+
+  // The label names the arrows alone, so the row has to be the place that says the two behaviors
+  // differ in whether they create a note — and that a segment click creates either way (#371).
+  it("explains what each arrow behavior does", async () => {
+    await mountNavigation();
+    expect(screen.getByText(m.nav_block_section_arrows_description())).toBeTruthy();
   });
 
   it("hides the use-defaults button when useDefaults is not enabled", async () => {

--- a/src/code-blocks/nav/settings/ui/NavBlockLinesEditor.vue
+++ b/src/code-blocks/nav/settings/ui/NavBlockLinesEditor.vue
@@ -36,7 +36,7 @@ const {
   field: "navBlock" | "intervalBlock";
   title: string;
   icon: string;
-  /** The navigation block alone has a create/open mode and adjacent periods. */
+  /** The navigation block alone has previous/next arrows, so only it has their setting. */
   navigation?: boolean;
   useDefaults?: boolean;
 }>();
@@ -120,10 +120,11 @@ function onDropAtStart(orderedIds: string[]): void {
       <UiIconButton :icon="icons.action.add" :tooltip="m.block_lines_add_line()" @click="add" />
     </template>
 
-    <UiSettingRow v-if="navigation" :name="m.nav_block_section_mode_label()">
+    <UiSettingRow v-if="navigation" :name="m.nav_block_section_arrows_label()">
+      <template #description>{{ m.nav_block_section_arrows_description() }}</template>
       <UiDropdown v-model="config[field].type">
-        <option value="create">{{ m.nav_block_section_mode_option({ kind: "create" }) }}</option>
-        <option value="existing">{{ m.nav_block_section_mode_option({ kind: "existing" }) }}</option>
+        <option value="create">{{ m.nav_block_section_arrows_option({ kind: "create" }) }}</option>
+        <option value="existing">{{ m.nav_block_section_arrows_option({ kind: "existing" }) }}</option>
       </UiDropdown>
     </UiSettingRow>
 


### PR DESCRIPTION
## What and why

The journal navigation block's **Mode** setting offered **Create new note** and **Open existing note** — wording carried over verbatim from v2 (`git show 2.1.10:src/settings/JournalSettingsEdit.vue:583-587`).

Both choices read as descriptions of what *clicking the block* does. The setting has never touched clicks. Its only consumer is `NavigationCodeBlock.vue`, where it decides two things about the **previous/next arrows alone**:

- `:65-73` — what they step to: `cycle.previousAnchor`/`nextAnchor` (the adjacent period) vs `index.findPrevious`/`findNext` (the nearest anchor that has a note)
- `:186` — whether the resulting `OpenDateFlow` may create

So the one capability a user asks for by name — arrows that skip over the periods they have no note for — was the one the label never mentioned. #371 was filed asking for a feature that had shipped in v2, and the reporter did not recognise "Open existing note" as the answer when pointed at it.

This renames the row after the arrows it controls and gives it the explanatory text the row never had:

| | before | after |
| --- | --- | --- |
| label | Mode | Previous and next arrows |
| `create` | Create new note | Step to the adjacent period |
| `existing` | Open existing note | Jump to the nearest existing note |

> Stepping always moves one period, creating that note if it's missing. Jumping skips periods that have no note, and never creates one. Clicking a segment always creates its note, whichever you choose.

The third sentence earns its place: naming the row after the arrows raises the obvious question about segments, and the old label had been answering it wrongly.

The message keys moved with the copy (`nav_block_section_mode_*` → `nav_block_section_arrows_*`) so "mode" does not survive in the code either. No stored value changes: `navBlock.type` keeps `"create"`/`"existing"`, so there is no schema change, no migration, and nothing new in `repairCollectionEntry`'s path.

### README

`README.md:379` read:

> Mode: create a new note when a segment is clicked, or only open notes that already exist

`NavBlockSegment.vue:175-180` invokes `OpenDateFlow` with no `existingOnly`, so it defaults to `false` and a segment click creates in **both** modes. The line documented behaviour no code path has ever had, and omitted the arrow behaviour entirely — a reader who went to the manual still would not have found the answer to #371. Corrected, and it now states what a segment click actually does.

### Tests

`NavBlockLinesEditor.test.ts` covered only the negative case (the row is hidden on the interval block). Added two positive tests, both mutation-checked against this branch:

- removing the `#description` slot → "explains what each arrow behavior does" fails
- removing the `existing` `<option>` → "offers both arrow behaviors on the navigation block" fails

Neither passes with the production change reverted.

### Not in this PR

`journal-nav` still has no fence option for this — `nav-config.ts` exposes only `adjacent`. #371's title asks for a block option, and a journal-wide setting is unreachable from a fence no matter how it is labelled, so renaming alone would not have prevented the issue. That is a feature rather than a naming fix and wants its own decision.

Fixes #371

## Checklist

- [x] `npm run check:types` passes
- [x] `npm test` passes — 463 files, 5439 tests
- [x] `npm run check:lint` passes — 0 errors
- [x] `npm run check:i18n` passes — no violations, 11 locales
- [ ] the e2e per-suite scripts pass — not run; no runtime behaviour changes, and no e2e spec references the affected literals (`grep -rn "Create new note\|Open existing note\|nav_block_section_mode" e2e/` is empty)
- [x] User-facing copy is in `messages/en.json` only
- [x] `CHANGELOG.md` has an `[Unreleased]` entry, written for the user

All ten other locales are translated in this PR, reusing each locale's own established terms for *period*, *note* and *segment* from the keys around them. Worth a native eye on the three-sentence description in particular.

---

Unrelated finding, not touched here: `CONTRIBUTING.md:116-119` says "`check:i18n` has no key-parity check, so `en.json` alone passes every gate". It does have one — deleting `nav_block_section_arrows_description` from `de.json` fails the gate with *"missing from de.json — paraglide would fall back to en and ship English"*. The instruction the paragraph gives is still right; its stated reason is stale.