### PR TITLE
test(views): cover the click-modifier wiring on three open surfaces

### DIFF
--- a/src/code-blocks/home/ui/HomeCodeBlock.test.ts
+++ b/src/code-blocks/home/ui/HomeCodeBlock.test.ts
@@ -1,5 +1,5 @@
 import userEvent from "@testing-library/user-event";
-import { screen } from "@testing-library/vue";
+import { fireEvent, screen } from "@testing-library/vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { nextTick } from "vue";
 
@@ -105,6 +105,37 @@ describe("HomeCodeBlock", () => {
       OpenDateFlow,
       expect.objectContaining({ anchor: "2026-05-27", journalNames: ["Daily"] }),
     );
+  });
+
+  it("hands OpenDateFlow the open mode the click modifiers ask for", async () => {
+    const { flows } = await mount(
+      { Daily: fixedJournal("Daily", { type: "day" }) },
+      { show: ["day"], separator: " • ", scale: 1 },
+    );
+    const link = screen.getByRole("link");
+
+    await fireEvent.click(link);
+    expect(flows.invoke).toHaveBeenLastCalledWith(OpenDateFlow, expect.objectContaining({ openMode: "active" }));
+
+    await fireEvent.click(link, { metaKey: true });
+    expect(flows.invoke).toHaveBeenLastCalledWith(OpenDateFlow, expect.objectContaining({ openMode: "tab" }));
+
+    await fireEvent.click(link, { ctrlKey: true, altKey: true });
+    expect(flows.invoke).toHaveBeenLastCalledWith(OpenDateFlow, expect.objectContaining({ openMode: "split" }));
+  });
+
+  it("opens in a new tab on a middle-click", async () => {
+    const { flows } = await mount(
+      { Daily: fixedJournal("Daily", { type: "day" }) },
+      { show: ["day"], separator: " • ", scale: 1 },
+    );
+
+    await fireEvent(
+      screen.getByRole("link"),
+      new MouseEvent("auxclick", { button: 1, bubbles: true, cancelable: true }),
+    );
+
+    expect(flows.invoke).toHaveBeenLastCalledWith(OpenDateFlow, expect.objectContaining({ openMode: "tab" }));
   });
 
   it("narrows to the host note's shelf when the index registers it after mount", async () => {

--- a/src/views/toolbar-items/button/ButtonItem.test.ts
+++ b/src/views/toolbar-items/button/ButtonItem.test.ts
@@ -150,6 +150,23 @@ describe("ButtonItem", () => {
       expect(parameters.existingOnly).toBe(false);
     });
 
+    it("hands OpenDateFlow the open mode the click modifiers ask for", async () => {
+      const { result, flows } = await mountItem(buttonConfigFor({ type: "current", mode: "create", levels: ["day"] }));
+      const button = result.getByRole("button");
+
+      await fireEvent.click(button);
+      expect(flows).toHaveBeenLastCalledWith(OpenDateFlow, expect.objectContaining({ openMode: "active" }));
+
+      await fireEvent.click(button, { metaKey: true });
+      expect(flows).toHaveBeenLastCalledWith(OpenDateFlow, expect.objectContaining({ openMode: "tab" }));
+
+      await fireEvent.click(button, { ctrlKey: true, altKey: true });
+      expect(flows).toHaveBeenLastCalledWith(OpenDateFlow, expect.objectContaining({ openMode: "split" }));
+
+      await fireEvent(button, new MouseEvent("auxclick", { button: 1, bubbles: true, cancelable: true }));
+      expect(flows).toHaveBeenLastCalledWith(OpenDateFlow, expect.objectContaining({ openMode: "tab" }));
+    });
+
     it("recenters the view to today when mode is 'navigate'", async () => {
       const setRefDate = vi.fn();
       const { result } = await mountItem(buttonConfigFor({ type: "current", mode: "navigate", levels: ["day"] }), {

--- a/src/views/toolbar-items/existing-navigation/ui/ExistingNavigationItem.test.ts
+++ b/src/views/toolbar-items/existing-navigation/ui/ExistingNavigationItem.test.ts
@@ -1,4 +1,5 @@
 import userEvent from "@testing-library/user-event";
+import { fireEvent } from "@testing-library/vue";
 import { describe, expect, it, vi } from "vitest";
 import { defineComponent, h, ref } from "vue";
 
@@ -91,6 +92,33 @@ describe("ExistingNavigationItem", () => {
     expect(parameters.anchor).toBe("2030-03-10");
     expect(parameters.existingOnly).toBe(true);
     expect(notices.messages).toHaveLength(0);
+  });
+
+  it("hands OpenDateFlow the open mode the click modifiers ask for", async () => {
+    const { result, flows } = await mountItem(
+      { target: "day", direction: "previous" },
+      {
+        journals: DAILY,
+        active: { journalName: "daily", anchor: "2030-03-12" },
+        entries: [
+          { journalName: "daily", anchor: "2030-03-10" },
+          { journalName: "daily", anchor: "2030-03-12" },
+        ],
+      },
+    );
+    const button = result.container.querySelector<HTMLElement>("[data-direction='previous']")!;
+
+    await fireEvent.click(button);
+    expect(flows).toHaveBeenLastCalledWith(OpenDateFlow, expect.objectContaining({ openMode: "active" }));
+
+    await fireEvent.click(button, { metaKey: true });
+    expect(flows).toHaveBeenLastCalledWith(OpenDateFlow, expect.objectContaining({ openMode: "tab" }));
+
+    await fireEvent.click(button, { ctrlKey: true, altKey: true });
+    expect(flows).toHaveBeenLastCalledWith(OpenDateFlow, expect.objectContaining({ openMode: "split" }));
+
+    await fireEvent(button, new MouseEvent("auxclick", { button: 1, bubbles: true, cancelable: true }));
+    expect(flows).toHaveBeenLastCalledWith(OpenDateFlow, expect.objectContaining({ openMode: "tab" }));
   });
 
   it("disables the previous button when the target resolves no journals", async () => {


### PR DESCRIPTION
## Why

`defineOpenMode` is the single map from ctrl/meta/middle/alt to an open mode, and it has eight cases of its own unit coverage. What nothing asserted is that a *surface* hands it the event at all.

Three callers had no such test: `HomeCodeBlock`, `ButtonItem` and `ExistingNavigationItem`. Replacing `defineOpenMode(event)` with a literal `"active"` in any of them left the whole suite green — Mod-click would silently stop opening a new tab.

## What

One test per component. Each drives a plain click, `metaKey`, `ctrlKey+altKey` and a middle-click (`auxclick`, a separately bound handler) through the real component, asserting the `openMode` that reaches `OpenDateFlow`.

**Falsification checked:** with `defineOpenMode(event)` replaced by `"active"` in each component in turn, the corresponding test fails and passes again once restored.

## Scope

This came out of auditing what the retired manual checklist (#404) uniquely covered. Most of that list turned out to be automated already — the corrupt-`data.json` notice and self-disable, the post-boot reload-failed notice, the reload-required banner, the dump-logs success/empty/failure notices, and the locale fallback all have unit tests. These three modifier surfaces were the real gap.

The other click-modifier surfaces the checklist enumerated are covered: calendar cells (`use-notes-cell`, `NotesCalendarCell`), nav rows/arrows/segments (`NavigationCodeBlock`), period badges (`PeriodButtonsItem`), day-note cards (`DayNotesBlock`).

Tests only — no source changes. Full suite green (5478), lint clean, types clean.